### PR TITLE
ci: fix workflow-triggering gaps in the release-PR path

### DIFF
--- a/.github/workflows/pr-to-master.yml
+++ b/.github/workflows/pr-to-master.yml
@@ -3,6 +3,9 @@ name: PR to master
 on:
   pull_request:
     branches: [master]
+  # Lets this workflow be re-run manually — e.g. if GitHub never registered it because
+  # its first potential trigger was suppressed (see the GITHUB_TOKEN note below).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -72,7 +72,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - env:
-          GH_TOKEN: ${{ github.token }}
+          # A PR opened with the default GITHUB_TOKEN does not trigger other
+          # workflows (GitHub's loop-prevention rule) — pr-to-master.yml would
+          # never run on it. RELEASE_PR_TOKEN is a real PAT so the resulting
+          # PR is authored by a user, not the Actions bot, and triggers normally.
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
         run: |
           if gh pr list --base master --head staging --state open --json number --jq '.[0].number' | grep -q .; then
             echo "PR already open — it aggregates automatically, nothing to do."


### PR DESCRIPTION
## Summary
pr-to-master.yml never ran for PR #11 (staging -> master): it was opened by the default
GITHUB_TOKEN, whose events don't trigger other workflows. Since that was its only trigger
attempt, GitHub never registered the workflow, so even manually closing/reopening #11 didn't
help.

- Adds `workflow_dispatch` to pr-to-master.yml for manual re-run/registration.
- Switches open-release-pr (in staging-pipeline.yml) to a `RELEASE_PR_TOKEN` PAT instead of
  `github.token`, so future auto-opened release PRs are user-authored and trigger
  pr-to-master.yml normally.

**Follow-up needed:** add a `RELEASE_PR_TOKEN` repo secret (fine-grained PAT, Pull requests
read/write on this repo) before the next auto-opened release PR relies on it.

## Test plan
- [x] Both edited workflow files validated for YAML syntax
- [x] Merging this PR (push to staging) should synchronize PR #11 and finally trigger
      pr-to-master.yml for it