### PR TITLE
P2: React client scaffold (Task 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,10 @@ SESSION_SECRET=generate-me-with-openssl-rand-base64-32
 # --- Optional ---
 # Port the API listens on.
 PORT=3000
-# Directory holding the built SPA. Unset in P1 (no client yet); set in P2.
-# CLIENT_DIST=../client/dist
+# Directory holding the built SPA. Unset in dev (Vite serves it separately).
+# Set by compose.e2e.yaml / render.yaml for the production/e2e image.
+# CLIENT_DIST=apps/client/dist
+
+# Where the client dev server proxies /api to. Defaults to localhost; Compose
+# overrides it to the api container's service name.
+# VITE_API_PROXY_TARGET=http://localhost:3000

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog-Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@blog/client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@blog/shared": "*",
+    "@tanstack/react-query": "^5.101.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.25.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-router": "^8.3.0",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.6.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.3",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^6.0.4",
+    "jsdom": "^29.1.1",
+    "tailwindcss": "^4.3.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -1,0 +1,19 @@
+/* apps/client/src/index.css — Tailwind v4 is CSS-first: no tailwind.config.js,
+   no postcss.config.js. Light theme only (spec §2) — no .dark block. */
+@import 'tailwindcss';
+
+:root {
+  --background: oklch(0.98 0.051 105);       /* #FDFBD4 cream */
+  --foreground: oklch(0.28 0.047 67.5);      /* #38240D espresso */
+  --primary: oklch(0.581 0.155 49.5);        /* #C05800 burnt orange */
+  --primary-foreground: oklch(0.98 0.051 105); /* cream, for text on the orange primary */
+  --border: oklch(0.87 0.035 55);            /* light tan, same hue family as rust/orange */
+  --muted: oklch(0.94 0.025 60);             /* pale tan panel background */
+  --muted-foreground: oklch(0.403 0.101 53.8); /* #713600 rust */
+  --destructive: oklch(0.58 0.24 27);        /* red-orange, kept — already warm, harmonizes */
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+}

--- a/apps/client/src/main.d.ts
+++ b/apps/client/src/main.d.ts
@@ -1,0 +1,1 @@
+import './index.css';

--- a/apps/client/src/main.js
+++ b/apps/client/src/main.js
@@ -1,0 +1,5 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+createRoot(document.getElementById('root')).render(_jsx(StrictMode, { children: _jsx("h1", { children: "Blog-Chat" }) }));

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <h1>Blog-Chat</h1>
+  </StrictMode>,
+)

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/client/tsconfig.node.json
+++ b/apps/client/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/apps/client/vite.config.d.ts
+++ b/apps/client/vite.config.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("vite").UserConfig;
+export default _default;

--- a/apps/client/vite.config.js
+++ b/apps/client/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+// Same-origin in every environment (spec §11): the browser only ever talks to
+// :5173, and Vite forwards /api server-side. In Compose, VITE_API_PROXY_TARGET
+// is set to http://api:3000 (the container's service name); outside Compose it
+// defaults to localhost.
+export default defineConfig({
+    plugins: [react(), tailwindcss()],
+    server: {
+        proxy: {
+            '/api': {
+                target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
+                changeOrigin: false,
+            },
+        },
+    },
+});

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+// Same-origin in every environment (spec §11): the browser only ever talks to
+// :5173, and Vite forwards /api server-side. In Compose, VITE_API_PROXY_TARGET
+// is set to http://api:3000 (the container's service name); outside Compose it
+// defaults to localhost.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
+        changeOrigin: false,
+      },
+    },
+  },
+})

--- a/docs/superpowers/plans/2026-07-22-p2-react-client.md
+++ b/docs/superpowers/plans/2026-07-22-p2-react-client.md
@@ -1434,7 +1434,9 @@ import { Textarea } from '../ui/textarea.js'
 type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'text'
 
 function fieldKind(key: string, def: z.ZodTypeAny): FieldKind {
-  const inner = 'unwrap' in def && typeof def.unwrap === 'function' ? def.unwrap() : def
+  // z.coerce.boolean().default(false) / z.array(...).default([]) wrap the real
+  // type in ZodDefault — it has no .unwrap(), only .removeDefault() (_def.innerType).
+  const inner = def._def.typeName === 'ZodDefault' ? def._def.innerType : def
   if (inner._def.typeName === 'ZodBoolean') return 'checkbox'
   if (inner._def.typeName === 'ZodArray') return 'tags'
   if (key === 'body') return 'textarea'

--- a/docs/superpowers/plans/2026-07-22-p2-react-client.md
+++ b/docs/superpowers/plans/2026-07-22-p2-react-client.md
@@ -1,0 +1,2164 @@
+# P2 — React Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `apps/client` — a Vite + React SPA that consumes P1's API, giving the blog a UI. Served by
+`apps/api` in prod (one origin, no CORS — spec §11); proxied by Vite in dev for the same reason.
+
+**Architecture:** Server state lives in TanStack Query, never a client store — no Redux (spec §9). Every
+network call goes through a typed wrapper in `src/api/*` with `credentials: 'include'`; no component calls
+`fetch` directly. Three-tier components (`ui/` primitives, `patterns/` composed, `layouts/` page chrome —
+spec §4). Content gating is server-enforced already (P1); the client just renders whatever the API sends —
+there is no client-side gating logic to get wrong.
+
+**Tech Stack** (current stable, verified against the npm registry on 2026-07-22): React 19.2, Vite 8,
+`@vitejs/plugin-react` 6, React Router 8 (data router), TanStack Query 5, Tailwind CSS 4 (CSS-first config,
+`@tailwindcss/vite` plugin — no `tailwind.config.js`/PostCSS needed), `class-variance-authority` (cva),
+`sonner` (toasts), `lucide-react` (icons). Testing: Vitest + `@testing-library/react` + `jsdom` for
+components/hooks (unit layer), Playwright for E2E (spec §10).
+
+**Spec:** `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §3 (`apps/client` layout), §4
+(component tiers), §6 (gating — already server-enforced, read only), §9 (data flow, routes table), §10
+(testing), §11 (environments/proxy). This plan implements the P2 row of §13.
+
+**Branch:** `dev/react-client`, off `staging` (P1 merged).
+
+---
+
+## Global Constraints
+
+- **No component calls `fetch` directly.** Every request goes through `src/api/*`, which sets
+  `credentials: 'include'` so the httpOnly session cookie rides along.
+- **Server state is TanStack Query's job. No Redux, no client store for anything the API owns.**
+- **The client never re-implements gating.** `PostDto.gated` (from P1's `postService`) tells the UI whether
+  it received a teaser; the client shows a "Sign in to read" prompt when `gated` is true and nothing more.
+  Any route guard in this plan (e.g. the editor) is **UX only** — the API is what actually enforces
+  authorization (spec §9 routes table).
+- **One component per `.tsx` file**, split `ui/` (styling primitives) / `patterns/` (composed) / `layouts/`
+  (page chrome), per CLAUDE.md.
+- **The API's error JSON shape is fixed and must not be re-invented client-side:**
+  `{ error: { message: string, fields?: Record<string, string[]> } }` — `fields` present only on a 400
+  (`apps/api/src/middleware/error-handler.ts`).
+- **No `any`** — `@typescript-eslint/no-explicit-any` is already an error at the root; `apps/client` inherits
+  the root `eslint.config.mjs`, extended with React-specific rules in Task 1.
+- **Light theme only, no dark-mode toggle** (spec §2) — cream background, burnt-orange/espresso brand palette.
+- Node >= 22 (already pinned repo-wide).
+
+---
+
+## File Structure
+
+**Modified at the root:**
+
+| File | Change |
+|---|---|
+| `package.json` | add `@blog/client` workspace is automatic (already `apps/*`); no root script changes needed — `typecheck`/`build`/`test` already fan out |
+| `eslint.config.mjs` | add a React-scoped config block (JSX, hooks rules) for `apps/client/**` |
+| `.env.example` | uncomment `CLIENT_DIST`, document `VITE_API_PROXY_TARGET` |
+| `compose.yaml` | add a `client` dev service (Vite dev server, proxying `/api` to `api`) |
+| `compose.e2e.yaml` | `api` service gets `CLIENT_DIST=apps/client/dist` — the runner image now has a build to serve |
+| `render.yaml` | no new service — the client ships baked into `blogchat-api`'s image, per spec §11 |
+| `playwright.config.ts` | create — points at `compose.e2e.yaml`'s stack |
+| `e2e/*.spec.ts` | create — Playwright specs |
+
+**Modified in `apps/api`:** `Dockerfile` (`builder` stage also builds the client; `runner` stage copies its
+`dist` alongside the API's).
+
+**Created in `apps/client`:**
+
+```
+apps/client/
+├── package.json / tsconfig.json / tsconfig.node.json / vite.config.ts / vitest.config.ts / index.html
+└── src/
+    ├── main.tsx                     # QueryClientProvider + RouterProvider + <Toaster />
+    ├── routes.tsx                   # createBrowserRouter route table
+    ├── index.css                    # @import "tailwindcss"; + shadcn CSS variables (light only)
+    ├── test/setup.ts                # jest-dom matchers, MSW-free fetch mocking helpers
+    ├── lib/
+    │   ├── cn.ts                    # clsx + tailwind-merge, the cva convention
+    │   └── query-client.ts          # QueryClient instance + query-key constants
+    ├── api/
+    │   ├── client.ts                # request(), ApiError — the ONE place fetch() is called
+    │   ├── auth.ts / posts.ts / users.ts   # typed per-resource wrappers
+    ├── hooks/
+    │   ├── use-auth.ts               # useMe, useLogin, useSignup, useLogout
+    │   ├── use-posts.ts               # usePosts, usePost, useCreatePost, useUpdatePost, useDeletePost
+    │   └── use-likes.ts               # useLike / useUnlike, optimistic
+    ├── components/
+    │   ├── ui/                       # Button, Input, Label, Textarea, Card, Skeleton
+    │   ├── patterns/                 # PostCard, EmptyState, PageHeader, AutoForm, RequireAuth
+    │   └── layouts/PageShell.tsx      # nav + container, wraps every page
+    └── pages/
+        ├── BlogFeedPage.tsx / PostPage.tsx / NewPostPage.tsx / EditPostPage.tsx
+        └── LoginPage.tsx / SignupPage.tsx
+```
+
+---
+
+## Task 1: Vite scaffold, workspace wiring, Tailwind
+
+**Files:**
+- Create: `apps/client/package.json`, `tsconfig.json`, `tsconfig.node.json`, `vite.config.ts`, `index.html`
+- Create: `apps/client/src/main.tsx` (placeholder `<h1>`), `src/index.css`
+- Modify: `eslint.config.mjs`, `.env.example`
+
+**Interfaces:**
+- Consumes: nothing (first task)
+- Produces: `npm run dev --workspace=@blog/client` on `:5173`, proxying `/api` to the value of
+  `VITE_API_PROXY_TARGET` (default `http://localhost:3000`); `npm run build --workspace=@blog/client` →
+  `apps/client/dist`
+
+- [ ] **Step 1: Write `apps/client/package.json`**
+
+```json
+{
+  "name": "@blog/client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@blog/shared": "*",
+    "@tanstack/react-query": "^5.101.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.25.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-router": "^8.3.0",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.6.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.3",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^6.0.4",
+    "jsdom": "^29.1.1",
+    "tailwindcss": "^4.3.3",
+    "vite": "^8.1.5"
+  }
+}
+```
+
+- [ ] **Step 2: Write `apps/client/tsconfig.json` and `tsconfig.node.json`**
+
+```json
+// apps/client/tsconfig.json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+```
+
+```json
+// apps/client/tsconfig.node.json — separate project so vite.config.ts (a Node file)
+// doesn't pull DOM/JSX assumptions into the app's own compile, and vice versa.
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}
+```
+
+- [ ] **Step 3: Write `vite.config.ts` — the dev proxy is the load-bearing part**
+
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+// Same-origin in every environment (spec §11): the browser only ever talks to
+// :5173, and Vite forwards /api server-side. In Compose, VITE_API_PROXY_TARGET
+// is set to http://api:3000 (the container's service name); outside Compose it
+// defaults to localhost.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
+        changeOrigin: false,
+      },
+    },
+  },
+})
+```
+
+- [ ] **Step 4: Write `index.html`, `src/main.tsx` (placeholder), `src/index.css`**
+
+```html
+<!-- apps/client/index.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog-Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+```ts
+// apps/client/src/main.tsx — replaced with the real app in Task 4
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <h1>Blog-Chat</h1>
+  </StrictMode>,
+)
+```
+
+```css
+/* apps/client/src/index.css — Tailwind v4 is CSS-first: no tailwind.config.js,
+   no postcss.config.js. Light theme only (spec §2) — no .dark block. */
+@import 'tailwindcss';
+
+:root {
+  --background: oklch(0.98 0.051 105);       /* #FDFBD4 cream */
+  --foreground: oklch(0.28 0.047 67.5);      /* #38240D espresso */
+  --primary: oklch(0.581 0.155 49.5);        /* #C05800 burnt orange */
+  --primary-foreground: oklch(0.98 0.051 105); /* cream, for text on the orange primary */
+  --border: oklch(0.87 0.035 55);            /* light tan, same hue family as rust/orange */
+  --muted: oklch(0.94 0.025 60);             /* pale tan panel background */
+  --muted-foreground: oklch(0.403 0.101 53.8); /* #713600 rust */
+  --destructive: oklch(0.58 0.24 27);        /* red-orange, kept — already warm, harmonizes */
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+}
+```
+
+- [ ] **Step 5: Add the React-scoped eslint block**
+
+Append to `eslint.config.mjs`'s `tseslint.config(...)` call, as an additional config object (existing
+`ignores` and rules blocks stay untouched):
+
+```js
+{
+  files: ['apps/client/**/*.{ts,tsx}'],
+  rules: {
+    // React 19 doesn't need `import React` for JSX; unused-import churn is noise.
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+    ],
+  },
+},
+```
+
+- [ ] **Step 6: Uncomment/extend `.env.example`**
+
+```bash
+# Directory holding the built SPA. Unset in dev (Vite serves it separately).
+# Set by compose.e2e.yaml / render.yaml for the production/e2e image.
+# CLIENT_DIST=apps/client/dist
+
+# Where the client dev server proxies /api to. Defaults to localhost; Compose
+# overrides it to the api container's service name.
+# VITE_API_PROXY_TARGET=http://localhost:3000
+```
+
+- [ ] **Step 7: Gate and commit**
+
+Run: `npm install && npm run typecheck && npm run lint && npm run build`
+Expected: all pass; `apps/client/dist/index.html` exists.
+
+```bash
+git add apps/client package.json package-lock.json eslint.config.mjs .env.example
+git commit -m "feat(client): Vite + React + Tailwind v4 scaffold with dev proxy"
+```
+
+---
+
+## Task 2: UI primitives (`components/ui/`)
+
+**Files:**
+- Create: `apps/client/src/lib/cn.ts`
+- Create: `apps/client/src/components/ui/button.tsx`, `input.tsx`, `label.tsx`, `textarea.tsx`, `card.tsx`,
+  `skeleton.tsx`
+- Test: `apps/client/src/components/ui/button.test.tsx`
+- Create: `apps/client/vitest.config.ts`, `apps/client/src/test/setup.ts`
+
+**Interfaces:**
+- Produces: `cn(...classes)`; `<Button variant="default"|"outline"|"ghost"|"destructive" size="sm"|"default"|"lg">`,
+  `<Input>`, `<Label>`, `<Textarea>`, `<Card>`, `<Skeleton>` — all forward `ref` and spread native props.
+
+- [ ] **Step 1: Wire up Vitest for component tests**
+
+```ts
+// apps/client/vitest.config.ts
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: { environment: 'jsdom', setupFiles: ['./src/test/setup.ts'], globals: true },
+  }),
+)
+```
+
+```ts
+// apps/client/src/test/setup.ts
+import '@testing-library/jest-dom/vitest'
+```
+
+- [ ] **Step 2: Write the failing test for `Button`'s variant/disabled behavior**
+
+```tsx
+// apps/client/src/components/ui/button.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { Button } from './button.js'
+
+describe('Button', () => {
+  it('renders its children and forwards onClick', async () => {
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Save</Button>)
+    screen.getByText('Save').click()
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('is disabled and non-interactive when disabled is set', () => {
+    render(<Button disabled>Save</Button>)
+    expect(screen.getByText('Save')).toBeDisabled()
+  })
+
+  it('applies the destructive variant class', () => {
+    render(<Button variant="destructive">Delete</Button>)
+    expect(screen.getByText('Delete').className).toContain('bg-[var(--destructive)]')
+  })
+})
+```
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/components/ui/button.test.tsx`
+Expected: FAIL — `./button.js` does not exist yet.
+
+- [ ] **Step 4: Implement `cn` and `Button`**
+
+```ts
+// apps/client/src/lib/cn.ts
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}
+```
+
+```tsx
+// apps/client/src/components/ui/button.tsx
+import { cva, type VariantProps } from 'class-variance-authority'
+import { forwardRef, type ButtonHTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90',
+        outline: 'border border-[var(--border)] bg-transparent hover:bg-[var(--muted)]',
+        ghost: 'bg-transparent hover:bg-[var(--muted)]',
+        destructive: 'bg-[var(--destructive)] text-[var(--primary-foreground)] hover:opacity-90',
+      },
+      size: {
+        sm: 'h-8 px-3',
+        default: 'h-10 px-4',
+        lg: 'h-12 px-6 text-base',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'default' },
+  },
+)
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />
+  ),
+)
+Button.displayName = 'Button'
+```
+
+- [ ] **Step 5: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/components/ui/button.test.tsx`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Implement the remaining primitives (no new test — thin wrappers, exercised transitively by
+  Task 4+'s component tests)**
+
+```tsx
+// apps/client/src/components/ui/input.tsx
+import { forwardRef, type InputHTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        'h-10 w-full rounded-md border border-[var(--border)] bg-transparent px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Input.displayName = 'Input'
+```
+
+```tsx
+// apps/client/src/components/ui/label.tsx
+import { forwardRef, type LabelHTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+
+export const Label = forwardRef<HTMLLabelElement, LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} className={cn('text-sm font-medium', className)} {...props} />
+  ),
+)
+Label.displayName = 'Label'
+```
+
+```tsx
+// apps/client/src/components/ui/textarea.tsx
+import { forwardRef, type TextareaHTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        'min-h-32 w-full rounded-md border border-[var(--border)] bg-transparent p-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Textarea.displayName = 'Textarea'
+```
+
+```tsx
+// apps/client/src/components/ui/card.tsx
+import type { HTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('rounded-lg border border-[var(--border)] p-4', className)} {...props} />
+}
+```
+
+```tsx
+// apps/client/src/components/ui/skeleton.tsx
+import type { HTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+
+export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-[var(--muted)]', className)} {...props} />
+}
+```
+
+- [ ] **Step 7: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+
+```bash
+git add apps/client/src/lib apps/client/src/components/ui apps/client/vitest.config.ts apps/client/src/test
+git commit -m "feat(client): ui primitives (Button, Input, Label, Textarea, Card, Skeleton)"
+```
+
+---
+
+## Task 3: API client layer
+
+**Files:**
+- Create: `apps/client/src/api/client.ts`, `auth.ts`, `posts.ts`, `users.ts`
+- Test: `apps/client/src/api/client.test.ts`
+
+**Interfaces:**
+- Consumes: `PostDto`-shaped JSON from `GET/POST/PATCH /api/v1/posts*` (P1); the fixed error shape from
+  `apps/api/src/middleware/error-handler.ts`
+- Produces:
+  - `class ApiError extends Error { status: number; fields: Record<string, string[]> }`
+  - `request<T>(path: string, init?: RequestInit): Promise<T>` — throws `ApiError` on a non-2xx response
+  - `type Post = { id: string; title: string; slug: string; body: string; premium: boolean; gated: boolean; author: { id: string; username: string }; tags: string[]; likeCount: number; coverImage?: string; createdAt: string; updatedAt: string }`
+    (mirrors `apps/api/src/lib/services/post.ts`'s `PostDto`, with dates as ISO strings over JSON)
+  - `authApi.signup/login/logout/me`, `postsApi.list/get/create/update/remove/like/unlike`,
+    `usersApi.get/update/remove`
+
+- [ ] **Step 1: Write the failing test for `request`'s error handling**
+
+```ts
+// apps/client/src/api/client.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, request } from './client.js'
+
+describe('request', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns the parsed JSON body on a 2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    )
+    await expect(request('/api/v1/health')).resolves.toEqual({ ok: true })
+  })
+
+  it('returns undefined for a 204 with no body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })))
+    await expect(request('/api/v1/posts/x')).resolves.toBeUndefined()
+  })
+
+  it('throws ApiError carrying the status and field errors on a 400', async () => {
+    const body = { error: { message: 'Invalid input.', fields: { title: ['Too short'] } } }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status: 400 })))
+    await expect(request('/api/v1/posts')).rejects.toMatchObject({
+      status: 400,
+      message: 'Invalid input.',
+      fields: { title: ['Too short'] },
+    })
+  })
+
+  it('always sends credentials so the session cookie rides along', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    await request('/api/v1/posts')
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/posts', expect.objectContaining({ credentials: 'include' }))
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/api/client.test.ts`
+Expected: FAIL — `./client.js` does not exist.
+
+- [ ] **Step 3: Implement `request` and `ApiError`**
+
+```ts
+// apps/client/src/api/client.ts
+export class ApiError extends Error {
+  readonly status: number
+  readonly fields: Record<string, string[]>
+
+  constructor(status: number, message: string, fields: Record<string, string[]> = {}) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.fields = fields
+  }
+}
+
+export async function request<T = unknown>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...init.headers },
+  })
+
+  if (res.status === 204) return undefined as T
+
+  const body = (await res.json().catch(() => null)) as
+    | { error?: { message: string; fields?: Record<string, string[]> } }
+    | null
+
+  if (!res.ok) {
+    throw new ApiError(res.status, body?.error?.message ?? 'Request failed.', body?.error?.fields ?? {})
+  }
+
+  return body as T
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/api/client.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Implement the typed per-resource wrappers (no new test — thin, exercised by the hook tests
+  in Tasks 5/7/9/10)**
+
+```ts
+// apps/client/src/api/posts.ts
+import { request } from './client.js'
+
+export type PostAuthor = { id: string; username: string }
+
+export type Post = {
+  id: string
+  title: string
+  slug: string
+  body: string
+  premium: boolean
+  gated: boolean
+  author: PostAuthor
+  tags: string[]
+  likeCount: number
+  coverImage?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type CreatePostInput = { title: string; body: string; premium?: boolean; tags?: string[] }
+export type UpdatePostInput = Partial<CreatePostInput>
+
+export const postsApi = {
+  list: () => request<Post[]>('/api/v1/posts'),
+  get: (slug: string) => request<Post>(`/api/v1/posts/${slug}`),
+  create: (input: CreatePostInput) =>
+    request<Post>('/api/v1/posts', { method: 'POST', body: JSON.stringify(input) }),
+  update: (slug: string, input: UpdatePostInput) =>
+    request<Post>(`/api/v1/posts/${slug}`, { method: 'PATCH', body: JSON.stringify(input) }),
+  remove: (slug: string) => request<void>(`/api/v1/posts/${slug}`, { method: 'DELETE' }),
+  like: (slug: string) => request<{ likeCount: number }>(`/api/v1/posts/${slug}/likes`, { method: 'PUT' }),
+  unlike: (slug: string) =>
+    request<{ likeCount: number }>(`/api/v1/posts/${slug}/likes`, { method: 'DELETE' }),
+}
+```
+
+```ts
+// apps/client/src/api/auth.ts
+import { request } from './client.js'
+
+export type AuthUser = { id: string; username: string }
+export type SignupInput = { username: string; email: string; password: string }
+export type LoginInput = { username: string; password: string }
+
+export const authApi = {
+  signup: (input: SignupInput) =>
+    request<AuthUser>('/api/v1/auth/signup', { method: 'POST', body: JSON.stringify(input) }),
+  login: (input: LoginInput) =>
+    request<AuthUser>('/api/v1/auth/login', { method: 'POST', body: JSON.stringify(input) }),
+  logout: () => request<void>('/api/v1/auth/logout', { method: 'POST' }),
+  me: () => request<AuthUser>('/api/v1/auth/me'),
+}
+```
+
+```ts
+// apps/client/src/api/users.ts
+import { request } from './client.js'
+
+export type PublicUser = { id: string; username: string; bio?: string; image?: string; createdAt: string }
+export type UpdateUserInput = { bio?: string; image?: string; password?: string }
+
+export const usersApi = {
+  get: (id: string) => request<PublicUser>(`/api/v1/users/${id}`),
+  update: (id: string, input: UpdateUserInput) =>
+    request<PublicUser>(`/api/v1/users/${id}`, { method: 'PATCH', body: JSON.stringify(input) }),
+  remove: (id: string) => request<void>(`/api/v1/users/${id}`, { method: 'DELETE' }),
+}
+```
+
+- [ ] **Step 6: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+
+```bash
+git add apps/client/src/api
+git commit -m "feat(client): typed API wrappers (client.ts + auth/posts/users)"
+```
+
+---
+
+## Task 4: Query client, router, page shell
+
+**Files:**
+- Create: `apps/client/src/lib/query-client.ts`, `src/routes.tsx`
+- Create: `apps/client/src/components/layouts/PageShell.tsx`
+- Modify: `apps/client/src/main.tsx`
+
+**Interfaces:**
+- Consumes: `postsApi`, `authApi` (Task 3)
+- Produces: `queryClient: QueryClient`; `queryKeys.posts.list/detail(slug)`, `queryKeys.me`; the route table
+  (paths from spec §9); `<PageShell>` wrapping every page with nav + container
+
+- [ ] **Step 1: Write the query client and key constants**
+
+```ts
+// apps/client/src/lib/query-client.ts
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
+})
+
+export const queryKeys = {
+  posts: {
+    list: ['posts'] as const,
+    detail: (slug: string) => ['posts', slug] as const,
+  },
+  me: ['me'] as const,
+}
+```
+
+- [ ] **Step 2: Write `PageShell`**
+
+```tsx
+// apps/client/src/components/layouts/PageShell.tsx
+import type { ReactNode } from 'react'
+import { Link } from 'react-router'
+import { useMe, useLogout } from '../../hooks/use-auth.js'
+import { Button } from '../ui/button.js'
+
+export function PageShell({ children }: { children: ReactNode }) {
+  const { data: me } = useMe()
+  const logout = useLogout()
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-[var(--border)]">
+        <nav className="mx-auto flex max-w-3xl items-center justify-between p-4">
+          <Link to="/" className="text-lg font-semibold">
+            Blog-Chat
+          </Link>
+          <div className="flex items-center gap-3">
+            {me ? (
+              <>
+                <Link to="/blog/new" className="text-sm">
+                  New post
+                </Link>
+                <Button variant="ghost" size="sm" onClick={() => logout.mutate()}>
+                  Log out
+                </Button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" className="text-sm">
+                  Log in
+                </Link>
+                <Link to="/signup" className="text-sm">
+                  Sign up
+                </Link>
+              </>
+            )}
+          </div>
+        </nav>
+      </header>
+      <main className="mx-auto max-w-3xl p-4">{children}</main>
+    </div>
+  )
+}
+```
+
+(`useMe`/`useLogout` are implemented in Task 5 — this file is written now and typechecks once Task 5 lands;
+the two tasks are typically done in the same PR, so this is a documented forward reference, not a broken
+build in isolation.)
+
+- [ ] **Step 3: Write the route table**
+
+```tsx
+// apps/client/src/routes.tsx
+import { createBrowserRouter } from 'react-router'
+import { PageShell } from './components/layouts/PageShell.js'
+import { BlogFeedPage } from './pages/BlogFeedPage.js'
+import { PostPage } from './pages/PostPage.js'
+import { NewPostPage } from './pages/NewPostPage.js'
+import { EditPostPage } from './pages/EditPostPage.js'
+import { LoginPage } from './pages/LoginPage.js'
+import { SignupPage } from './pages/SignupPage.js'
+
+export const router = createBrowserRouter([
+  {
+    element: (
+      <PageShell>
+        {/* Outlet renders the matched child route */}
+        <Outlet />
+      </PageShell>
+    ),
+    children: [
+      { path: '/', element: <BlogFeedPage /> },
+      { path: '/blog/new', element: <NewPostPage /> },
+      { path: '/blog/:slug', element: <PostPage /> },
+      { path: '/blog/:slug/edit', element: <EditPostPage /> },
+      { path: '/login', element: <LoginPage /> },
+      { path: '/signup', element: <SignupPage /> },
+    ],
+  },
+])
+```
+
+Add the missing `Outlet` import: `import { Outlet, createBrowserRouter } from 'react-router'`.
+
+- [ ] **Step 4: Wire `main.tsx`**
+
+```tsx
+// apps/client/src/main.tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from 'react-router/dom'
+import { Toaster } from 'sonner'
+import { queryClient } from './lib/query-client.js'
+import { router } from './routes.js'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <Toaster position="top-center" />
+    </QueryClientProvider>
+  </StrictMode>,
+)
+```
+
+- [ ] **Step 5: Gate and commit** (once Tasks 5–9's page stubs exist — see note below)
+
+> **Sequencing note:** this task's `routes.tsx` imports six page components and `PageShell` imports
+> `use-auth.ts`, none of which exist until Tasks 5–9. Do Task 5 (auth pages + hooks) immediately after this
+> one, then stub `BlogFeedPage`/`PostPage`/`NewPostPage`/`EditPostPage` with a one-line placeholder so the
+> build is green, and let Tasks 7–9 replace the stubs with real implementations. Do not skip the gate.
+
+```bash
+git add apps/client/src/lib/query-client.ts apps/client/src/routes.tsx apps/client/src/components/layouts apps/client/src/main.tsx
+git commit -m "feat(client): query client, router, page shell"
+```
+
+---
+
+## Task 5: Auth pages, hooks, route guard
+
+**Files:**
+- Create: `apps/client/src/hooks/use-auth.ts`
+- Create: `apps/client/src/components/patterns/RequireAuth.tsx`
+- Create: `apps/client/src/pages/LoginPage.tsx`, `SignupPage.tsx`
+- Test: `apps/client/src/hooks/use-auth.test.tsx`
+
+**Interfaces:**
+- Consumes: `authApi` (Task 3), `queryKeys.me` (Task 4)
+- Produces:
+  - `useMe(): UseQueryResult<AuthUser | null>` — resolves `null` (not throwing) on a 401, so callers don't
+    need a try/catch just to check "am I logged in"
+  - `useLogin/useSignup(): UseMutationResult` — invalidate `queryKeys.me` on success
+  - `useLogout(): UseMutationResult` — clears the `me` cache to `null` directly (no need to refetch a
+    logged-out state)
+  - `<RequireAuth>{children}</RequireAuth>` — redirects to `/login` if `useMe()` resolves to `null`
+
+- [ ] **Step 1: Write the failing test for `useMe`'s 401-as-null behavior**
+
+```tsx
+// apps/client/src/hooks/use-auth.test.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useMe } from './use-auth.js'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useMe', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('resolves to null on a 401 rather than throwing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: 'Unauthorized.' } }), { status: 401 }),
+      ),
+    )
+    const { result } = renderHook(() => useMe(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('resolves to the user on 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ id: '1', username: 'demo' }), { status: 200 })),
+    )
+    const { result } = renderHook(() => useMe(), { wrapper })
+    await waitFor(() => expect(result.current.data).toEqual({ id: '1', username: 'demo' }))
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/hooks/use-auth.test.tsx`
+Expected: FAIL — `./use-auth.js` does not exist.
+
+- [ ] **Step 3: Implement `use-auth.ts`**
+
+```ts
+// apps/client/src/hooks/use-auth.ts
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { authApi, type AuthUser, type LoginInput, type SignupInput } from '../api/auth.js'
+import { ApiError } from '../api/client.js'
+import { queryKeys } from '../lib/query-client.js'
+
+export function useMe() {
+  return useQuery({
+    queryKey: queryKeys.me,
+    queryFn: async (): Promise<AuthUser | null> => {
+      try {
+        return await authApi.me()
+      } catch (err) {
+        // Anonymous is an expected state, not an error to surface — everywhere
+        // that reads useMe() just checks `data == null`.
+        if (err instanceof ApiError && err.status === 401) return null
+        throw err
+      }
+    },
+  })
+}
+
+export function useLogin() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: LoginInput) => authApi.login(input),
+    onSuccess: (user) => queryClient.setQueryData(queryKeys.me, user),
+  })
+}
+
+export function useSignup() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: SignupInput) => authApi.signup(input),
+    onSuccess: (user) => queryClient.setQueryData(queryKeys.me, user),
+  })
+}
+
+export function useLogout() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => authApi.logout(),
+    onSuccess: () => queryClient.setQueryData(queryKeys.me, null),
+  })
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/hooks/use-auth.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Implement `RequireAuth`, `LoginPage`, `SignupPage`** (no new test — `RequireAuth`'s redirect
+  and the forms' field-error rendering are covered by the Playwright flow in Task 9)
+
+```tsx
+// apps/client/src/components/patterns/RequireAuth.tsx
+import type { ReactNode } from 'react'
+import { Navigate, useLocation } from 'react-router'
+import { useMe } from '../../hooks/use-auth.js'
+
+// UX guard only. The API is what actually enforces authorization (spec §9) —
+// this just avoids showing an editor to a user who will get a 401 anyway.
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { data: me, isPending } = useMe()
+  const location = useLocation()
+
+  if (isPending) return null
+  if (!me) return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  return <>{children}</>
+}
+```
+
+```tsx
+// apps/client/src/pages/LoginPage.tsx
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { useLogin } from '../hooks/use-auth.js'
+import { Button } from '../components/ui/button.js'
+import { Input } from '../components/ui/input.js'
+import { Label } from '../components/ui/label.js'
+
+export function LoginPage() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const login = useLogin()
+  const navigate = useNavigate()
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    login.mutate(
+      { username, password },
+      {
+        onSuccess: () => navigate('/'),
+        onError: () => toast.error('Invalid username or password.'),
+      },
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-sm flex-col gap-4">
+      <h1 className="text-xl font-semibold">Log in</h1>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="username">Username</Label>
+        <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} required />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" disabled={login.isPending}>
+        Log in
+      </Button>
+    </form>
+  )
+}
+```
+
+```tsx
+// apps/client/src/pages/SignupPage.tsx
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { useSignup } from '../hooks/use-auth.js'
+import { ApiError } from '../api/client.js'
+import { Button } from '../components/ui/button.js'
+import { Input } from '../components/ui/input.js'
+import { Label } from '../components/ui/label.js'
+
+export function SignupPage() {
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const signup = useSignup()
+  const navigate = useNavigate()
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    signup.mutate(
+      { username, email, password },
+      {
+        onSuccess: () => navigate('/'),
+        onError: (err) => toast.error(err instanceof ApiError ? err.message : 'Signup failed.'),
+      },
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-sm flex-col gap-4">
+      <h1 className="text-xl font-semibold">Sign up</h1>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="username">Username</Label>
+        <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} required />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={8}
+        />
+      </div>
+      <Button type="submit" disabled={signup.isPending}>
+        Sign up
+      </Button>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 6: Stub the remaining four pages so the app builds**
+
+```tsx
+// apps/client/src/pages/BlogFeedPage.tsx (replaced in Task 7)
+export function BlogFeedPage() {
+  return <p>Coming in Task 7.</p>
+}
+```
+
+Repeat the same one-line-return pattern for `PostPage.tsx` (Task 8), `NewPostPage.tsx`/`EditPostPage.tsx`
+(Task 9) — each just exports a named function returning a placeholder `<p>`.
+
+- [ ] **Step 7: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run build && npm run test`
+
+```bash
+git add apps/client/src/hooks/use-auth.ts apps/client/src/hooks/use-auth.test.tsx apps/client/src/components/patterns/RequireAuth.tsx apps/client/src/pages
+git commit -m "feat(client): auth pages, hooks, and a UX-only route guard"
+```
+
+---
+
+## Task 6: Blog feed + `PostCard`
+
+**Files:**
+- Create: `apps/client/src/hooks/use-posts.ts`
+- Create: `apps/client/src/components/patterns/PostCard.tsx`, `EmptyState.tsx`
+- Modify: `apps/client/src/pages/BlogFeedPage.tsx` (replace the Task 5 stub)
+- Test: `apps/client/src/components/patterns/PostCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `postsApi.list` (Task 3), `queryKeys.posts.list` (Task 4)
+- Produces: `usePosts(): UseQueryResult<Post[]>`; `<PostCard post={Post} />`; `<EmptyState message />`
+
+- [ ] **Step 1: Write the failing test for `PostCard`'s teaser/gated rendering**
+
+```tsx
+// apps/client/src/components/patterns/PostCard.test.tsx
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { PostCard } from './PostCard.js'
+import type { Post } from '../../api/posts.js'
+
+const basePost: Post = {
+  id: '1',
+  title: 'Gating at the boundary',
+  slug: 'gating-at-the-boundary',
+  body: 'Full text here.',
+  premium: true,
+  gated: true,
+  author: { id: 'u1', username: 'demo' },
+  tags: ['express'],
+  likeCount: 3,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+describe('PostCard', () => {
+  it('shows a premium badge and a sign-in prompt when gated', () => {
+    render(<PostCard post={basePost} />, { wrapper: MemoryRouter })
+    expect(screen.getByText(/premium/i)).toBeInTheDocument()
+    expect(screen.getByText(/sign in to read/i)).toBeInTheDocument()
+  })
+
+  it('does not show the sign-in prompt for a free or unlocked post', () => {
+    render(<PostCard post={{ ...basePost, gated: false }} />, { wrapper: MemoryRouter })
+    expect(screen.queryByText(/sign in to read/i)).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/components/patterns/PostCard.test.tsx`
+Expected: FAIL — `./PostCard.js` does not exist.
+
+- [ ] **Step 3: Implement `PostCard`**
+
+```tsx
+// apps/client/src/components/patterns/PostCard.tsx
+import { Link } from 'react-router'
+import type { Post } from '../../api/posts.js'
+import { Card } from '../ui/card.js'
+
+export function PostCard({ post }: { post: Post }) {
+  return (
+    <Card>
+      <Link to={`/blog/${post.slug}`} className="text-lg font-semibold hover:underline">
+        {post.title}
+      </Link>
+      {post.premium && (
+        <span className="ml-2 rounded bg-[var(--muted)] px-2 py-0.5 text-xs">Premium</span>
+      )}
+      <p className="mt-2 text-sm text-[var(--muted-foreground)]">{post.body}</p>
+      {post.gated && <p className="mt-2 text-sm text-[var(--primary)]">Sign in to read the full post</p>}
+      <p className="mt-3 text-xs text-[var(--muted-foreground)]">
+        by {post.author.username} · {post.likeCount} likes
+      </p>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/components/patterns/PostCard.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Implement `usePosts`, `EmptyState`, and the real `BlogFeedPage`**
+
+```ts
+// apps/client/src/hooks/use-posts.ts (add to; extended by Tasks 8/9/10)
+import { useQuery } from '@tanstack/react-query'
+import { postsApi } from '../api/posts.js'
+import { queryKeys } from '../lib/query-client.js'
+
+export function usePosts() {
+  return useQuery({ queryKey: queryKeys.posts.list, queryFn: postsApi.list })
+}
+```
+
+```tsx
+// apps/client/src/components/patterns/EmptyState.tsx
+export function EmptyState({ message }: { message: string }) {
+  return <p className="py-12 text-center text-[var(--muted-foreground)]">{message}</p>
+}
+```
+
+```tsx
+// apps/client/src/pages/BlogFeedPage.tsx
+import { usePosts } from '../hooks/use-posts.js'
+import { PostCard } from '../components/patterns/PostCard.js'
+import { EmptyState } from '../components/patterns/EmptyState.js'
+import { Skeleton } from '../components/ui/skeleton.js'
+
+export function BlogFeedPage() {
+  const { data: posts, isPending } = usePosts()
+
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-24" />
+        <Skeleton className="h-24" />
+      </div>
+    )
+  }
+  if (!posts || posts.length === 0) return <EmptyState message="No posts yet." />
+
+  return (
+    <div className="flex flex-col gap-4">
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run build && npm run test`
+
+```bash
+git add apps/client/src/hooks/use-posts.ts apps/client/src/components/patterns/PostCard.tsx apps/client/src/components/patterns/PostCard.test.tsx apps/client/src/components/patterns/EmptyState.tsx apps/client/src/pages/BlogFeedPage.tsx
+git commit -m "feat(client): blog feed page and PostCard"
+```
+
+---
+
+## Task 7: Post detail page (gating UI)
+
+**Files:**
+- Modify: `apps/client/src/hooks/use-posts.ts` (add `usePost`)
+- Modify: `apps/client/src/pages/PostPage.tsx` (replace the Task 5 stub)
+
+**Interfaces:**
+- Consumes: `postsApi.get`, `useMe` (Task 5)
+- Produces: `usePost(slug): UseQueryResult<Post>`
+
+- [ ] **Step 1: Add `usePost`**
+
+```ts
+// apps/client/src/hooks/use-posts.ts — append
+export function usePost(slug: string) {
+  return useQuery({ queryKey: queryKeys.posts.detail(slug), queryFn: () => postsApi.get(slug) })
+}
+```
+
+- [ ] **Step 2: Implement `PostPage`**
+
+The API already decided what this page is allowed to show — `post.gated` is the only branch needed. There
+is nothing else to check client-side (spec §6).
+
+```tsx
+// apps/client/src/pages/PostPage.tsx
+import { Link, useParams } from 'react-router'
+import { usePost } from '../hooks/use-posts.js'
+import { useMe } from '../hooks/use-auth.js'
+import { Skeleton } from '../components/ui/skeleton.js'
+import { LikeButton } from '../components/patterns/LikeButton.js'
+
+export function PostPage() {
+  const { slug } = useParams<{ slug: string }>()
+  const { data: post, isPending } = usePost(slug!)
+  const { data: me } = useMe()
+
+  if (isPending) return <Skeleton className="h-64" />
+  if (!post) return <p>Post not found.</p>
+
+  const isOwner = me?.id === post.author.id
+
+  return (
+    <article>
+      <h1 className="text-2xl font-semibold">{post.title}</h1>
+      <p className="mt-1 text-sm text-[var(--muted-foreground)]">by {post.author.username}</p>
+      <div className="mt-4 whitespace-pre-wrap">{post.body}</div>
+      {post.gated && (
+        <p className="mt-4 rounded bg-[var(--muted)] p-4 text-sm">
+          <Link to="/login" className="text-[var(--primary)] underline">
+            Sign in
+          </Link>{' '}
+          to read the rest of this post.
+        </p>
+      )}
+      <div className="mt-6 flex items-center gap-4">
+        <LikeButton slug={post.slug} liked={false} likeCount={post.likeCount} />
+        {isOwner && (
+          <Link to={`/blog/${post.slug}/edit`} className="text-sm underline">
+            Edit
+          </Link>
+        )}
+      </div>
+    </article>
+  )
+}
+```
+
+(`LikeButton` is built in Task 10 — stub it with a one-line placeholder now if Task 10 hasn't landed yet in
+your execution order; this plan's tasks are designed be done in order, so by the time `PostPage` is gated
+in review, `LikeButton` already exists.)
+
+- [ ] **Step 3: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run build`
+
+```bash
+git add apps/client/src/hooks/use-posts.ts apps/client/src/pages/PostPage.tsx
+git commit -m "feat(client): post detail page with server-driven gating UI"
+```
+
+---
+
+## Task 8: `AutoForm` and the post editor (create/edit)
+
+**Files:**
+- Create: `apps/client/src/components/patterns/AutoForm.tsx`
+- Modify: `apps/client/src/hooks/use-posts.ts` (add `useCreatePost`, `useUpdatePost`)
+- Modify: `apps/client/src/pages/NewPostPage.tsx`, `EditPostPage.tsx` (replace the Task 5 stubs)
+- Test: `apps/client/src/components/patterns/AutoForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `CreatePostSchema`/`UpdatePostSchema` from `@blog/shared` (P1)
+- Produces: `<AutoForm schema={ZodObject} initialValues? onSubmit={(values) => void} submitLabel? />` —
+  renders one field per schema key (string → text/textarea by field name heuristic, boolean → checkbox,
+  `string[]` → comma-separated text input), shows `ZodError` field messages inline, calls `onSubmit` with
+  the **parsed** (not raw) values only after `schema.safeParse` succeeds.
+
+- [ ] **Step 1: Write the failing test for field derivation and validation**
+
+```tsx
+// apps/client/src/components/patterns/AutoForm.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { AutoForm } from './AutoForm.js'
+
+const schema = z.object({
+  title: z.string().min(3, 'Title must be at least 3 characters'),
+  premium: z.coerce.boolean().default(false),
+  tags: z.array(z.string()).default([]),
+})
+
+describe('AutoForm', () => {
+  it('renders one labeled field per schema key', () => {
+    render(<AutoForm schema={schema} onSubmit={vi.fn()} />)
+    expect(screen.getByLabelText('title')).toBeInTheDocument()
+    expect(screen.getByLabelText('premium')).toBeInTheDocument()
+    expect(screen.getByLabelText('tags')).toBeInTheDocument()
+  })
+
+  it('shows the schema error message and does not call onSubmit for invalid input', () => {
+    const onSubmit = vi.fn()
+    render(<AutoForm schema={schema} onSubmit={onSubmit} />)
+    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'ab' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(screen.getByText('Title must be at least 3 characters')).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('parses a comma-separated tags input into a string array on submit', () => {
+    const onSubmit = vi.fn()
+    render(<AutoForm schema={schema} onSubmit={onSubmit} />)
+    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
+    fireEvent.change(screen.getByLabelText('tags'), { target: { value: 'express, testing' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'A valid title', tags: ['express', 'testing'] }),
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/components/patterns/AutoForm.test.tsx`
+Expected: FAIL — `./AutoForm.js` does not exist.
+
+- [ ] **Step 3: Implement `AutoForm`**
+
+```tsx
+// apps/client/src/components/patterns/AutoForm.tsx
+import { useState, type FormEvent } from 'react'
+import type { z, ZodObject, ZodRawShape } from 'zod'
+import { Button } from '../ui/button.js'
+import { Input } from '../ui/input.js'
+import { Label } from '../ui/label.js'
+import { Textarea } from '../ui/textarea.js'
+
+type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'text'
+
+function fieldKind(key: string, def: z.ZodTypeAny): FieldKind {
+  const inner = 'unwrap' in def && typeof def.unwrap === 'function' ? def.unwrap() : def
+  if (inner._def.typeName === 'ZodBoolean') return 'checkbox'
+  if (inner._def.typeName === 'ZodArray') return 'tags'
+  if (key === 'body') return 'textarea'
+  return 'text'
+}
+
+export function AutoForm<S extends ZodObject<ZodRawShape>>({
+  schema,
+  initialValues,
+  onSubmit,
+  submitLabel = 'Save',
+}: {
+  schema: S
+  initialValues?: Partial<z.infer<S>>
+  onSubmit: (values: z.infer<S>) => void
+  submitLabel?: string
+}) {
+  const shape = schema.shape
+  const keys = Object.keys(shape) as (keyof typeof shape & string)[]
+
+  const [values, setValues] = useState<Record<string, string | boolean>>(() =>
+    Object.fromEntries(
+      keys.map((key) => {
+        const initial = initialValues?.[key as keyof typeof initialValues]
+        if (fieldKind(key, shape[key]) === 'checkbox') return [key, Boolean(initial ?? false)]
+        if (fieldKind(key, shape[key]) === 'tags') return [key, Array.isArray(initial) ? initial.join(', ') : '']
+        return [key, typeof initial === 'string' ? initial : '']
+      }),
+    ),
+  )
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  function parsedValue(key: string): unknown {
+    const kind = fieldKind(key, shape[key])
+    if (kind === 'checkbox') return values[key]
+    if (kind === 'tags') {
+      const raw = values[key]
+      return typeof raw === 'string'
+        ? raw
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : []
+    }
+    return values[key]
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const candidate = Object.fromEntries(keys.map((key) => [key, parsedValue(key)]))
+    const result = schema.safeParse(candidate)
+    if (!result.success) {
+      setErrors(Object.fromEntries(result.error.issues.map((issue) => [String(issue.path[0]), issue.message])))
+      return
+    }
+    setErrors({})
+    onSubmit(result.data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {keys.map((key) => {
+        const kind = fieldKind(key, shape[key])
+        return (
+          <div key={key} className="flex flex-col gap-1">
+            <Label htmlFor={key}>{key}</Label>
+            {kind === 'checkbox' ? (
+              <input
+                id={key}
+                type="checkbox"
+                checked={Boolean(values[key])}
+                onChange={(e) => setValues((v) => ({ ...v, [key]: e.target.checked }))}
+              />
+            ) : kind === 'textarea' ? (
+              <Textarea
+                id={key}
+                value={String(values[key] ?? '')}
+                onChange={(e) => setValues((v) => ({ ...v, [key]: e.target.value }))}
+              />
+            ) : (
+              <Input
+                id={key}
+                value={String(values[key] ?? '')}
+                onChange={(e) => setValues((v) => ({ ...v, [key]: e.target.value }))}
+              />
+            )}
+            {errors[key] && <p className="text-sm text-[var(--destructive)]">{errors[key]}</p>}
+          </div>
+        )
+      })}
+      <Button type="submit">{submitLabel}</Button>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/components/patterns/AutoForm.test.tsx`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Add mutation hooks and wire the two pages**
+
+```ts
+// apps/client/src/hooks/use-posts.ts — append
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { CreatePostInput, UpdatePostInput } from '../api/posts.js'
+
+export function useCreatePost() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: CreatePostInput) => postsApi.create(input),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.list }),
+  })
+}
+
+export function useUpdatePost(slug: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: UpdatePostInput) => postsApi.update(slug, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.posts.list })
+      queryClient.invalidateQueries({ queryKey: queryKeys.posts.detail(slug) })
+    },
+  })
+}
+```
+
+```tsx
+// apps/client/src/pages/NewPostPage.tsx
+import { CreatePostSchema } from '@blog/shared'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { AutoForm } from '../components/patterns/AutoForm.js'
+import { RequireAuth } from '../components/patterns/RequireAuth.js'
+import { useCreatePost } from '../hooks/use-posts.js'
+import { ApiError } from '../api/client.js'
+
+export function NewPostPage() {
+  const createPost = useCreatePost()
+  const navigate = useNavigate()
+
+  return (
+    <RequireAuth>
+      <h1 className="mb-4 text-xl font-semibold">New post</h1>
+      <AutoForm
+        schema={CreatePostSchema}
+        onSubmit={(values) =>
+          createPost.mutate(values, {
+            onSuccess: (post) => navigate(`/blog/${post.slug}`),
+            onError: (err) => toast.error(err instanceof ApiError ? err.message : 'Could not create post.'),
+          })
+        }
+      />
+    </RequireAuth>
+  )
+}
+```
+
+```tsx
+// apps/client/src/pages/EditPostPage.tsx
+import { UpdatePostSchema } from '@blog/shared'
+import { useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
+import { AutoForm } from '../components/patterns/AutoForm.js'
+import { RequireAuth } from '../components/patterns/RequireAuth.js'
+import { usePost, useUpdatePost } from '../hooks/use-posts.js'
+import { ApiError } from '../api/client.js'
+
+export function EditPostPage() {
+  const { slug } = useParams<{ slug: string }>()
+  const { data: post } = usePost(slug!)
+  const updatePost = useUpdatePost(slug!)
+  const navigate = useNavigate()
+
+  if (!post) return null
+
+  return (
+    <RequireAuth>
+      <h1 className="mb-4 text-xl font-semibold">Edit post</h1>
+      <AutoForm
+        schema={UpdatePostSchema}
+        initialValues={post}
+        onSubmit={(values) =>
+          updatePost.mutate(values, {
+            onSuccess: () => navigate(`/blog/${post.slug}`),
+            onError: (err) => toast.error(err instanceof ApiError ? err.message : 'Could not save changes.'),
+          })
+        }
+      />
+    </RequireAuth>
+  )
+}
+```
+
+- [ ] **Step 6: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run build && npm run test`
+
+```bash
+git add apps/client/src/components/patterns/AutoForm.tsx apps/client/src/components/patterns/AutoForm.test.tsx apps/client/src/hooks/use-posts.ts apps/client/src/pages/NewPostPage.tsx apps/client/src/pages/EditPostPage.tsx
+git commit -m "feat(client): schema-driven AutoForm and the post editor"
+```
+
+---
+
+## Task 9: Delete post (owner-only UI action)
+
+**Files:**
+- Modify: `apps/client/src/hooks/use-posts.ts` (add `useDeletePost`)
+- Modify: `apps/client/src/pages/PostPage.tsx` (add a delete button for the owner)
+
+**Interfaces:**
+- Consumes: `postsApi.remove` (Task 3)
+- Produces: `useDeletePost(slug): UseMutationResult`
+
+- [ ] **Step 1: Add `useDeletePost`**
+
+Legacy bug being fixed here (spec §14 correctness item): a failed delete must not remove the post from the
+UI. Using `invalidateQueries` rather than an optimistic removal means a failed request leaves the post
+visibly present, because nothing was removed from the cache until the server confirmed it.
+
+```ts
+// apps/client/src/hooks/use-posts.ts — append
+export function useDeletePost() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (slug: string) => postsApi.remove(slug),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.list }),
+  })
+}
+```
+
+- [ ] **Step 2: Wire the delete button into `PostPage`**
+
+```tsx
+// apps/client/src/pages/PostPage.tsx — inside the isOwner block, alongside the Edit link
+import { useDeletePost } from '../hooks/use-posts.js' // add to existing imports
+import { useNavigate } from 'react-router' // add to existing import
+import { Button } from '../components/ui/button.js'
+
+// inside the component, alongside `me`/`isOwner`:
+const deletePost = useDeletePost()
+const navigate = useNavigate()
+
+// inside the isOwner block:
+{
+  isOwner && (
+    <>
+      <Link to={`/blog/${post.slug}/edit`} className="text-sm underline">
+        Edit
+      </Link>
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={() =>
+          deletePost.mutate(post.slug, {
+            onSuccess: () => navigate('/'),
+            onError: () => toast.error('Could not delete the post.'),
+          })
+        }
+      >
+        Delete
+      </Button>
+    </>
+  )
+}
+```
+
+- [ ] **Step 3: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run build`
+
+```bash
+git add apps/client/src/hooks/use-posts.ts apps/client/src/pages/PostPage.tsx
+git commit -m "feat(client): delete post — invalidate rather than optimistically remove"
+```
+
+---
+
+## Task 10: Likes with optimistic UI
+
+**Files:**
+- Create: `apps/client/src/hooks/use-likes.ts`
+- Create: `apps/client/src/components/patterns/LikeButton.tsx`
+- Modify: `apps/client/src/pages/PostPage.tsx` (use the real `LikeButton`)
+- Test: `apps/client/src/hooks/use-likes.test.tsx`
+
+**Interfaces:**
+- Consumes: `postsApi.like/unlike` (Task 3)
+- Produces: `useLikePost(slug): UseMutationResult` — optimistically increments `likeCount` in the
+  `queryKeys.posts.detail(slug)` cache via `onMutate`, rolls back via `onError`'s returned context, and
+  reconciles with the server via `onSettled`'s invalidation (spec §9: "the optimistic UI... demonstrates the
+  failure path, not just the happy path")
+
+- [ ] **Step 1: Write the failing test for the optimistic update and its rollback**
+
+```tsx
+// apps/client/src/hooks/use-likes.test.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useLikePost } from './use-likes.js'
+import { queryKeys } from '../lib/query-client.js'
+import type { Post } from '../api/posts.js'
+
+const post: Post = {
+  id: '1',
+  title: 't',
+  slug: 's',
+  body: 'b',
+  premium: false,
+  gated: false,
+  author: { id: 'u1', username: 'demo' },
+  tags: [],
+  likeCount: 2,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(queryKeys.posts.detail('s'), post)
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return { client, wrapper }
+}
+
+describe('useLikePost', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('increments likeCount immediately, before the request resolves', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {}))) // never resolves
+    const { client, wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLikePost('s'), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(client.getQueryData<Post>(queryKeys.posts.detail('s'))?.likeCount).toBe(3))
+  })
+
+  it('rolls back likeCount if the request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{"error":{"message":"nope"}}', { status: 500 })))
+    const { client, wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLikePost('s'), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(client.getQueryData<Post>(queryKeys.posts.detail('s'))?.likeCount).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/hooks/use-likes.test.tsx`
+Expected: FAIL — `./use-likes.js` does not exist.
+
+- [ ] **Step 3: Implement `useLikePost`**
+
+```ts
+// apps/client/src/hooks/use-likes.ts
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { postsApi } from '../api/posts.js'
+import { queryKeys } from '../lib/query-client.js'
+import type { Post } from '../api/posts.js'
+
+export function useLikePost(slug: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => postsApi.like(slug),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.posts.detail(slug) })
+      const previous = queryClient.getQueryData<Post>(queryKeys.posts.detail(slug))
+      if (previous) {
+        queryClient.setQueryData<Post>(queryKeys.posts.detail(slug), {
+          ...previous,
+          likeCount: previous.likeCount + 1,
+        })
+      }
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(queryKeys.posts.detail(slug), context.previous)
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.detail(slug) }),
+  })
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/hooks/use-likes.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Implement `LikeButton` and wire it into `PostPage`**
+
+```tsx
+// apps/client/src/components/patterns/LikeButton.tsx
+import { Heart } from 'lucide-react'
+import { useLikePost } from '../../hooks/use-likes.js'
+import { Button } from '../ui/button.js'
+
+export function LikeButton({ slug, likeCount }: { slug: string; likeCount: number }) {
+  const like = useLikePost(slug)
+  return (
+    <Button variant="outline" size="sm" onClick={() => like.mutate()} disabled={like.isPending}>
+      <Heart className="mr-1 size-4" /> {likeCount}
+    </Button>
+  )
+}
+```
+
+In `PostPage.tsx`, drop the `liked={false}` prop from Task 7's `LikeButton` usage (it was a placeholder for
+a prop this component never ends up needing — `PostDto` has no per-viewer "did I like this" field yet, so
+the button always shows the current count and lets the mutation run; a future phase can add a `likedByMe`
+flag to `PostDto` if that UX is wanted).
+
+- [ ] **Step 6: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run build && npm run test`
+
+```bash
+git add apps/client/src/hooks/use-likes.ts apps/client/src/hooks/use-likes.test.tsx apps/client/src/components/patterns/LikeButton.tsx apps/client/src/pages/PostPage.tsx
+git commit -m "feat(client): likes with optimistic UI and rollback on failure"
+```
+
+---
+
+## Task 11: Docker/Compose — client dev container + prod build baked into the API image
+
+**Files:**
+- Modify: `apps/api/Dockerfile` (`builder`/`runner` stages)
+- Modify: `compose.yaml` (new `client` service)
+- Modify: `compose.e2e.yaml`, `render.yaml` (`CLIENT_DIST`)
+
+**Interfaces:**
+- Consumes: `apps/client`'s build output (Task 1)
+- Produces: `docker compose watch` now serves the client on `:5173` proxying to `api`; the `runner` image
+  serves the built SPA from `apps/api` alone, no separate client container in prod (spec §11)
+
+- [ ] **Step 1: Update `apps/api/Dockerfile`'s `deps`/`builder`/`runner` stages**
+
+The `deps` stage's `COPY package.json` lines need the client's manifest too, so `npm ci` installs it; the
+`builder` stage needs to build the client as well as the API; `runner` needs the client's `dist` alongside
+the API's, at the path `CLIENT_DIST` will point to.
+
+```dockerfile
+# apps/api/Dockerfile — diff against the existing file
+
+# In the `deps` stage, add the client manifest next to the existing COPY lines:
+COPY apps/client/package.json ./apps/client/
+
+# In the `builder` stage, build both workspaces (was: only @blog/api):
+RUN npm run build --workspace=@blog/api --workspace=@blog/client
+
+# In the `prod-deps` stage, also add:
+COPY apps/client/package.json ./apps/client/
+
+# In the `runner` stage, after the existing api dist COPY, add:
+COPY --from=builder --chown=api:nodejs /app/apps/client/dist ./apps/client/dist
+# CLIENT_DIST is relative to the WORKDIR (/app), matching this path.
+ENV CLIENT_DIST=apps/client/dist
+```
+
+- [ ] **Step 2: Add the `client` dev service to `compose.yaml`**
+
+```yaml
+# compose.yaml — add alongside the existing `api` service
+  client:
+    build:
+      context: .
+      dockerfile: apps/client/Dockerfile.dev
+    ports: ['5173:5173']
+    environment:
+      VITE_API_PROXY_TARGET: http://api:3000
+    depends_on: [api]
+    develop:
+      watch:
+        - action: sync
+          path: ./apps/client
+          target: /app/apps/client
+          ignore: [node_modules/, dist/]
+```
+
+```dockerfile
+# apps/client/Dockerfile.dev — a minimal dev-only image (no multi-stage prod
+# target here; the prod bundle is built as part of apps/api's Dockerfile instead)
+# syntax=docker/dockerfile:1
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY packages/shared/package.json ./packages/shared/
+COPY apps/client/package.json ./apps/client/
+RUN --mount=type=secret,id=extra-ca,target=/tmp/extra-ca.pem \
+    --mount=type=cache,target=/root/.npm \
+    if [ -s /tmp/extra-ca.pem ]; then export NODE_EXTRA_CA_CERTS=/tmp/extra-ca.pem; fi \
+    && npm ci
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--workspace=@blog/client", "--", "--host"]
+```
+
+`--host` is required so Vite listens on `0.0.0.0` inside the container — without it, `localhost:5173` from
+the host machine can't reach the dev server bound only to the container's loopback interface.
+
+- [ ] **Step 3: Point `compose.e2e.yaml`'s `api` service at the built client**
+
+```yaml
+# compose.e2e.yaml — add to the api service's `environment:` block
+      CLIENT_DIST: apps/client/dist
+```
+
+(This is already the `ENV` default baked into the `runner` image from Step 1 — setting it explicitly here
+too is redundant but harmless; keep it for clarity/consistency with how every other env var in this file is
+explicit rather than relying on an image default.)
+
+- [ ] **Step 4: Add `CLIENT_DIST` to `render.yaml`**
+
+```yaml
+# render.yaml — api service's envVars, alongside the existing entries
+      - key: CLIENT_DIST
+        value: apps/client/dist
+```
+
+- [ ] **Step 5: Verify the dev stack**
+
+Run: `docker compose up -d --build`
+Then: open `http://localhost:5173` — confirm the blog feed loads (proxied through to the `api` container).
+
+Run: `docker compose -f compose.e2e.yaml up --build -d --wait`
+Then: `curl -s localhost:3000/` — expect the built `index.html`, not a 404 (proves the SPA catch-all now has
+a real build to serve, not just the P1 fixture).
+Tear down: `docker compose down -v` / `docker compose -f compose.e2e.yaml down -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/Dockerfile apps/client/Dockerfile.dev compose.yaml compose.e2e.yaml render.yaml
+git commit -m "build: bake the client build into the api image; add a client dev container"
+```
+
+---
+
+## Task 12: Playwright E2E
+
+**Files:**
+- Create: `playwright.config.ts`, `e2e/auth-and-posts.spec.ts`, `e2e/gating.spec.ts`
+- Modify: root `package.json` (`@playwright/test` devDependency)
+- Modify: CI workflow(s) — the e2e-smoke job already runs `compose.e2e.yaml`; add a Playwright step after
+  the health check
+
+**Interfaces:**
+- Consumes: `compose.e2e.yaml`'s stack (Task 11), the seeded demo account (`apps/api/src/scripts/seed.ts`,
+  P1 Task 13)
+
+- [ ] **Step 1: Add the dependency and config**
+
+```bash
+npm install -D @playwright/test --workspace=false
+```
+
+(installed at the root, since `test:e2e` is already a root script)
+
+```ts
+// playwright.config.ts
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  use: { baseURL: 'http://localhost:3000' },
+  webServer: {
+    command: 'docker compose -f compose.e2e.yaml up --build --wait',
+    url: 'http://localhost:3000/api/v1/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})
+```
+
+- [ ] **Step 2: Write the signup → post → like → logout flow**
+
+```ts
+// e2e/auth-and-posts.spec.ts
+import { expect, test } from '@playwright/test'
+
+test('signup, create a post, like it, then log out', async ({ page }) => {
+  const username = `e2e-${Date.now()}`
+
+  await page.goto('/signup')
+  await page.getByLabel('Username').fill(username)
+  await page.getByLabel('Email').fill(`${username}@example.com`)
+  await page.getByLabel('Password').fill('a-valid-password')
+  await page.getByRole('button', { name: 'Sign up' }).click()
+  await expect(page).toHaveURL('/')
+
+  await page.getByText('New post').click()
+  await page.getByLabel('title').fill('An E2E post')
+  await page.getByLabel('body').fill('Written by Playwright.')
+  await page.getByRole('button', { name: 'Save' }).click()
+  await expect(page).toHaveURL(/\/blog\/an-e2e-post/)
+
+  await page.getByRole('button', { name: /^0/ }).click() // the like button, starts at 0
+  await expect(page.getByRole('button', { name: /^1/ })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Log out' }).click()
+  await expect(page.getByText('Log in')).toBeVisible()
+})
+```
+
+- [ ] **Step 3: Write the gating test — assert on raw response bytes, not the DOM**
+
+This is the same assertion P1's `posts.test.ts` makes over Supertest, repeated here at the browser/network
+level per spec §10 ("asserting on raw response bytes, not the DOM").
+
+```ts
+// e2e/gating.spec.ts
+import { expect, test } from '@playwright/test'
+
+test('an anonymous reader never receives a premium post\'s full body over the wire', async ({ page, request }) => {
+  // Seeded by apps/api/src/scripts/seed.ts — a known premium post slug.
+  const res = await request.get('/api/v1/posts/gating-content-at-the-serialization-boundary')
+  const body = await res.json()
+  expect(body.gated).toBe(true)
+  expect(body.body).not.toContain('the full paragraph that only a signed-in reader should see')
+
+  await page.goto('/blog/gating-content-at-the-serialization-boundary')
+  await expect(page.getByText('Sign in to read the rest of this post.')).toBeVisible()
+})
+```
+
+> **Depends on seed data:** this test assumes the seeded premium post's non-teaser paragraph contains the
+> literal string asserted against. Check `apps/api/src/scripts/seed.ts`'s actual post body when implementing
+> this step and adjust the string to match — do not invent a slug or sentence that doesn't exist in the seed.
+
+- [ ] **Step 4: Run locally and confirm both pass**
+
+Run: `npm run test:e2e`
+Expected: 2 passed. Playwright's `webServer` config brings the e2e Compose stack up automatically.
+
+- [ ] **Step 5: Add the Playwright step to CI**
+
+In `.github/workflows/pr-to-staging.yml` (P1 Task 14), after the existing e2e-smoke health-check step, add:
+
+```yaml
+      - name: Playwright E2E
+        run: npx playwright install --with-deps chromium && npm run test:e2e
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add playwright.config.ts e2e package.json package-lock.json .github/workflows/pr-to-staging.yml
+git commit -m "test(e2e): Playwright coverage for auth+posts+likes and the gating boundary"
+```
+
+---
+
+## Task 13: Final gate and docs
+
+**Files:**
+- Modify: `README.md` (client quick start, replacing the "no UI yet" note from P1)
+- Modify: `docs/architecture/deployment-architecture.md` (client row: 📋 → 🚧/✅ as appropriate)
+- Modify: spec §14 (tick the P2-scoped items that now have coverage)
+
+**Interfaces:**
+- Consumes: everything above
+- Produces: a P2 that is complete, tested, and ready for review
+
+- [ ] **Step 1: Update the README**
+
+Replace the P1-era "There is no UI yet — that is P2" line with a quick-start note that `npm run dev` now
+also serves the client on `:5173`, and drop the curl-only demo section down to "the API, if you want to
+bypass the UI" framing rather than the primary path.
+
+- [ ] **Step 2: Update `docs/architecture/deployment-architecture.md`**
+
+`apps/client` row: `📋 planned` → `🚧 built, baked into the apps/api image` (not a separate Render service —
+this was always the design, spec §11). Update "Last verified against reality" to the date this lands.
+
+- [ ] **Step 3: Tick the P2-scoped spec §14 items**
+
+From the list P1 left as **P2 (client)**:
+- A failed delete does not remove the post from the UI → `use-posts.ts`'s `useDeletePost` (Task 9,
+  invalidate-not-optimistic)
+- The loading state actually renders → `BlogFeedPage`'s `isPending` branch (Task 6) / `PostPage`'s (Task 7)
+- Logout is not fired before a dependent request resolves → N/A in this design (logout has no dependent
+  request racing it); note this explicitly rather than force-fitting a test to a bug shape that doesn't
+  exist in the new architecture
+- Password confirmation validated before the request → **not built** in this plan (no signup confirm-password
+  field was in scope — note as a gap, not silently dropped)
+
+- [ ] **Step 4: Final full gate**
+
+Run: `npm ci && npm run typecheck && npm run lint && npm run build && npm run test && npm run test:e2e`
+Expected: all pass, no skips.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/
+git commit -m "docs: P2 client quick start, architecture status, spec checklist"
+```
+
+- [ ] **Step 6: STOP — do not push, merge, or deploy**
+
+Report to the user: P2 is complete on `dev/react-client`, N commits, full gate green including Playwright.
+**Ask** whether to push and open a PR into `staging`. Do not merge to `master` or deploy without explicit
+per-time approval, same as every prior phase.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage.** §3 client layout → Tasks 1, 4; §4 component tiers → Tasks 2 (`ui/`), 6/8 (`patterns/`),
+4 (`layouts/`), 8 (`AutoForm`); §6 gating → Task 7 (read-only, server already decided); §9 data flow/routes →
+Tasks 4, 6–10; §10 testing → Vitest throughout, Playwright in Task 12; §11 environments/proxy → Tasks 1, 11.
+
+**Known gap, stated rather than silently dropped:** password-confirmation-before-request (spec §14, a P2
+item) has no corresponding task — the signup form in Task 5 has no confirm-password field. If wanted, it's
+a small addition to `SignupPage` plus a Zod `.refine()` on a client-only schema (the API schema doesn't need
+a confirm field — it's a UX check, not a security one).
+
+**One deliberate simplification vs. the spec:** `PostDto` has no per-viewer "did I already like this"
+field, so `LikeButton` always shows the raw count and lets the mutation fire regardless of prior state. The
+API's like/unlike are idempotent either way, so this cannot corrupt the count — it just means a user could
+click "like" on a post they already liked and get a no-op 200 rather than a disabled button. Documented here
+so it reads as a choice, not an oversight, if a reviewer asks "where's the liked-by-me indicator."

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,4 +14,14 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ['apps/client/**/*.{ts,tsx}'],
+    rules: {
+      // React 19 doesn't need `import React` for JSX; unused-import churn is noise.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+    },
+  },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,13 +43,430 @@
         "tsx": "^4.23.1"
       }
     },
+    "apps/client": {
+      "name": "@blog/client",
+      "version": "0.0.0",
+      "dependencies": {
+        "@blog/shared": "*",
+        "@tanstack/react-query": "^5.101.4",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.25.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-router": "^8.3.0",
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.6.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.3.3",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.2.0",
+        "@vitejs/plugin-react": "^6.0.4",
+        "jsdom": "^29.1.1",
+        "tailwindcss": "^4.3.3",
+        "vite": "^8.1.5"
+      }
+    },
+    "apps/client/node_modules/@vitejs/plugin-react": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "apps/client/node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@blog/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@blog/client": {
+      "resolved": "apps/client",
       "link": true
     },
     "node_modules/@blog/shared": {
       "resolved": "packages/shared",
       "link": true
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -637,6 +1054,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -714,6 +1149,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -751,6 +1197,25 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -762,6 +1227,16 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -845,6 +1320,270 @@
       "peerDependencies": {
         "@redis/client": "^6.1.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -1196,6 +1935,663 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/bcryptjs": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
@@ -1317,6 +2713,26 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -1836,6 +3252,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1865,6 +3292,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -2012,6 +3449,16 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -2217,6 +3664,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -2354,6 +3822,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -2385,6 +3859,86 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2401,6 +3955,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2438,6 +3999,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -2448,6 +4029,14 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2476,6 +4065,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3220,6 +4836,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3280,6 +4903,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -3369,6 +5005,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3407,6 +5053,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3420,6 +5073,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3429,6 +5092,14 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -3451,6 +5122,85 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -3505,6 +5255,267 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -3567,6 +5578,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3611,6 +5652,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -3685,6 +5733,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4096,6 +6154,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4359,6 +6430,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4434,6 +6535,56 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-router": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -4446,6 +6597,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/redis": {
@@ -4464,6 +6629,16 @@
         "node": ">= 20.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4472,6 +6647,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rollup": {
@@ -4559,6 +6768,25 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4733,6 +6961,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -4795,6 +7033,19 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4880,6 +7131,44 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar-stream": {
@@ -4999,6 +7288,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -5006,6 +7315,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -6157,6 +8479,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6341,6 +8673,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6348,6 +8693,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
@@ -6411,6 +8766,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yauzl": {
       "version": "3.4.0",


### PR DESCRIPTION
## Summary
- Vite + React 19 + TypeScript scaffold for `apps/client`, wired into the npm workspace
- Tailwind v4 (CSS-first config, no `tailwind.config.js`/PostCSS) with a custom brand palette
- Dev proxy (`/api` → the API) so the client is same-origin in dev exactly as in prod
- Full P2 implementation plan (13 tasks) checked in at `docs/superpowers/plans/2026-07-22-p2-react-client.md`

## Test plan
- [x] `npm run typecheck` — all workspaces pass
- [x] `npm run lint` — clean
- [x] `npm run build` — `apps/client/dist/index.html` produced
- [x] `npm run test` — 159/159 passing