### PR TITLE
P2 Task 4: Query client, router, page shell

### DIFF
--- a/apps/client/src/components/layouts/PageShell.tsx
+++ b/apps/client/src/components/layouts/PageShell.tsx
@@ -1,0 +1,47 @@
+import { Link, useNavigate } from 'react-router'
+import { useMe } from '../../hooks/use-auth.js'
+
+export function PageShell({ children }: { children: React.ReactNode }) {
+  const { data: me } = useMe()
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex min-h-screen flex-col bg-[var(--background)] text-[var(--foreground)]">
+      <header className="border-b border-[var(--border)] py-4">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4">
+          <Link to="/" className="text-lg font-semibold">
+            Blog
+          </Link>
+          <nav className="flex gap-4">
+            {me ? (
+              <>
+                <span className="text-sm">Welcome, {me.username}</span>
+                <Link to="/blog/new" className="text-sm hover:underline">
+                  New Post
+                </Link>
+                <button
+                  onClick={() => navigate('/logout')}
+                  className="text-sm hover:underline"
+                >
+                  Logout
+                </button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" className="text-sm hover:underline">
+                  Login
+                </Link>
+                <Link to="/signup" className="text-sm hover:underline">
+                  Sign up
+                </Link>
+              </>
+            )}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-8">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/apps/client/src/hooks/use-auth.ts
+++ b/apps/client/src/hooks/use-auth.ts
@@ -1,0 +1,6 @@
+import type { User } from '../api/auth.js'
+
+// Temporary stub - will be replaced by Task 5
+export function useMe() {
+  return { data: null as User | null }
+}

--- a/apps/client/src/lib/query-client.ts
+++ b/apps/client/src/lib/query-client.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1, staleTime: 5 * 60 * 1000 },
+    mutations: { retry: 1 },
+  },
+})
+
+export const queryKeys = {
+  me: ['auth', 'me'] as const,
+  posts: {
+    list: ['posts'] as const,
+    detail: (slug: string) => ['posts', slug] as const,
+    likes: {
+      detail: (slug: string) => ['posts', slug, 'likes'] as const,
+    },
+  },
+  users: {
+    detail: (id: string) => ['users', id] as const,
+  },
+}

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,9 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from 'react-router/dom'
+import { Toaster } from 'sonner'
+import { queryClient } from './lib/query-client.js'
+import { router } from './routes.js'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <h1>Blog-Chat</h1>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <Toaster position="top-center" />
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/client/src/pages/BlogFeedPage.tsx
+++ b/apps/client/src/pages/BlogFeedPage.tsx
@@ -1,0 +1,1 @@
+export function BlogFeedPage() { return <p>Feed</p> }

--- a/apps/client/src/pages/EditPostPage.tsx
+++ b/apps/client/src/pages/EditPostPage.tsx
@@ -1,0 +1,1 @@
+export function EditPostPage() { return <p>Edit</p> }

--- a/apps/client/src/pages/LoginPage.tsx
+++ b/apps/client/src/pages/LoginPage.tsx
@@ -1,0 +1,1 @@
+export function LoginPage() { return <p>Login</p> }

--- a/apps/client/src/pages/NewPostPage.tsx
+++ b/apps/client/src/pages/NewPostPage.tsx
@@ -1,0 +1,1 @@
+export function NewPostPage() { return <p>New</p> }

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -1,0 +1,1 @@
+export function PostPage() { return <p>Post</p> }

--- a/apps/client/src/pages/SignupPage.tsx
+++ b/apps/client/src/pages/SignupPage.tsx
@@ -1,0 +1,1 @@
+export function SignupPage() { return <p>Signup</p> }

--- a/apps/client/src/routes.tsx
+++ b/apps/client/src/routes.tsx
@@ -1,0 +1,26 @@
+import { createBrowserRouter, Outlet } from 'react-router'
+import { PageShell } from './components/layouts/PageShell.js'
+import { BlogFeedPage } from './pages/BlogFeedPage.js'
+import { PostPage } from './pages/PostPage.js'
+import { NewPostPage } from './pages/NewPostPage.js'
+import { EditPostPage } from './pages/EditPostPage.js'
+import { LoginPage } from './pages/LoginPage.js'
+import { SignupPage } from './pages/SignupPage.js'
+
+export const router = createBrowserRouter([
+  {
+    element: (
+      <PageShell>
+        <Outlet />
+      </PageShell>
+    ),
+    children: [
+      { path: '/', element: <BlogFeedPage /> },
+      { path: '/blog/new', element: <NewPostPage /> },
+      { path: '/blog/:slug', element: <PostPage /> },
+      { path: '/blog/:slug/edit', element: <EditPostPage /> },
+      { path: '/login', element: <LoginPage /> },
+      { path: '/signup', element: <SignupPage /> },
+    ],
+  },
+])


### PR DESCRIPTION
## Summary
Root-level wiring: TanStack Query setup, React Router v8 with all 6 routes, page shell with navigation, and page stubs for future tasks.

- `queryClient` with retry/staleTime defaults
- `queryKeys` constants for type-safe cache invalidation
- Router with 6 routes; all nested under `<PageShell>` layout
- Temporary `useMe` stub (replaced by Task 5's real implementation)
- 6 one-line page stubs (real implementations in Tasks 6-9)

## Test plan
- [x] typecheck, lint, build, test all pass (166 tests)
- [x] Vite and React Router wired correctly
- [x] QueryClientProvider + RouterProvider render without errors