### PR TITLE
Gate content per reader, drop the premium flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,15 @@ the SPA is same-origin — if the client ever moves to its own origin, CSRF toke
 `helmet → json → session → routers → 404 → error handler`. The legacy app registered `cors()` *after* its
 routers, so it never applied. The error handler is always last.
 
-**Content gating lives in the service layer, not the UI.** `postService.getPost(slug, session)` omits the
-full `body` from its return value when a post is premium and there's no session — the API never serializes
-it, so there is nothing to find in DevTools. Gating in a component would be cosmetic. See spec §6.
+**Content gating lives in the service layer, not the UI.** `postService.getBySlug(slug, viewerId)` omits the
+full `body` from its return value when there's no session — the API never serializes it, so there is nothing
+to find in DevTools. Gating in a component would be cosmetic. See spec §6.
+
+The wall is **per-reader, not per-post**: there is no `premium` flag and no paid tier. Every post is teased
+for anonymous readers and full for any signed-in one, so signing up (free) is what unlocks content. The
+feed (`postService.list`) is teasers for *everyone* — a list endpoint never ships full bodies — which is why
+`PostDto.gated` means "this reader is locked out", **not** "this body is truncated". Those two are separate
+arguments to `toDto` on purpose; collapsing them reports every feed item as locked.
 
 ## Project constraints
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The API is on http://localhost:3000/api/v1. There is no UI yet — that is P2.
 ## Try the authorization model with curl
 
 ```bash
-# Anonymous: the premium post's body is a teaser. The full text is not in the
-# response at all — the API never serialized it.
+# Anonymous: the body is a teaser. The full text is not in the response at
+# all — the API never serialized it.
 curl -s localhost:3000/api/v1/posts/gating-content-at-the-serialization-boundary
 
 # Signed in: the full body.

--- a/apps/client/src/api/posts.ts
+++ b/apps/client/src/api/posts.ts
@@ -7,7 +7,7 @@ export type Post = {
   title: string
   slug: string
   body: string
-  premium: boolean
+  /** Server's verdict: this reader is anonymous, so `body` is only the teaser. */
   gated: boolean
   author: { id: string; username: string }
   tags: string[]

--- a/apps/server/src/lib/services/post.test.ts
+++ b/apps/server/src/lib/services/post.test.ts
@@ -17,11 +17,11 @@ beforeEach(async () => {
   authorId = author._id.toString()
 })
 
-const create = (over: Partial<{ title: string; body: string; premium: boolean; tags: string[] }> = {}) =>
-  postService.create(
-    { title: 'A Fine Title', body: LONG_BODY, premium: false, tags: [], ...over },
-    authorId,
-  )
+const create = (over: Partial<{ title: string; body: string; tags: string[] }> = {}) =>
+  postService.create({ title: 'A Fine Title', body: LONG_BODY, tags: [], ...over }, authorId)
+
+const signUpReader = () =>
+  UserModel.create({ username: 'reader', email: 'r@example.com', password: 'x' })
 
 describe('postService.create', () => {
   it('derives the slug from the title', async () => {
@@ -45,15 +45,10 @@ describe('postService.create', () => {
 
 describe('postService.list', () => {
   it('returns teaser bodies only — a list endpoint never ships full bodies', async () => {
-    await create({ premium: false })
+    await create()
     const [post] = await postService.list()
     expect(post!.body).toBe('Para one.\n\nPara two.')
     expect(post!.body).not.toContain('Para three')
-  })
-
-  it('teases free posts too — the feed is a feed, not a paywall probe', async () => {
-    await create({ premium: false })
-    expect((await postService.list())[0]!.body).not.toContain('Para three')
   })
 
   it('includes the like count', async () => {
@@ -66,18 +61,33 @@ describe('postService.list', () => {
     await create()
     expect((await postService.list())[0]!.author.username).toBe('author')
   })
+
+  // `gated` answers "is this reader locked out of the full body", NOT "is this
+  // body a teaser" — the feed teases everyone, so the latter reading would flag
+  // signed-in readers too and the UI could not use it to prompt for a login.
+  it('marks every post gated for an anonymous reader', async () => {
+    await create()
+    expect((await postService.list())[0]!.gated).toBe(true)
+  })
+
+  it('marks nothing gated for a signed-in reader', async () => {
+    await create()
+    const reader = await signUpReader()
+    expect((await postService.list(reader._id.toString()))[0]!.gated).toBe(false)
+  })
+
+  it('still ships ONLY the teaser to a signed-in reader — ungating is not a licence to bulk-send bodies', async () => {
+    await create()
+    const reader = await signUpReader()
+    const [post] = await postService.list(reader._id.toString())
+    expect(post!.body).toBe('Para one.\n\nPara two.')
+    expect(JSON.stringify(post)).not.toContain('Para three')
+  })
 })
 
 describe('postService.getBySlug — THE gating rule (spec §6)', () => {
-  it('returns the full body of a FREE post to an anonymous reader', async () => {
-    const { slug } = await create({ premium: false })
-    const post = await postService.getBySlug(slug, undefined)
-    expect(post.body).toBe(LONG_BODY)
-    expect(post.gated).toBe(false)
-  })
-
-  it('OMITS the full body of a PREMIUM post for an anonymous reader', async () => {
-    const { slug } = await create({ premium: true })
+  it('OMITS the full body for an anonymous reader', async () => {
+    const { slug } = await create()
     const post = await postService.getBySlug(slug, undefined)
     expect(post.body).toBe('Para one.\n\nPara two.')
     expect(post.gated).toBe(true)
@@ -85,14 +95,14 @@ describe('postService.getBySlug — THE gating rule (spec §6)', () => {
 
   it('leaves the gated bytes nowhere in the serialized object', async () => {
     // The real assertion: not "hidden", ABSENT. Serialize the whole DTO and grep.
-    const { slug } = await create({ premium: true })
+    const { slug } = await create()
     const post = await postService.getBySlug(slug, undefined)
     expect(JSON.stringify(post)).not.toContain('Para three')
   })
 
-  it('returns the full body of a PREMIUM post to a signed-in reader', async () => {
-    const { slug } = await create({ premium: true })
-    const reader = await UserModel.create({ username: 'reader', email: 'r@example.com', password: 'x' })
+  it('returns the full body to a signed-in reader', async () => {
+    const { slug } = await create()
+    const reader = await signUpReader()
     const post = await postService.getBySlug(slug, reader._id.toString())
     expect(post.body).toBe(LONG_BODY)
     expect(post.gated).toBe(false)

--- a/apps/server/src/lib/services/post.ts
+++ b/apps/server/src/lib/services/post.ts
@@ -16,8 +16,6 @@ export type PostDto = {
   title: string
   slug: string
   body: string
-  premium: boolean
-  /** true when `body` holds only the teaser because the reader is not signed in. */
   gated: boolean
   author: PostAuthor
   tags: string[]
@@ -40,16 +38,23 @@ function isPopulated(author: unknown): author is PopulatedAuthor {
  * `full: false` means the full body is never copied into the returned object,
  * so it cannot leak: there is nothing to find in DevTools because the API never
  * put it there. Gating in a route handler or a component would be cosmetic.
+ *
+ * `full` and `gated` are deliberately independent. Collapsing them (`gated:
+ * !full`) is only correct for a single-post read; the feed always teases, so
+ * deriving one from the other there would report every post as locked.
  */
-function toDto(post: HydratedDocument<Post>, likeCount: number, full: boolean): PostDto {
+function toDto(
+  post: HydratedDocument<Post>,
+  likeCount: number,
+  { full, gated }: { full: boolean; gated: boolean },
+): PostDto {
   const author = post.author
   return {
     id: post._id.toString(),
     title: post.title,
     slug: post.slug,
     body: full ? post.body : deriveTeaser(post.body),
-    premium: post.premium,
-    gated: !full,
+    gated,
     author: isPopulated(author)
       ? { id: author._id.toString(), username: author.username }
       : { id: String(author), username: '' },
@@ -80,20 +85,29 @@ async function countLikes(postId: Types.ObjectId): Promise<number> {
 }
 
 export const postService = {
-  /** The feed. Teaser bodies ALWAYS — a list endpoint never ships full bodies. */
-  async list(): Promise<PostDto[]> {
+  /**
+   * The feed. Teaser bodies ALWAYS — a list endpoint never ships full bodies,
+   * signed in or not. `viewerId` therefore changes only `gated`, i.e. whether
+   * the card invites the reader to sign in, never how much text is sent.
+   */
+  async list(viewerId?: string): Promise<PostDto[]> {
     const posts = await PostModel.find().sort({ createdAt: -1 }).populate('author', 'username')
-    return Promise.all(posts.map(async (p) => toDto(p, await countLikes(p._id), false)))
+    return Promise.all(
+      posts.map(async (p) =>
+        toDto(p, await countLikes(p._id), {
+          full: false,
+          gated: !viewerId,
+        }),
+      ),
+    )
   },
 
   async getBySlug(slug: string, viewerId?: string): Promise<PostDto> {
     const post = await PostModel.findOne({ slug }).populate('author', 'username')
     if (!post) throw new NotFoundError('Post not found.')
 
-    // The gating rule, stated once: a premium post shows its full body only to
-    // a signed-in reader. Everything else about the post stays public.
-    const full = !post.premium || Boolean(viewerId)
-    return toDto(post, await countLikes(post._id), full)
+    const full = Boolean(viewerId)
+    return toDto(post, await countLikes(post._id), { full, gated: !full })
   },
 
   async create(input: CreatePost, authorId: string): Promise<PostDto> {
@@ -105,7 +119,7 @@ export const postService = {
       author: new Types.ObjectId(authorId),
     })
     await post.populate('author', 'username')
-    return toDto(post, 0, true)
+    return toDto(post, 0, { full: true, gated: false })
   },
 
   async update(slug: string, input: UpdatePost): Promise<PostDto> {
@@ -117,13 +131,12 @@ export const postService = {
       post.slug = await uniqueSlug(input.title, post._id)
     }
     if (input.body !== undefined) post.body = input.body
-    if (input.premium !== undefined) post.premium = input.premium
     if (input.tags !== undefined) post.tags = input.tags
 
     await post.save()
     await post.populate('author', 'username')
     // The owner is the only caller who reaches here, so the full body is correct.
-    return toDto(post, await countLikes(post._id), true)
+    return toDto(post, await countLikes(post._id), { full: true, gated: false })
   },
 
   async remove(slug: string): Promise<void> {

--- a/apps/server/src/middleware/validate.test.ts
+++ b/apps/server/src/middleware/validate.test.ts
@@ -6,7 +6,7 @@ import { validate } from './validate.js'
 
 const Schema = z.object({
   title: z.string().min(3, 'Title must be at least 3 characters'),
-  premium: z.coerce.boolean().default(false),
+  draft: z.coerce.boolean().default(false),
 })
 
 function ctx(body: unknown) {
@@ -22,7 +22,7 @@ describe('validate', () => {
     const { req, res, next } = ctx({ title: 'A Good Title' })
     validate(Schema)(req, res, next)
     expect(next).toHaveBeenCalledWith()
-    expect(req.body).toEqual({ title: 'A Good Title', premium: false })
+    expect(req.body).toEqual({ title: 'A Good Title', draft: false })
   })
 
   it('passes a ValidationError carrying Zod field errors', () => {

--- a/apps/server/src/models/post.ts
+++ b/apps/server/src/models/post.ts
@@ -7,7 +7,6 @@ const postSchema = new Schema(
     title: { type: String, required: true, trim: true, minlength: 3, maxlength: 120 },
     slug: { type: String, required: true, unique: true },
     body: { type: String, required: true, minlength: 1, maxlength: 50_000 },
-    premium: { type: Boolean, required: true, default: false },
     coverImage: { type: String },
     author: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
     tags: {

--- a/apps/server/src/routes/v1/posts.test.ts
+++ b/apps/server/src/routes/v1/posts.test.ts
@@ -26,6 +26,22 @@ describe('GET /api/v1/posts', () => {
     expect(res.status).toBe(200)
     expect(res.body[0].body).not.toContain('Para three')
   })
+
+  it('flags the feed gated for an anonymous reader and ungated for a signed-in one', async () => {
+    const a = app()
+    const author = await signedInAgent(a, 'author')
+    await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: BODY })
+
+    expect((await request(a).get('/api/v1/posts')).body[0].gated).toBe(true)
+
+    // The session cookie is the only difference — this is what proves the
+    // router actually forwards the viewer, not just that the service can.
+    const reader = await signedInAgent(a, 'reader')
+    const signedIn = await reader.get('/api/v1/posts')
+    expect(signedIn.body[0].gated).toBe(false)
+    // Ungated still does not mean unabridged: the feed is teasers for everyone.
+    expect(signedIn.text).not.toContain('Para three')
+  })
 })
 
 describe('POST /api/v1/posts', () => {
@@ -63,33 +79,26 @@ describe('POST /api/v1/posts', () => {
 })
 
 describe('GET /api/v1/posts/:slug — gating over real HTTP (spec §6, §14)', () => {
-  it('returns the full body of a free post to an anonymous reader', async () => {
+  it('leaves the gated bytes ABSENT from the RAW response for an anonymous reader', async () => {
     const a = app()
     const author = await signedInAgent(a, 'author')
-    await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: BODY, premium: false })
+    await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: BODY })
 
     const res = await request(a).get('/api/v1/posts/a-fine-title')
-    expect(res.body.body).toContain('Para three')
-    expect(res.body.gated).toBe(false)
-  })
-
-  it('leaves the gated bytes ABSENT from the RAW premium response for an anonymous reader', async () => {
-    const a = app()
-    const author = await signedInAgent(a, 'author')
-    await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: BODY, premium: true })
-
-    const res = await request(a).get('/api/v1/posts/a-fine-title')
+    // Still 200 with a real page — title, author and teaser are public. Only
+    // the rest of the body is withheld.
     expect(res.status).toBe(200)
+    expect(res.body.title).toBe('A Fine Title')
     expect(res.body.gated).toBe(true)
     // Assert on the raw payload, not the parsed field: the bytes must not be
     // anywhere in the response, under any key.
     expect(res.text).not.toContain('Para three')
   })
 
-  it('returns the full premium body to a signed-in reader', async () => {
+  it('returns the full body to a signed-in reader', async () => {
     const a = app()
     const author = await signedInAgent(a, 'author')
-    await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: BODY, premium: true })
+    await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: BODY })
     const reader = await signedInAgent(a, 'reader')
 
     const res = await reader.get('/api/v1/posts/a-fine-title')

--- a/apps/server/src/routes/v1/posts.ts
+++ b/apps/server/src/routes/v1/posts.ts
@@ -17,8 +17,8 @@ export const postsRouter = Router()
 const loadPostOwner = (req: Request<{ slug: string }>) =>
   postService.findBySlugForOwnerCheck(req.params.slug)
 
-postsRouter.get('/', async (_req, res) => {
-  res.json(await postService.list())
+postsRouter.get('/', async (req, res) => {
+  res.json(await postService.list(req.session?.userId))
 })
 
 postsRouter.post('/', requireAuth, validate(CreatePostSchema), async (req, res) => {
@@ -36,7 +36,7 @@ postsRouter.delete<{ slug: string }>('/:slug/likes', requireAuth, async (req, re
 
 postsRouter.get('/:slug', async (req, res) => {
   // The viewer id is passed to the service, which decides what to serialize.
-  // The handler does NOT branch on premium — gating belongs to one layer only.
+  // The handler does NOT branch on the session — gating belongs to one layer only.
   res.json(await postService.getBySlug(req.params.slug, req.session?.userId))
 })
 

--- a/apps/server/src/scripts/seed.ts
+++ b/apps/server/src/scripts/seed.ts
@@ -14,7 +14,6 @@ const DEMO_PASSWORD = 'demo-password-1234'
 const POSTS = [
   {
     title: 'Rebuilding a Five-Year-Old MERN App',
-    premium: false,
     tags: ['engineering', 'react'],
     body: [
       'This blog is a rebuild of a MERN app I wrote five years ago.',
@@ -24,7 +23,6 @@ const POSTS = [
   },
   {
     title: 'Why Identity Never Comes From The Request Body',
-    premium: false,
     tags: ['security'],
     body: [
       'The legacy app had an endpoint that took a user id and a new password, both from the request body, and applied them.',
@@ -34,11 +32,10 @@ const POSTS = [
   },
   {
     title: 'Gating Content At The Serialization Boundary',
-    premium: true,
     tags: ['engineering', 'security'],
     body: [
-      'A paywall implemented in a component is a suggestion. The body is still in the JSON, one DevTools tab away.',
-      'This post is premium, so if you are reading this paragraph you are signed in — the API never serialized it otherwise.',
+      'A registration wall implemented in a component is a suggestion. The body is still in the JSON, one DevTools tab away.',
+      'If you are reading this paragraph you are signed in — the API never serialized it otherwise.',
       'The rule lives in postService.getBySlug, which does not copy the body into its return value when the reader is anonymous. There is nothing to find in the response because it was never put there.',
     ].join('\n\n'),
   },
@@ -73,7 +70,7 @@ async function seed(): Promise<void> {
     })
     // One like from the reader, so likeCount is not uniformly zero in the demo.
     await LikeModel.create({ user: new mongoose.Types.ObjectId(reader.id), post: created._id })
-    console.log(`  ${created.slug}${post.premium ? ' (premium)' : ''}`)
+    console.log(`  ${created.slug}`)
   }
 
   await mongoose.disconnect()

--- a/docs/superpowers/plans/2026-07-22-p2-react-client.md
+++ b/docs/superpowers/plans/2026-07-22-p2-react-client.md
@@ -23,6 +23,14 @@ components/hooks (unit layer), Playwright for E2E (spec §10).
 
 **Branch:** `dev/react-client`, off `staging` (P1 merged).
 
+> **Amendment 2026-07-25 — the `premium` flag is gone (branch `dev/simplify-gating`).** Gating is now
+> *per-reader*, not per-post: every post is teased for anonymous readers and full for any signed-in one.
+> `Post` has no `premium` field, `CreatePostSchema` has none either, and there is no Premium badge.
+> Wherever a snippet below still shows `premium`, ignore that line — the rest of the snippet stands.
+> Affects Task 3's `Post` type, Task 6's `PostCard`, Task 8's `AutoForm` demo schema, Task 10's fixture,
+> and Task 12's E2E. `PostDto.gated` now means **"this reader is locked out"**, never "this body is
+> truncated" — the feed teases everyone, so those two came apart. See spec §6.
+
 ---
 
 ## Global Constraints
@@ -516,7 +524,7 @@ git commit -m "feat(client): ui primitives (Button, Input, Label, Textarea, Card
 - Produces:
   - `class ApiError extends Error { status: number; fields: Record<string, string[]> }`
   - `request<T>(path: string, init?: RequestInit): Promise<T>` — throws `ApiError` on a non-2xx response
-  - `type Post = { id: string; title: string; slug: string; body: string; premium: boolean; gated: boolean; author: { id: string; username: string }; tags: string[]; likeCount: number; coverImage?: string; createdAt: string; updatedAt: string }`
+  - `type Post = { id: string; title: string; slug: string; body: string; gated: boolean; author: { id: string; username: string }; tags: string[]; likeCount: number; coverImage?: string; createdAt: string; updatedAt: string }`
     (mirrors `apps/server/src/lib/services/post.ts`'s `PostDto`, with dates as ISO strings over JSON)
   - `authApi.signup/login/logout/me`, `postsApi.list/get/create/update/remove/like/unlike`,
     `usersApi.get/update/remove`
@@ -624,7 +632,6 @@ export type Post = {
   title: string
   slug: string
   body: string
-  premium: boolean
   gated: boolean
   author: PostAuthor
   tags: string[]
@@ -634,7 +641,7 @@ export type Post = {
   updatedAt: string
 }
 
-export type CreatePostInput = { title: string; body: string; premium?: boolean; tags?: string[] }
+export type CreatePostInput = { title: string; body: string; tags?: string[] }
 export type UpdatePostInput = Partial<CreatePostInput>
 
 export const postsApi = {
@@ -1151,7 +1158,6 @@ const basePost: Post = {
   title: 'Gating at the boundary',
   slug: 'gating-at-the-boundary',
   body: 'Full text here.',
-  premium: true,
   gated: true,
   author: { id: 'u1', username: 'demo' },
   tags: ['express'],
@@ -1161,13 +1167,12 @@ const basePost: Post = {
 }
 
 describe('PostCard', () => {
-  it('shows a premium badge and a sign-in prompt when gated', () => {
+  it('prompts an anonymous reader to sign in', () => {
     render(<PostCard post={basePost} />, { wrapper: MemoryRouter })
-    expect(screen.getByText(/premium/i)).toBeInTheDocument()
-    expect(screen.getByText(/sign in to read/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /sign in to read/i })).toHaveAttribute('href', '/login')
   })
 
-  it('does not show the sign-in prompt for a free or unlocked post', () => {
+  it('drops the prompt once the reader is signed in', () => {
     render(<PostCard post={{ ...basePost, gated: false }} />, { wrapper: MemoryRouter })
     expect(screen.queryByText(/sign in to read/i)).not.toBeInTheDocument()
   })
@@ -1193,11 +1198,15 @@ export function PostCard({ post }: { post: Post }) {
       <Link to={`/blog/${post.slug}`} className="text-lg font-semibold hover:underline">
         {post.title}
       </Link>
-      {post.premium && (
-        <span className="ml-2 rounded bg-[var(--muted)] px-2 py-0.5 text-xs">Premium</span>
-      )}
       <p className="mt-2 text-sm text-[var(--muted-foreground)]">{post.body}</p>
-      {post.gated && <p className="mt-2 text-sm text-[var(--primary)]">Sign in to read the full post</p>}
+      {post.gated && (
+        <p className="mt-2 text-sm">
+          <Link to="/login" className="text-[var(--primary)] hover:underline">
+            Sign in to read
+          </Link>{' '}
+          the full post.
+        </p>
+      )}
       <p className="mt-3 text-xs text-[var(--muted-foreground)]">
         by {post.author.username} · {post.likeCount} likes
       </p>
@@ -1381,7 +1390,7 @@ import { AutoForm } from './AutoForm.js'
 
 const schema = z.object({
   title: z.string().min(3, 'Title must be at least 3 characters'),
-  premium: z.coerce.boolean().default(false),
+  draft: z.coerce.boolean().default(false),
   tags: z.array(z.string()).default([]),
 })
 
@@ -1389,7 +1398,7 @@ describe('AutoForm', () => {
   it('renders one labeled field per schema key', () => {
     render(<AutoForm schema={schema} onSubmit={vi.fn()} />)
     expect(screen.getByLabelText('title')).toBeInTheDocument()
-    expect(screen.getByLabelText('premium')).toBeInTheDocument()
+    expect(screen.getByLabelText('draft')).toBeInTheDocument()
     expect(screen.getByLabelText('tags')).toBeInTheDocument()
   })
 
@@ -1748,7 +1757,6 @@ const post: Post = {
   title: 't',
   slug: 's',
   body: 'b',
-  premium: false,
   gated: false,
   author: { id: 'u1', username: 'demo' },
   tags: [],
@@ -2055,8 +2063,9 @@ level per spec §10 ("asserting on raw response bytes, not the DOM").
 // e2e/gating.spec.ts
 import { expect, test } from '@playwright/test'
 
-test('an anonymous reader never receives a premium post\'s full body over the wire', async ({ page, request }) => {
-  // Seeded by apps/server/src/scripts/seed.ts — a known premium post slug.
+test('an anonymous reader never receives a full body over the wire', async ({ page, request }) => {
+  // Seeded by apps/server/src/scripts/seed.ts — any seeded slug works now that
+  // gating is per-reader; this one's body names the mechanism.
   const res = await request.get('/api/v1/posts/gating-content-at-the-serialization-boundary')
   const body = await res.json()
   expect(body.gated).toBe(true)
@@ -2067,7 +2076,7 @@ test('an anonymous reader never receives a premium post\'s full body over the wi
 })
 ```
 
-> **Depends on seed data:** this test assumes the seeded premium post's non-teaser paragraph contains the
+> **Depends on seed data:** this test assumes the seeded post's non-teaser paragraph contains the
 > literal string asserted against. Check `apps/server/src/scripts/seed.ts`'s actual post body when implementing
 > this step and adjust the string to match — do not invent a slug or sentence that doesn't exist in the seed.
 

--- a/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
+++ b/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
@@ -324,23 +324,35 @@ straight from the client payload, so anyone could speak as anyone.
 
 ## 6. Content Gating (the "Medium mechanism")
 
-Posts carry a `premium: boolean` flag.
+> **Revised 2026-07-25.** The original design put a `premium: boolean` on each post, so the wall was
+> *per-post*: free posts were fully public, premium ones needed a session. That flag is **removed**. The
+> wall is now *per-reader* — every post is teased for anonymous readers and full for any signed-in one.
+> There is no paid tier and there never was: `UserModel` has no plan field, so "premium" only ever meant
+> "login-walled". Dropping it removes a distinction that bought nothing and made `gated` ambiguous.
 
-| | Free post | Premium (anonymous) | Premium (logged in) |
-|---|---|---|---|
-| Title, author, tags, cover, like count | ✅ | ✅ | ✅ |
-| Body | ✅ full | ⚠️ **teaser only** (first ~2 paragraphs) | ✅ full |
-| Comments | ✅ | ❌ | ✅ |
-| Chat | — | ❌ | ✅ |
-| Like / comment / post | login required | ❌ | ✅ |
+The gate is **authentication, not payment**. Signing up is free; a session is the only key.
 
-**Enforcement lives in the service layer, not the UI.** `postService.getPost(slug, session)` returns an
-object that **does not contain** the full `body` when the post is premium and the session is null:
+| | Anonymous | Signed in |
+|---|---|---|
+| Title, author, tags, cover, like count | ✅ | ✅ |
+| Body | ⚠️ **teaser only** (first ~2 paragraphs) | ✅ full |
+| Comments | ❌ | ✅ |
+| Chat | ❌ | ✅ |
+| Like / comment / post | ❌ | ✅ |
+
+**Enforcement lives in the service layer, not the UI.** `postService.getBySlug(slug, viewerId)` returns an
+object that **does not contain** the full `body` when the session is null:
 
 ```ts
-// premium && !session  →  { ...post, body: teaser, gated: true }
+// !viewerId  →  { ...post, body: teaser, gated: true }
 // the full body is never serialized into the response
 ```
+
+**`gated` means "this reader is locked out", not "this body is truncated."** The two come apart in the
+feed: `postService.list(viewerId)` ships teasers to *everyone*, signed in or not — a list endpoint never
+sends full bodies — so a signed-in reader's feed is truncated but ungated. `toDto` therefore takes `full`
+and `gated` as independent arguments; deriving one from the other (`gated: !full`) would mark every feed
+item locked and the UI would prompt signed-in readers to sign in.
 
 The React component renders whatever it is handed; when `gated` is true it shows the teaser and a "Sign in to
 read" prompt. There is no full body in the JSON to open in DevTools, because the API never put it there.
@@ -427,8 +439,7 @@ nonexistent `Task` model — a five-year-old leftover from a to-do tutorial — 
 {
   title:       string
   slug:        string    // UNIQUE — enables /blog/:slug
-  body:        string    // Markdown
-  premium:     boolean   // default false — gated posts (§6)
+  body:        string    // Markdown — teased for anonymous readers (§6)
   coverImage?: string    // Cloudinary public ID
   author:      ObjectId → User
   tags:        string[]  // indexed
@@ -527,7 +538,7 @@ and the service-layer authorization rules.
 §14 regression checklist is enforced against **real routes through the real middleware chain**:
 - a non-owner gets 403 on `DELETE /api/v1/posts/:slug`
 - an anonymous request gets 401, not a redirect
-- `GET /api/v1/posts/:slug` for a premium post as an anonymous user contains no full body
+- `GET /api/v1/posts/:slug` as an anonymous user contains no full body
 - logout is `POST`-only; `GET /api/v1/auth/logout` is 404
 - middleware order is correct (a malformed body reaches the error handler, not a router)
 
@@ -634,7 +645,7 @@ parallel agents.
 |---|---|---|
 | **P1** | `dev/express-api-foundation` | Monorepo re-shape, `apps/server` (Express + TS; originally scaffolded as `apps/api`, renamed during the P2 restructure) session auth on Redis, `requireAuth`/`requireOwner`, posts CRUD with correct authorization, Supertest integration suite, Compose dev + e2e, seed script, CI, deployed to Render. **Demoable via curl/Postman — no UI needed.** |
 | **P2** | `dev/react-client` | Vite + React + React Router + TanStack Query, Tailwind + shadcn (`ui`/`patterns`/`layouts`), auth pages, blog feed/post/editor, likes with optimistic UI, Playwright E2E, served by `apps/server` in prod. |
-| **P3** | `dev/comments-markdown` | Threaded comments, Markdown editor + preview, `AutoForm`, `premium` flag + gating (no JSON-LD — SEO dropped). |
+| **P3** | `dev/comments-markdown` | Threaded comments, Markdown editor + preview, `AutoForm`. (Gating shipped in P2 and needs no flag — see §6.) |
 | **P4** | `dev/realtime-chat` | `apps/realtime` Socket.io service, signed handshake tickets, Redis message buffer, presence + typing indicators. |
 | **P5** | `dev/media-and-search` | Signed Cloudinary uploads, avatars + cover images, tags, MongoDB full-text search. |
 | **P6** | `dev/oauth-polish` | Google + Facebook OAuth via Passport, Redis rate limiting, README + architecture diagram, demo account, final visual polish. |
@@ -683,7 +694,7 @@ items, a Supertest integration test against the real route.
       (old `app.js:56` echoed `message.user` straight from the client payload) — **P4** (realtime, not built yet)
 - [x] Session token is not readable by JavaScript (httpOnly cookie, not `localStorage`) — `session.test.ts`
 - [x] Login does not reveal whether a username exists — `auth.test.ts`
-- [x] A premium post's full body is absent from the API response for an anonymous reader (§6) — `posts.test.ts`
+- [x] A post's full body is absent from the API response for an anonymous reader (§6) — `posts.test.ts`
 
 **Correctness**
 - [ ] Socket listeners are cleaned up (old `chat.jsx:51` added a listener per message received) — **P4**

--- a/packages/zod-shared/src/schemas/post.ts
+++ b/packages/zod-shared/src/schemas/post.ts
@@ -11,7 +11,6 @@ export const CreatePostSchema = z.object({
     .trim()
     .min(1, 'Body cannot be empty')
     .max(50_000, 'Body must be at most 50,000 characters'),
-  premium: z.coerce.boolean().default(false),
   tags: z.array(z.string().trim().min(1)).max(5, 'A post can have at most 5 tags').default([]),
 })
 
@@ -32,6 +31,11 @@ export function slugify(title: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
+/**
+ * The public preview of a post. Every post is teased for anonymous readers —
+ * there is no per-post opt-out, so this runs on the way out of the API for any
+ * request without a session (spec §6).
+ */
 export function deriveTeaser(body: string, paragraphs = 2): string {
   return body.split(/\n{2,}/).slice(0, paragraphs).join('\n\n')
 }

--- a/packages/zod-shared/src/schemas/schemas.test.ts
+++ b/packages/zod-shared/src/schemas/schemas.test.ts
@@ -54,14 +54,18 @@ describe('SignupSchema', () => {
 
 describe('CreatePostSchema', () => {
   it('rejects a title shorter than 3 characters', () => {
-    const result = CreatePostSchema.safeParse({ title: 'ab', body: 'hello', premium: false })
+    const result = CreatePostSchema.safeParse({ title: 'ab', body: 'hello' })
     expect(result.success).toBe(false)
   })
 
-  it('defaults premium to false and tags to an empty array', () => {
+  it('defaults tags to an empty array', () => {
     const result = CreatePostSchema.parse({ title: 'A good title', body: 'hello' })
-    expect(result.premium).toBe(false)
     expect(result.tags).toEqual([])
+  })
+
+  it('strips a premium field — gating is per-reader, not per-post', () => {
+    const result = CreatePostSchema.parse({ title: 'A good title', body: 'hello', premium: true })
+    expect(result).not.toHaveProperty('premium')
   })
 
   it('rejects an author field from client input', () => {


### PR DESCRIPTION
## What

Removes the per-post `premium: boolean` flag. Gating is now **per-reader**: every post is teased for
anonymous readers and full for any signed-in one. Signing up (free) is the only key.

## Why

There was never a paid tier behind `premium` — `UserModel` has no plan field — so it only ever meant
"login-walled". It bought a distinction that cost more than it gave.

The feed forced a second, less obvious correction. `postService.list()` teases every post and derived
`gated: !full` from that, so it reported **every** feed item as locked — including to signed-in readers,
who would have been shown "Sign in to read" on content they could already open.

`full` (how much body is sent) and `gated` (whether this reader is locked out) are now independent
arguments to `toDto`. The feed sends teasers to everyone but flags only the anonymous ones. `list()` takes
a `viewerId`; the router forwards `req.session.userId`, as `GET /:slug` already did.

**So `gated` means "this reader is locked out", never "this body is truncated."** A signed-in reader's
feed is truncated but ungated.

## Verified in Docker Compose

Clean `--no-cache` rebuild, seeded, exercised with curl, then wiped:

| Check | Result |
|---|---|
| Anonymous feed — all gated | `[True, True, True]` |
| `premium` key present anywhere | `False` |
| Anonymous detail — withheld paragraph in **raw bytes** | absent (grep 0) |
| Signed-in feed — ungated | `[False, False, False]` |
| Signed-in feed still teasers (no bulk leak) | grep 0 |
| Signed-in detail — full body | present (grep 1) |

`npm run typecheck` clean, `npm run build` clean, **174/174 tests pass**.

## Breaking

`premium` is gone from `Post`, `CreatePostSchema` and `PostDto`. Existing Mongo documents keep the field;
it is simply never read or serialized again.

Docs updated: spec §6 (with a dated revision note), `CLAUDE.md`, `README.md`, and the P2 plan.
