### PR TITLE
feat(client): post detail page with server-driven gating UI

### DIFF
--- a/apps/client/src/hooks/use-posts.ts
+++ b/apps/client/src/hooks/use-posts.ts
@@ -18,5 +18,9 @@ export function usePosts() {
  * which is a prefix of this key.
  */
 export function usePost(slug: string) {
-  return useQuery({ queryKey: queryKeys.posts.detail(slug), queryFn: () => postsApi.get(slug) })
+  return useQuery({
+    queryKey: queryKeys.posts.detail(slug),
+    queryFn: () => postsApi.get(slug),
+    enabled: Boolean(slug),
+  })
 }

--- a/apps/client/src/hooks/use-posts.ts
+++ b/apps/client/src/hooks/use-posts.ts
@@ -10,3 +10,13 @@ import { queryKeys } from '../lib/query-client.js'
 export function usePosts() {
   return useQuery({ queryKey: queryKeys.posts.list, queryFn: postsApi.list })
 }
+
+/**
+ * A single post. Same reasoning as `usePosts`: the payload is viewer-dependent
+ * (`gated` and the full body are decided server-side per session), but
+ * the key stays viewer-agnostic because auth transitions invalidate `['posts']`,
+ * which is a prefix of this key.
+ */
+export function usePost(slug: string) {
+  return useQuery({ queryKey: queryKeys.posts.detail(slug), queryFn: () => postsApi.get(slug) })
+}

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -1,1 +1,68 @@
-export function PostPage() { return <p>Post</p> }
+import { Link, useParams } from 'react-router'
+import { usePost } from '../hooks/use-posts.js'
+import { useMe } from '../hooks/use-auth.js'
+import { EmptyState } from '../components/patterns/EmptyState.js'
+import { Skeleton } from '../components/ui/skeleton.js'
+
+/**
+ * The post detail page. `post.gated` is the server's verdict that this reader is
+ * locked out, so `post.body` is only a teaser — the full body was never
+ * serialized. The page relays that verdict; it never decides it, and
+ * there is no second gating rule to apply client-side.
+ */
+export function PostPage() {
+  const { slug } = useParams<{ slug: string }>()
+  const { data: post, isPending, isError } = usePost(slug ?? '')
+  const { data: me } = useMe()
+
+  if (isPending) return <Skeleton className="h-64" />
+  if (isError) return <EmptyState message="Could not load this post. Please try again." />
+  if (!post) return <EmptyState message="Post not found." />
+
+  const isOwner = me?.id === post.author.id
+
+  return (
+    <article className="flex flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">{post.title}</h1>
+        <p className="text-sm text-[var(--muted-foreground)]">by {post.author.username}</p>
+      </header>
+
+      <div className="whitespace-pre-wrap">{post.body}</div>
+
+      {post.gated && (
+        <p className="rounded bg-[var(--muted)] p-4 text-sm">
+          <Link to="/login" className="text-[var(--primary)] underline">
+            Sign in
+          </Link>{' '}
+          to read the rest of this post.
+        </p>
+      )}
+
+      {post.tags.length > 0 && (
+        <ul className="flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <li
+              key={tag}
+              className="rounded bg-[var(--muted)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
+            >
+              {tag}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-4 text-sm text-[var(--muted-foreground)]">
+        {/* Read-only until Task 10 swaps this for the interactive LikeButton. */}
+        <span>
+          {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
+        </span>
+        {isOwner && (
+          <Link to={`/blog/${post.slug}/edit`} className="underline">
+            Edit
+          </Link>
+        )}
+      </div>
+    </article>
+  )
+}


### PR DESCRIPTION
Implements the post detail page. The client renders whatever the API sends and never re-implements gating.

## Changes
- `hooks/use-posts.ts` — adds `usePost(slug)` on `queryKeys.posts.detail`. The key stays viewer-agnostic because auth transitions invalidate `['posts']`, a prefix of `['posts', slug]`.
- `pages/PostPage.tsx` — replaces the 1-line stub. Title, author, full body, tags, like count, "Sign in to read the rest" prompt driven solely by `post.gated`, and an Edit link when the viewer is the author.

## Deviations from the plan
- **No `LikeButton`.** It belongs to Task 10 and doesn't exist yet. The plan suggested a placeholder file, but that would collide with Task 10's own work, so the like count renders as read-only text with a comment marking the swap. **Task 10 must replace that `<span>`** — this is not in Task 10's plan text.
- **Added an `isError` branch.** The plan handled only `isPending` / `!post`, so a network failure rendered "Post not found." Mirrors the existing `BlogFeedPage` pattern.

## Verification
`npm run typecheck && npm run lint && npm run build` — all green.

## Merge order
Merge this **first**. It unblocks Tasks 9 and 10, and #next (`dev/post-editor-form`) will need a trivial union resolution in `use-posts.ts` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)