### PR TITLE
feat(client): delete post — invalidate rather than optimistically remove

### DIFF
--- a/apps/client/src/hooks/use-posts.ts
+++ b/apps/client/src/hooks/use-posts.ts
@@ -34,6 +34,14 @@ export function useCreatePost() {
   })
 }
 
+export function useDeletePost() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (slug: string) => postsApi.remove(slug),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.list }),
+  })
+}
+
 export function useUpdatePost(slug: string) {
   const queryClient = useQueryClient()
   return useMutation({

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -1,7 +1,10 @@
-import { Link, useParams } from 'react-router'
-import { usePost } from '../hooks/use-posts.js'
+import { Link, useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
+import { ApiError } from '../api/client.js'
+import { usePost, useDeletePost } from '../hooks/use-posts.js'
 import { useMe } from '../hooks/use-auth.js'
 import { EmptyState } from '../components/patterns/EmptyState.js'
+import { Button } from '../components/ui/button.js'
 import { Skeleton } from '../components/ui/skeleton.js'
 
 /**
@@ -14,6 +17,8 @@ export function PostPage() {
   const { slug } = useParams<{ slug: string }>()
   const { data: post, isPending, isError } = usePost(slug ?? '')
   const { data: me } = useMe()
+  const deletePost = useDeletePost()
+  const navigate = useNavigate()
 
   if (isPending) return <Skeleton className="h-64" />
   if (isError) return <EmptyState message="Could not load this post. Please try again." />
@@ -58,9 +63,25 @@ export function PostPage() {
           {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
         </span>
         {isOwner && (
-          <Link to={`/blog/${post.slug}/edit`} className="underline">
-            Edit
-          </Link>
+          <>
+            <Link to={`/blog/${post.slug}/edit`} className="underline">
+              Edit
+            </Link>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={deletePost.isPending}
+              onClick={() =>
+                deletePost.mutate(post.slug, {
+                  onSuccess: () => navigate('/'),
+                  onError: (err) =>
+                    toast.error(err instanceof ApiError ? err.message : 'Could not delete the post.'),
+                })
+              }
+            >
+              Delete
+            </Button>
+          </>
         )}
       </div>
     </article>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,15 @@
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['**/node_modules/**', '**/dist/**', '**/coverage/**', '**/test-results/**'] },
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/coverage/**',
+      '**/test-results/**',
+      '.remember/**',
+    ],
+  },
   ...tseslint.configs.recommended,
   {
     rules: {


### PR DESCRIPTION
P2 Task 9.

Adds `useDeletePost` and an owner-only Delete button on the post detail page.

**The correctness point** (spec §14): the delete is deliberately **not** optimistic. The post leaves the cache only after the server confirms, so a failed request leaves it visibly present rather than vanishing from a UI that no longer matches the database. `queryKeys.posts.list` is `['posts']` — a prefix of every `detail(slug)` key — so one invalidation drops the deleted post's detail entry too.

Errors surface through `sonner` with the `ApiError` message, matching `NewPostPage`/`EditPostPage`. The button is disabled while the mutation is in flight.

Also carries a separate `chore(lint)` commit: the remember hook writes timestamp files named `*.ts` under `.remember/tmp`, which ESLint parsed as TypeScript and failed the repo-wide gate. The directory git-ignores itself; ESLint needed telling separately.

**Gate:** typecheck, lint, build clean; 180/180 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By4q8q1D5wn8crXkBzUWnw