### PR TITLE
feat(client): likes with optimistic UI and rollback on failure

### DIFF
--- a/apps/client/src/components/patterns/LikeButton.tsx
+++ b/apps/client/src/components/patterns/LikeButton.tsx
@@ -1,0 +1,18 @@
+import { Heart } from 'lucide-react'
+import { useLikePost } from '../../hooks/use-likes.js'
+import { Button } from '../ui/button.js'
+
+/**
+ * No `liked` prop: `PostDto` carries no per-viewer "did I like this" flag, so
+ * the button shows the raw count and lets the mutation run either way. Like is
+ * idempotent server-side (unique index on `(user, post)`), so a second click is
+ * a no-op 200, not a double count.
+ */
+export function LikeButton({ slug, likeCount }: { slug: string; likeCount: number }) {
+  const like = useLikePost(slug)
+  return (
+    <Button variant="outline" size="sm" onClick={() => like.mutate()} disabled={like.isPending}>
+      <Heart className="mr-1 size-4" /> {likeCount}
+    </Button>
+  )
+}

--- a/apps/client/src/hooks/use-likes.test.tsx
+++ b/apps/client/src/hooks/use-likes.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useLikePost } from './use-likes.js'
+import { queryKeys } from '../lib/query-client.js'
+import type { Post } from '../api/posts.js'
+
+const post: Post = {
+  id: '1',
+  title: 't',
+  slug: 's',
+  body: 'b',
+  gated: false,
+  author: { id: 'u1', username: 'demo' },
+  tags: [],
+  likeCount: 2,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  client.setQueryData(queryKeys.posts.detail('s'), post)
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return { client, wrapper }
+}
+
+describe('useLikePost', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('increments likeCount immediately, before the request resolves', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {}))) // never resolves
+    const { client, wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLikePost('s'), { wrapper })
+    result.current.mutate()
+    await waitFor(() =>
+      expect(client.getQueryData<Post>(queryKeys.posts.detail('s'))?.likeCount).toBe(3),
+    )
+  })
+
+  it('rolls back likeCount if the request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ error: { message: 'nope' } }), { status: 500 }),
+        ),
+    )
+    const { client, wrapper } = makeWrapper()
+    const { result } = renderHook(() => useLikePost('s'), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(client.getQueryData<Post>(queryKeys.posts.detail('s'))?.likeCount).toBe(2)
+  })
+})

--- a/apps/client/src/hooks/use-likes.ts
+++ b/apps/client/src/hooks/use-likes.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { postsApi } from '../api/posts.js'
+import { queryKeys } from '../lib/query-client.js'
+import type { Post } from '../api/posts.js'
+
+/**
+ * Optimistic, unlike `useDeletePost` — a like is cheap and reversible, so the
+ * count moves before the server answers and `onError` puts it back. The
+ * rollback is the point: the failure path is tested, not just the happy one.
+ */
+export function useLikePost(slug: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => postsApi.like(slug),
+    onMutate: async () => {
+      // An in-flight refetch would otherwise land after this and clobber it.
+      await queryClient.cancelQueries({ queryKey: queryKeys.posts.detail(slug) })
+      const previous = queryClient.getQueryData<Post>(queryKeys.posts.detail(slug))
+      if (previous) {
+        queryClient.setQueryData<Post>(queryKeys.posts.detail(slug), {
+          ...previous,
+          likeCount: previous.likeCount + 1,
+        })
+      }
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(queryKeys.posts.detail(slug), context.previous)
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.detail(slug) }),
+  })
+}

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -4,6 +4,7 @@ import { ApiError } from '../api/client.js'
 import { usePost, useDeletePost } from '../hooks/use-posts.js'
 import { useMe } from '../hooks/use-auth.js'
 import { EmptyState } from '../components/patterns/EmptyState.js'
+import { LikeButton } from '../components/patterns/LikeButton.js'
 import { Button } from '../components/ui/button.js'
 import { Skeleton } from '../components/ui/skeleton.js'
 
@@ -58,10 +59,7 @@ export function PostPage() {
       )}
 
       <div className="flex items-center gap-4 text-sm text-[var(--muted-foreground)]">
-        {/* Read-only until Task 10 swaps this for the interactive LikeButton. */}
-        <span>
-          {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
-        </span>
+        <LikeButton slug={post.slug} likeCount={post.likeCount} />
         {isOwner && (
           <>
             <Link to={`/blog/${post.slug}/edit`} className="underline">


### PR DESCRIPTION
P2 Task 10. **Stacked on `dev/delete-post` (#25)** — both edit `PostPage.tsx`, so stacking avoids a guaranteed conflict. Retarget to `staging` once #25 merges.

Adds `useLikePost`, a `LikeButton` pattern component, and swaps the read-only like count on the post page for the interactive button.

**The contrast with Task 9 is the point.** Delete invalidates rather than removing optimistically; a like moves the count *before* the server answers and `onError` puts it back from the `onMutate` context. `onSettled` invalidates either way so the cache reconciles with the server.

`LikeButton` takes no `liked` prop — `PostDto` carries no per-viewer "did I like this" flag, so the button shows the raw count and lets the mutation run regardless. Like is idempotent server-side (unique `(user, post)` index), so a second click is a no-op 200, not a double count. Adding `likedByMe` to `PostDto` is a future phase, not a gap here.

**Tests** (`use-likes.test.tsx`, TDD — written and confirmed failing first):
- count increments immediately, with `fetch` stubbed to never resolve
- count rolls back to its original value when the request 500s

**Gate:** typecheck, lint, build clean; 182/182 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By4q8q1D5wn8crXkBzUWnw