### PR TITLE
test(e2e): Playwright coverage for auth+posts+likes and the gating boundary

### DIFF
--- a/.github/workflows/pr-to-staging.yml
+++ b/.github/workflows/pr-to-staging.yml
@@ -59,6 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
       # infra/secrets/e2e/*.txt is gitignored (never commit a secret file, even a
       # throwaway one) — CI has no other source for it, so materialize it here.
       - run: cp infra/secrets/e2e/session_secret.txt.example infra/secrets/e2e/session_secret.txt
@@ -71,6 +76,17 @@ jobs:
           status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/v1/health)
           echo "GET /api/v1/health -> $status"
           test "$status" = "200"
+      # playwright.config.ts reuses this already-running stack rather than
+      # starting a second one on the same port.
+      - name: Playwright E2E
+        run: npx playwright install --with-deps chromium && npm run test:e2e
+      - name: Upload the Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
       - name: Show logs on failure
         if: failure()
         run: docker compose -f infra/compose.e2e.yaml --project-directory . logs

--- a/apps/client/src/components/layouts/PageShell.tsx
+++ b/apps/client/src/components/layouts/PageShell.tsx
@@ -1,9 +1,10 @@
 import { Link, useNavigate } from 'react-router'
-import { useMe } from '../../hooks/use-auth.js'
+import { useLogout, useMe } from '../../hooks/use-auth.js'
 
 export function PageShell({ children }: { children: React.ReactNode }) {
   const { data: me } = useMe()
   const navigate = useNavigate()
+  const logout = useLogout()
 
   return (
     <div className="flex min-h-screen flex-col bg-[var(--background)] text-[var(--foreground)]">
@@ -19,8 +20,11 @@ export function PageShell({ children }: { children: React.ReactNode }) {
                 <Link to="/blog/new" className="text-sm hover:underline">
                   New Post
                 </Link>
+                {/* There is no /logout route — logging out is a POST, not a
+                    page. Navigating there rendered a dead end. */}
                 <button
-                  onClick={() => navigate('/logout')}
+                  onClick={() => logout.mutate(undefined, { onSuccess: () => navigate('/') })}
+                  disabled={logout.isPending}
                   className="text-sm hover:underline"
                 >
                   Logout

--- a/e2e/auth-and-posts.spec.ts
+++ b/e2e/auth-and-posts.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * The whole authenticated round trip through the real prod image: an account
+ * that did not exist, a post it owns, a like on it, and a session that ends.
+ *
+ * Selectors are the accessible name the app actually renders — "Sign Up",
+ * "New Post", "Publish", "Logout" — not the ones the plan guessed at.
+ */
+test('signup, create a post, like it, then log out', async ({ page }) => {
+  const username = `e2e-${Date.now()}`
+
+  await page.goto('/signup')
+  await page.getByLabel('Username').fill(username)
+  await page.getByLabel('Email').fill(`${username}@example.com`)
+  await page.getByLabel('Password').fill('a-valid-password')
+  await page.getByRole('button', { name: 'Sign Up' }).click()
+  await expect(page).toHaveURL('/')
+  await expect(page.getByText(`Welcome, ${username}`)).toBeVisible()
+
+  await page.getByRole('link', { name: 'New Post' }).click()
+  // AutoForm labels every field with its raw schema key.
+  await page.getByLabel('title').fill('An E2E post')
+  await page.getByLabel('body').fill('Written by Playwright.')
+  await page.getByRole('button', { name: 'Publish' }).click()
+  // Re-runs collide on the slug, so the server suffixes it: -2, -3, ...
+  await expect(page).toHaveURL(/\/blog\/an-e2e-post/)
+
+  // The like button's accessible name is just its count — a fresh post is at 0.
+  await page.getByRole('button', { name: '0' }).click()
+  await expect(page.getByRole('button', { name: '1' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Logout' }).click()
+  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible()
+})

--- a/e2e/gating.spec.ts
+++ b/e2e/gating.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * The gating boundary, asserted on raw response bytes rather than the DOM —
+ * hiding the body in a component would pass a DOM check while the text sat in
+ * the JSON, one DevTools tab away.
+ *
+ * The fixture is built through the API instead of read from the seed script:
+ * `compose.e2e.yaml` starts an empty Mongo and never seeds, and the `runner`
+ * image contains only the bundled dist — `src/scripts/seed.ts` and `tsx` are
+ * both absent from it, so `npm run seed` cannot run against this stack.
+ */
+const SENTINEL = 'only a signed-in reader should ever receive this sentence'
+
+test('an anonymous reader never receives a full body over the wire', async ({
+  page,
+  request,
+  playwright,
+}) => {
+  const username = `gate-${Date.now()}`
+
+  // `request` keeps the session cookie across calls, so this context is the author.
+  const signup = await request.post('/api/v1/auth/signup', {
+    data: { username, email: `${username}@example.com`, password: 'a-valid-password' },
+  })
+  expect(signup.ok()).toBe(true)
+
+  const created = await request.post('/api/v1/posts', {
+    data: {
+      title: `Gating check ${Date.now()}`,
+      body: [
+        'Paragraph one is public — the teaser always includes it.',
+        'Paragraph two is public as well; deriveTeaser keeps the first two.',
+        `Paragraph three is past the wall: ${SENTINEL}.`,
+      ].join('\n\n'),
+      tags: [],
+    },
+  })
+  expect(created.ok()).toBe(true)
+  const { slug } = await created.json()
+
+  // The author sees everything — without this the anonymous assertion below
+  // could pass simply because the sentence was never stored.
+  const asAuthor = await (await request.get(`/api/v1/posts/${slug}`)).json()
+  expect(asAuthor.gated).toBe(false)
+  expect(asAuthor.body).toContain(SENTINEL)
+
+  // A context with no cookies at all.
+  // Built by hand, so it needs the proxy header the config gives every other
+  // context — see playwright.config.ts for why it is required at all.
+  const anon = await playwright.request.newContext({
+    baseURL: 'http://localhost:3000',
+    extraHTTPHeaders: { 'X-Forwarded-Proto': 'https' },
+  })
+  const res = await anon.get(`/api/v1/posts/${slug}`)
+  expect(res.ok()).toBe(true)
+  const anonBody = await res.json()
+  expect(anonBody.gated).toBe(true)
+  expect(anonBody.body).not.toContain(SENTINEL)
+  // Nothing anywhere in the payload, not just the body field.
+  expect(JSON.stringify(anonBody)).not.toContain(SENTINEL)
+  await anon.dispose()
+
+  // `page` is a separate browser context and carries no session either.
+  await page.goto(`/blog/${slug}`)
+  await expect(page.getByText('to read the rest of this post')).toBeVisible()
+  await expect(page.getByText(SENTINEL)).toHaveCount(0)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "apps/*"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.62.0",
         "@types/node": "^22.10.0",
         "eslint": "^9.17.0",
         "typescript": "^5.7.0",
@@ -71,48 +72,6 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
-      }
-    },
-    "apps/client/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "apps/client/node_modules/vite": {
@@ -1291,6 +1250,22 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@redis/bloom": {
@@ -6833,6 +6808,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.22",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "name": "blog-chat-app",
   "private": true,
-  "workspaces": ["packages/*", "apps/*"],
-  "engines": { "node": ">=22" },
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "docker compose -f infra/compose.yaml --project-directory . watch",
     "build": "npm run build --workspaces --if-present",
@@ -13,6 +18,7 @@
     "seed": "npm run seed --workspace=@blog/server"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.0",
     "@types/node": "^22.10.0",
     "eslint": "^9.17.0",
     "typescript": "^5.7.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from '@playwright/test'
+
+/**
+ * E2E runs against `infra/compose.e2e.yaml`, which builds the Dockerfile's
+ * `runner` target — the same image Render would run. A broken production build
+ * fails here rather than after a deploy.
+ *
+ * `reuseExistingServer` is unconditionally true, NOT `!process.env.CI`: the
+ * `e2e-smoke` job brings the stack up itself with `up --build --wait` before
+ * calling this, so with `false` Playwright would refuse to start on an
+ * already-bound :3000. Reusing is correct in both places for the same reason —
+ * whoever brought the stack up, that is the stack under test.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  // The suite signs up real users against a shared stack; parallel workers
+  // racing the same Mongo make failures hard to read for no time saved.
+  workers: 1,
+  use: {
+    baseURL: 'http://localhost:3000',
+    /**
+     * The e2e stack runs the real production image, so `NODE_ENV=production`
+     * gives it `secure: true` session cookies and `trust proxy`. Over plain
+     * http:// Express marks the connection insecure and express-session drops
+     * the cookie silently — signup returns 201 with no Set-Cookie and every
+     * authenticated step afterwards 401s.
+     *
+     * This is the header Render's TLS-terminating proxy sets in front of the
+     * same image, so sending it reproduces the production topology rather than
+     * working around it. Downgrading the container to NODE_ENV=development
+     * would "fix" it by testing an artifact prod never runs.
+     */
+    extraHTTPHeaders: { 'X-Forwarded-Proto': 'https' },
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command:
+      'docker compose -f infra/compose.e2e.yaml --project-directory . up --build --wait',
+    url: 'http://localhost:3000/api/v1/health',
+    reuseExistingServer: true,
+    // A cold `runner` build pulls base images and runs npm ci twice.
+    timeout: 600_000,
+  },
+})


### PR DESCRIPTION
P2 Task 12. **Stacked on `dev/likes-optimistic-ui` (#26)**, which is stacked on `dev/delete-post` (#25) — the auth flow clicks the like button, so it can't run without Task 10. Retarget down the stack as each merges.

Two specs, both **verified green against the real `runner` image locally** (2 passed).

### Three plan assumptions that turned out to be false

**1. The plan's selectors don't exist.** It guessed `Sign up` / `New post` / `Save` / `Log out` / `Log in`; the app renders `Sign Up` / `New Post` / `Publish` / `Logout` / `Login`. Fixed against the actual components.

**2. The gating spec can't use seed data.** It was written to fetch a seeded slug, but `compose.e2e.yaml` starts an empty Mongo and never seeds — and it *can't*: the `runner` image ships only the bundled `dist`, so `src/scripts/seed.ts` and `tsx` are both absent. The spec now builds its own fixture through the API. That's stronger anyway: it plants a sentinel sentence in paragraph 3 (past `deriveTeaser`'s 2-paragraph cut), asserts the author receives it, then asserts an anonymous context does not — so the test can't pass by the text simply never having been stored.

**3. `reuseExistingServer: !process.env.CI` would have broken CI.** The `e2e-smoke` job brings the stack up itself before Playwright runs, so `false` makes Playwright refuse to start on an already-bound `:3000`. It's now unconditionally `true`: whoever brought the stack up, that's the stack under test.

### The session-cookie problem this surfaced

The e2e stack runs the production image, so `NODE_ENV=production` gives it `secure: true` cookies plus `trust proxy`. Over plain `http://localhost:3000` Express marks the connection insecure and express-session **drops the cookie silently** — signup returns `201` with no `Set-Cookie`, and every authenticated step 401s. Confirmed by hand with curl.

The fix is `extraHTTPHeaders: { 'X-Forwarded-Proto': 'https' }` — the exact header Render's TLS-terminating proxy sets in front of this same image. That reproduces the production topology instead of working around it; downgrading the container to `NODE_ENV=development` would have "fixed" it by testing an artifact production never runs.

### Carries a real bug fix

The E2E's logout step failed because `PageShell`'s Logout button called `navigate('/logout')` and **no `/logout` route exists** in `routes.tsx` — logout was a dead end and the session was never ended. `useLogout` already existed and was simply never wired up. Fixed in its own commit; this is the known-deferred logout 404.

### CI

`e2e-smoke` had no Node setup at all, so it gained `setup-node` + `npm ci` before the Playwright step, plus a report artifact on failure.

**Gate:** typecheck, lint, build clean; 182/182 unit/integration; 2/2 E2E against the prod image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By4q8q1D5wn8crXkBzUWnw