### PR TITLE
Replace comma-separated tags box with a chip input

### DIFF
--- a/apps/client/src/components/patterns/AutoForm.test.tsx
+++ b/apps/client/src/components/patterns/AutoForm.test.tsx
@@ -13,6 +13,12 @@ const schema = z.object({
   tags: z.array(z.string()).default([]),
 })
 
+function addTag(tag: string) {
+  const input = screen.getByLabelText('tags')
+  fireEvent.change(input, { target: { value: tag } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+}
+
 describe('AutoForm', () => {
   afterEach(() => cleanup())
 
@@ -31,13 +37,14 @@ describe('AutoForm', () => {
 
   // `.partial()` wraps every field in ZodOptional *outside* the ZodDefault that
   // `z.array(...).default([])` already added, so a single-level unwrap reports
-  // `tags` as a plain string field and the comma-split never runs.
+  // `tags` as a plain string field and it renders as a bare text box.
   it('still derives field kinds through a .partial() schema', () => {
     const onSubmit = vi.fn()
     render(<AutoForm schema={schema.partial()} onSubmit={onSubmit} />)
     expect(screen.getByLabelText('draft')).toHaveAttribute('type', 'checkbox')
 
-    fireEvent.change(screen.getByLabelText('tags'), { target: { value: 'express, testing' } })
+    addTag('express')
+    addTag('testing')
     fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
     fireEvent.click(screen.getByText('Save'))
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tags: ['express', 'testing'] }))
@@ -52,15 +59,28 @@ describe('AutoForm', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('parses a comma-separated tags input into a string array on submit', () => {
+  it('submits the tags added one at a time as a string array', () => {
     const onSubmit = vi.fn()
     render(<AutoForm schema={schema} onSubmit={onSubmit} />)
     fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
-    fireEvent.change(screen.getByLabelText('tags'), { target: { value: 'express, testing' } })
+    addTag('express')
+    addTag('testing')
+    expect(screen.getByText('express')).toBeInTheDocument()
     fireEvent.click(screen.getByText('Save'))
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'A valid title', tags: ['express', 'testing'] }),
     )
+  })
+
+  it('drops a tag removed with its × button', () => {
+    const onSubmit = vi.fn()
+    render(<AutoForm schema={schema} onSubmit={onSubmit} />)
+    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
+    addTag('keep')
+    addTag('drop')
+    fireEvent.click(screen.getByLabelText('Remove tag drop'))
+    fireEvent.click(screen.getByText('Save'))
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tags: ['keep'] }))
   })
 
   it('seeds the form from initialValues', () => {
@@ -74,7 +94,9 @@ describe('AutoForm', () => {
     )
     expect(screen.getByLabelText('title')).toHaveValue('Seeded')
     expect(screen.getByLabelText('draft')).toBeChecked()
-    expect(screen.getByLabelText('tags')).toHaveValue('a, b')
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+    expect(screen.getByLabelText('tags')).toHaveValue('')
     expect(screen.getByText('Save changes')).toBeInTheDocument()
   })
 })

--- a/apps/client/src/components/patterns/AutoForm.tsx
+++ b/apps/client/src/components/patterns/AutoForm.tsx
@@ -4,6 +4,7 @@ import { Button } from '../ui/button.js'
 import { Input } from '../ui/input.js'
 import { Label } from '../ui/label.js'
 import { Textarea } from '../ui/textarea.js'
+import { TagsInput } from './TagsInput.js'
 
 type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'text'
 
@@ -73,7 +74,7 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
     ([key, fieldSchema]) => ({ key, kind: fieldKind(key, fieldSchema) }),
   )
 
-  const [values, setValues] = useState<Record<string, string | boolean>>(() => {
+  const [values, setValues] = useState<Record<string, string | boolean | string[]>>(() => {
     const initial = (initialValues ?? {}) as Record<string, unknown>
     return Object.fromEntries(
       fields.map(({ key, kind }) => {
@@ -82,7 +83,7 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
           case 'checkbox':
             return [key, Boolean(seed ?? false)]
           case 'tags':
-            return [key, Array.isArray(seed) ? seed.join(', ') : '']
+            return [key, Array.isArray(seed) ? seed.map(String) : []]
           default:
             return [key, typeof seed === 'string' ? seed : '']
         }
@@ -91,25 +92,15 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
 
-  function parsedValue(key: string, kind: FieldKind): unknown {
-    if (kind === 'checkbox') return values[key]
-    if (kind === 'tags') {
-      const raw = values[key]
-      return typeof raw === 'string'
-        ? raw
-            .split(',')
-            .map((tag) => tag.trim())
-            .filter(Boolean)
-        : []
-    }
+  // `tags` is already held as an array by TagsInput, so nothing is parsed out of
+  // a raw string here — the state shape per field kind is the parsed shape.
+  function parsedValue(key: string): unknown {
     return values[key]
   }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    const candidate = Object.fromEntries(
-      fields.map(({ key, kind }) => [key, parsedValue(key, kind)]),
-    )
+    const candidate = Object.fromEntries(fields.map(({ key }) => [key, parsedValue(key)]))
     const result = schema.safeParse(candidate)
     if (!result.success) {
       setErrors(
@@ -133,6 +124,12 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
                 type="checkbox"
                 checked={Boolean(values[key])}
                 onChange={(e) => setValues((v) => ({ ...v, [key]: e.target.checked }))}
+              />
+            ) : kind === 'tags' ? (
+              <TagsInput
+                id={key}
+                value={Array.isArray(values[key]) ? (values[key] as string[]) : []}
+                onChange={(tags) => setValues((v) => ({ ...v, [key]: tags }))}
               />
             ) : kind === 'textarea' ? (
               <Textarea

--- a/apps/client/src/components/patterns/TagsInput.tsx
+++ b/apps/client/src/components/patterns/TagsInput.tsx
@@ -1,0 +1,78 @@
+import { useState, type KeyboardEvent } from 'react'
+import { Input } from '../ui/input.js'
+
+/**
+ * Tags are entered one at a time and shown as removable chips. The previous
+ * control was a plain text box whose comma-separated contract was invisible —
+ * nothing on screen said "split these with a comma", so tags arrived as one
+ * long tag. Enter commits, the hint states that, and the chips make the parsed
+ * result visible before submit instead of after.
+ */
+export function TagsInput({
+  id,
+  value,
+  onChange,
+}: {
+  id: string
+  value: string[]
+  onChange: (tags: string[]) => void
+}) {
+  const [draft, setDraft] = useState('')
+  const hintId = `${id}-hint`
+
+  function commit() {
+    const tag = draft.trim()
+    if (!tag) return
+    // Duplicates would survive the schema and reach the post, so drop them here.
+    if (!value.includes(tag)) onChange([...value, tag])
+    setDraft('')
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      // Without this the keypress submits the surrounding form instead.
+      e.preventDefault()
+      commit()
+      return
+    }
+    if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+      onChange(value.slice(0, -1))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Input
+        id={id}
+        type="text"
+        value={draft}
+        aria-describedby={hintId}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <p id={hintId} className="text-sm text-[var(--muted-foreground)]">
+        Type a tag and press Enter to add it.
+      </p>
+      {value.length > 0 && (
+        <ul className="flex flex-wrap gap-2">
+          {value.map((tag) => (
+            <li
+              key={tag}
+              className="flex items-center gap-1 rounded-full border border-[var(--border)] px-3 py-1 text-sm"
+            >
+              {tag}
+              <button
+                type="button"
+                aria-label={`Remove tag ${tag}`}
+                className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                onClick={() => onChange(value.filter((t) => t !== tag))}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What

The create/edit post form's `tags` field was a plain text box that silently expected commas — nothing on screen said so, so a whole list arrived as a single tag.

Tags are now entered one at a time:

- Type a tag, press **Enter** — it's committed and appears as a chip below the input.
- Each chip has an `x` button to remove it (`aria-label="Remove tag <tag>"`).
- A hint line under the input states the gesture, wired via `aria-describedby`.
- Backspace on an empty input removes the last chip; duplicates are ignored.

## Notes

`AutoForm` now holds `tags` as a `string[]` instead of a comma-joined string, so `parsedValue` no longer splits on commas — the state shape per field kind is the parsed shape. `initialValues` seeds chips directly, so the edit form shows existing tags as chips. The wire format is unchanged (`tags: string[]`), so nothing changed server-side.

Comma-split tests in `AutoForm.test.tsx` are replaced with add-via-Enter, remove-via-x, and seeded-chips assertions.

## Verification

- `npm run test` — 183/183 pass
- `npm run typecheck` — clean
- `npm run lint` — clean
