### PR TITLE
Full-text post search over the Mongo text index

### DIFF
--- a/apps/client/src/api/posts.test.ts
+++ b/apps/client/src/api/posts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { postsApi } from './posts.js'
+import { normalizeListParams, postsApi } from './posts.js'
 
 /** Stubs fetch and returns the mock, so tests can assert the URL that was hit. */
 function stubFetch() {
@@ -43,5 +43,22 @@ describe('postsApi.list', () => {
     const fetchMock = stubFetch()
     await postsApi.list({ q: 'a&b c' })
     expect(calledPath(fetchMock)).toBe('/api/v1/posts?q=a%26b+c')
+  })
+})
+
+// `usePosts` builds the cache key from this, so two params that produce one URL
+// have to produce one object — otherwise the same request is cached twice.
+describe('normalizeListParams', () => {
+  it('collapses a blank filter to no filter at all', () => {
+    expect(normalizeListParams({ q: '' })).toEqual({})
+    expect(normalizeListParams({ q: '  ', tag: '' })).toEqual({})
+  })
+
+  it('collapses a padded filter onto its trimmed form', () => {
+    expect(normalizeListParams({ q: ' mongo ' })).toEqual(normalizeListParams({ q: 'mongo' }))
+  })
+
+  it('keeps the filters that carry a value', () => {
+    expect(normalizeListParams({ q: 'mongo', tag: 'db' })).toEqual({ q: 'mongo', tag: 'db' })
   })
 })

--- a/apps/client/src/api/posts.test.ts
+++ b/apps/client/src/api/posts.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { postsApi } from './posts.js'
+
+/** Stubs fetch and returns the mock, so tests can assert the URL that was hit. */
+function stubFetch() {
+  const fetchMock = vi.fn().mockResolvedValue(new Response('[]', { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const calledPath = (fetchMock: ReturnType<typeof stubFetch>) => fetchMock.mock.calls[0]![0]
+
+describe('postsApi.list', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('hits the bare collection when there are no filters', async () => {
+    const fetchMock = stubFetch()
+    await postsApi.list()
+    expect(calledPath(fetchMock)).toBe('/api/v1/posts')
+  })
+
+  it('sends a term as ?q=', async () => {
+    const fetchMock = stubFetch()
+    await postsApi.list({ q: 'x' })
+    expect(calledPath(fetchMock)).toBe('/api/v1/posts?q=x')
+  })
+
+  it('sends a tag as ?tag=, and both filters together', async () => {
+    const fetchMock = stubFetch()
+    await postsApi.list({ q: 'x', tag: 'express' })
+    expect(calledPath(fetchMock)).toBe('/api/v1/posts?q=x&tag=express')
+  })
+
+  // A cleared box must produce the unfiltered feed, not `?q=` — the server has
+  // its own guard, but an empty term is not a search on either side.
+  it('omits a whitespace-only term entirely', async () => {
+    const fetchMock = stubFetch()
+    await postsApi.list({ q: '  ' })
+    expect(calledPath(fetchMock)).toBe('/api/v1/posts')
+  })
+
+  it('percent-encodes a term rather than pasting it into the URL', async () => {
+    const fetchMock = stubFetch()
+    await postsApi.list({ q: 'a&b c' })
+    expect(calledPath(fetchMock)).toBe('/api/v1/posts?q=a%26b+c')
+  })
+})

--- a/apps/client/src/api/posts.ts
+++ b/apps/client/src/api/posts.ts
@@ -21,14 +21,26 @@ export type Post = {
 export type PostListParams = { q?: string; tag?: string }
 
 /**
- * Builds `/api/v1/posts` with only the filters that carry a value. A
- * whitespace-only term is dropped rather than sent: an empty box is not a
- * search, and `$text: { $search: '' }` is an error on the server side.
+ * Drops the filters that carry no value and trims the rest. A whitespace-only
+ * term is not a search — and `$text: { $search: '' }` is an error on the server.
+ *
+ * Exported because the cache key has to be built from the SAME normalized
+ * object the URL is. Normalizing in only one of the two places would cache
+ * `{ q: 'mongo ' }`, `{ q: 'mongo' }` and `{}` vs `{ q: '' }` as distinct
+ * entries that all fetch one identical URL.
  */
-function listPath({ q, tag }: PostListParams): string {
+export function normalizeListParams({ q, tag }: PostListParams): PostListParams {
+  const normalized: PostListParams = {}
+  if (q?.trim()) normalized.q = q.trim()
+  if (tag?.trim()) normalized.tag = tag.trim()
+  return normalized
+}
+
+function listPath(params: PostListParams): string {
+  const { q, tag } = normalizeListParams(params)
   const search = new URLSearchParams()
-  if (q?.trim()) search.set('q', q.trim())
-  if (tag?.trim()) search.set('tag', tag.trim())
+  if (q) search.set('q', q)
+  if (tag) search.set('tag', tag)
   const query = search.toString()
   return query ? `/api/v1/posts?${query}` : '/api/v1/posts'
 }

--- a/apps/client/src/api/posts.ts
+++ b/apps/client/src/api/posts.ts
@@ -17,8 +17,24 @@ export type Post = {
   updatedAt: string
 }
 
+/** Feed filters, mirroring the server's `?q=` / `?tag=` query params. */
+export type PostListParams = { q?: string; tag?: string }
+
+/**
+ * Builds `/api/v1/posts` with only the filters that carry a value. A
+ * whitespace-only term is dropped rather than sent: an empty box is not a
+ * search, and `$text: { $search: '' }` is an error on the server side.
+ */
+function listPath({ q, tag }: PostListParams): string {
+  const search = new URLSearchParams()
+  if (q?.trim()) search.set('q', q.trim())
+  if (tag?.trim()) search.set('tag', tag.trim())
+  const query = search.toString()
+  return query ? `/api/v1/posts?${query}` : '/api/v1/posts'
+}
+
 export const postsApi = {
-  list: () => request<Post[]>('/api/v1/posts'),
+  list: (params: PostListParams = {}) => request<Post[]>(listPath(params)),
 
   get: (slug: string) => request<Post>(`/api/v1/posts/${slug}`),
 

--- a/apps/client/src/components/patterns/SearchBar.test.tsx
+++ b/apps/client/src/components/patterns/SearchBar.test.tsx
@@ -1,0 +1,37 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/PostCard.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SearchBar } from './SearchBar.js'
+
+describe('SearchBar', () => {
+  afterEach(() => cleanup())
+
+  it('renders the current value — the term always comes from the owner', () => {
+    render(<SearchBar value="mongo" onChange={vi.fn()} />)
+    expect(screen.getByRole('searchbox', { name: /search posts/i })).toHaveValue('mongo')
+  })
+
+  it('forwards typed input to onChange', () => {
+    const onChange = vi.fn()
+    render(<SearchBar value="" onChange={onChange} />)
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'mongo' } })
+    expect(onChange).toHaveBeenCalledWith('mongo')
+  })
+
+  // Controlled, not self-updating: without a parent applying the change the box
+  // stays empty, which is what lets the feed keep the term in the URL.
+  it('does not update itself when the value prop does not change', () => {
+    render(<SearchBar value="" onChange={vi.fn()} />)
+    const input = screen.getByRole('searchbox')
+    fireEvent.change(input, { target: { value: 'mongo' } })
+    expect(input).toHaveValue('')
+  })
+
+  it('stays labelled for assistive tech without showing a visible label', () => {
+    render(<SearchBar value="" onChange={vi.fn()} />)
+    expect(screen.getByLabelText('Search posts')).toBeInTheDocument()
+  })
+})

--- a/apps/client/src/components/patterns/SearchBar.tsx
+++ b/apps/client/src/components/patterns/SearchBar.tsx
@@ -1,0 +1,39 @@
+import { Input } from '../ui/input.js'
+
+/**
+ * A controlled search box and nothing more — no state, no debounce, no request.
+ * The owner decides what a term means and when to act on it; keeping this dumb
+ * is what lets the feed hold the term in the URL rather than in a component.
+ *
+ * `type="search"` gives the browser's clear affordance, and the label is
+ * visually hidden rather than absent so the input is still named for
+ * screen readers without a heading above the feed.
+ */
+export function SearchBar({
+  value,
+  onChange,
+  id = 'search',
+  label = 'Search posts',
+  placeholder = 'Search posts…',
+}: {
+  value: string
+  onChange: (value: string) => void
+  id?: string
+  label?: string
+  placeholder?: string
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="sr-only">
+        {label}
+      </label>
+      <Input
+        id={id}
+        type="search"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  )
+}

--- a/apps/client/src/components/patterns/SearchBar.tsx
+++ b/apps/client/src/components/patterns/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { Input } from '../ui/input.js'
 
 /**
@@ -12,7 +13,7 @@ import { Input } from '../ui/input.js'
 export function SearchBar({
   value,
   onChange,
-  id = 'search',
+  id,
   label = 'Search posts',
   placeholder = 'Search posts…',
 }: {
@@ -22,13 +23,18 @@ export function SearchBar({
   label?: string
   placeholder?: string
 }) {
+  // Two search bars on one page must not share an id, or the second label
+  // points at the first input. A caller can still pin the id if it needs to.
+  const generatedId = useId()
+  const inputId = id ?? generatedId
+
   return (
     <div>
-      <label htmlFor={id} className="sr-only">
+      <label htmlFor={inputId} className="sr-only">
         {label}
       </label>
       <Input
-        id={id}
+        id={inputId}
         type="search"
         value={value}
         placeholder={placeholder}

--- a/apps/client/src/hooks/use-auth.ts
+++ b/apps/client/src/hooks/use-auth.ts
@@ -44,7 +44,7 @@ function useAuthTransition<TInput, TResult>(
     onSuccess: (result) => {
       queryClient.setQueryData(queryKeys.me, resolveUser(result))
       // ['posts'] is a prefix of ['posts', slug], so detail queries go too.
-      return queryClient.invalidateQueries({ queryKey: queryKeys.posts.list })
+      return queryClient.invalidateQueries({ queryKey: queryKeys.posts.all })
     },
   })
 }

--- a/apps/client/src/hooks/use-debounced-value.test.tsx
+++ b/apps/client/src/hooks/use-debounced-value.test.tsx
@@ -1,0 +1,46 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useDebouncedValue } from './use-debounced-value.js'
+
+describe('useDebouncedValue', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('mongo', 300))
+    expect(result.current).toBe('mongo')
+  })
+
+  it('withholds a new value until the delay has elapsed', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'ab' })
+    act(() => void vi.advanceTimersByTime(299))
+    expect(result.current).toBe('a')
+
+    act(() => void vi.advanceTimersByTime(1))
+    expect(result.current).toBe('ab')
+  })
+
+  // The point of the hook: a keystroke mid-wait restarts the clock, so a burst
+  // settles on the last value once and never emits the intermediate ones.
+  it('restarts the timer on a rapid second change instead of firing twice', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'ab' })
+    act(() => void vi.advanceTimersByTime(200))
+    rerender({ value: 'abc' })
+
+    // 200ms after the FIRST change had it not been reset — still nothing.
+    act(() => void vi.advanceTimersByTime(200))
+    expect(result.current).toBe('a')
+
+    act(() => void vi.advanceTimersByTime(100))
+    expect(result.current).toBe('abc')
+  })
+})

--- a/apps/client/src/hooks/use-debounced-value.ts
+++ b/apps/client/src/hooks/use-debounced-value.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns `value` only once it has stopped changing for `delay` ms.
+ *
+ * The timer is cleaned up on every change, so a burst of edits resets it rather
+ * than queueing one expiry each — typing "mongo" issues one request, not five.
+ */
+export function useDebouncedValue<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debounced
+}

--- a/apps/client/src/hooks/use-posts.ts
+++ b/apps/client/src/hooks/use-posts.ts
@@ -1,6 +1,6 @@
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { CreatePost, UpdatePost } from '@blog/zod-shared'
-import { postsApi, type PostListParams } from '../api/posts.js'
+import { normalizeListParams, postsApi, type PostListParams } from '../api/posts.js'
 import { queryKeys } from '../lib/query-client.js'
 
 /**
@@ -13,11 +13,15 @@ import { queryKeys } from '../lib/query-client.js'
  * `keepPreviousData` keeps the previous results on screen while the next term
  * loads. Without it every keystroke that survives the debounce is a brand new
  * key, so `isPending` flips back to true and the feed blinks to skeletons.
+ *
+ * Normalizing before both the key and the request is what keeps them in step:
+ * a cleared box (`{ q: '' }`) must hit the same cache entry as no filters at all.
  */
 export function usePosts(params: PostListParams = {}) {
+  const filters = normalizeListParams(params)
   return useQuery({
-    queryKey: queryKeys.posts.list(params),
-    queryFn: () => postsApi.list(params),
+    queryKey: queryKeys.posts.list(filters),
+    queryFn: () => postsApi.list(filters),
     placeholderData: keepPreviousData,
   })
 }

--- a/apps/client/src/hooks/use-posts.ts
+++ b/apps/client/src/hooks/use-posts.ts
@@ -1,15 +1,25 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { CreatePost, UpdatePost } from '@blog/zod-shared'
-import { postsApi } from '../api/posts.js'
+import { postsApi, type PostListParams } from '../api/posts.js'
 import { queryKeys } from '../lib/query-client.js'
 
 /**
- * The feed. Deliberately not keyed by the viewer: the session cookie rides on
- * the request, and `useLogin`/`useLogout` invalidate this key, so signing in
- * refetches and the teasers come back ungated.
+ * The feed, optionally filtered. Keyed by the filters so each search term
+ * caches on its own, but deliberately NOT keyed by the viewer: the session
+ * cookie rides on the request, and `useLogin`/`useLogout` invalidate `posts.all`
+ * — a prefix of every key here — so signing in refetches and the teasers come
+ * back ungated.
+ *
+ * `keepPreviousData` keeps the previous results on screen while the next term
+ * loads. Without it every keystroke that survives the debounce is a brand new
+ * key, so `isPending` flips back to true and the feed blinks to skeletons.
  */
-export function usePosts() {
-  return useQuery({ queryKey: queryKeys.posts.list, queryFn: postsApi.list })
+export function usePosts(params: PostListParams = {}) {
+  return useQuery({
+    queryKey: queryKeys.posts.list(params),
+    queryFn: () => postsApi.list(params),
+    placeholderData: keepPreviousData,
+  })
 }
 
 /**
@@ -30,7 +40,7 @@ export function useCreatePost() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (input: CreatePost) => postsApi.create(input),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.list }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.all }),
   })
 }
 
@@ -38,7 +48,7 @@ export function useDeletePost() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (slug: string) => postsApi.remove(slug),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.list }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.posts.all }),
   })
 }
 
@@ -50,7 +60,7 @@ export function useUpdatePost(slug: string) {
       // ['posts'] is a prefix of ['posts', slug], so one invalidation would do —
       // but the slug changes when the title does, and the old detail key is the
       // one the editor is still mounted on.
-      queryClient.invalidateQueries({ queryKey: queryKeys.posts.list })
+      queryClient.invalidateQueries({ queryKey: queryKeys.posts.all })
       queryClient.invalidateQueries({ queryKey: queryKeys.posts.detail(slug) })
     },
   })

--- a/apps/client/src/lib/query-client.ts
+++ b/apps/client/src/lib/query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query'
+import type { PostListParams } from '../api/posts.js'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -10,7 +11,15 @@ export const queryClient = new QueryClient({
 export const queryKeys = {
   me: ['auth', 'me'] as const,
   posts: {
-    list: ['posts'] as const,
+    /**
+     * The invalidation target, never a query key of its own: every posts key
+     * below starts with `['posts']`, and TanStack matches by prefix, so
+     * invalidating this reaches the feed under every set of filters plus every
+     * detail. Filtered feeds must cache separately — hence `list(params)` — but
+     * they must all still be dropped together when a post changes.
+     */
+    all: ['posts'] as const,
+    list: (params: PostListParams = {}) => ['posts', 'list', params] as const,
     detail: (slug: string) => ['posts', slug] as const,
     likes: {
       detail: (slug: string) => ['posts', slug, 'likes'] as const,

--- a/apps/client/src/lib/query-client.ts
+++ b/apps/client/src/lib/query-client.ts
@@ -20,9 +20,14 @@ export const queryKeys = {
      */
     all: ['posts'] as const,
     list: (params: PostListParams = {}) => ['posts', 'list', params] as const,
-    detail: (slug: string) => ['posts', slug] as const,
+    /**
+     * Namespaced under 'detail' rather than sitting directly on the slug: with
+     * `['posts', slug]`, a post slugged "list" produces `['posts', 'list']`,
+     * which prefix-matches — and so invalidates — every filtered feed.
+     */
+    detail: (slug: string) => ['posts', 'detail', slug] as const,
     likes: {
-      detail: (slug: string) => ['posts', slug, 'likes'] as const,
+      detail: (slug: string) => ['posts', 'detail', slug, 'likes'] as const,
     },
   },
   users: {

--- a/apps/client/src/pages/BlogFeedPage.tsx
+++ b/apps/client/src/pages/BlogFeedPage.tsx
@@ -14,14 +14,27 @@ export function BlogFeedPage() {
   const term = searchParams.get('q') ?? ''
   // The box tracks every keystroke; the query does not. Debouncing between the
   // two is what makes this one request per pause instead of one per character.
-  const debouncedTerm = useDebouncedValue(term)
+  // Trimmed for the same reason the API drops a blank filter: "   " is not a
+  // search, so it must not colour the empty state either.
+  const debouncedTerm = useDebouncedValue(term).trim()
 
   const { data: posts, isPending, isError } = usePosts({ q: debouncedTerm })
 
-  // `replace` so typing does not push one history entry per keystroke — back
-  // should leave the feed, not replay the search character by character.
+  // Edits `q` in place instead of replacing the whole search string: passing an
+  // object would drop every other param, and `tag` is already plumbed through
+  // the API — a keystroke silently clearing a tag filter would be a confusing
+  // bug to trace back here. `replace` so typing does not push one history entry
+  // per keystroke; back should leave the feed, not replay the search.
   const handleSearch = (next: string) =>
-    setSearchParams(next ? { q: next } : {}, { replace: true })
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev)
+        if (next) params.set('q', next)
+        else params.delete('q')
+        return params
+      },
+      { replace: true },
+    )
 
   let content: ReactNode
   if (isPending) {

--- a/apps/client/src/pages/BlogFeedPage.tsx
+++ b/apps/client/src/pages/BlogFeedPage.tsx
@@ -1,29 +1,60 @@
+import type { ReactNode } from 'react'
+import { useSearchParams } from 'react-router'
 import { usePosts } from '../hooks/use-posts.js'
+import { useDebouncedValue } from '../hooks/use-debounced-value.js'
 import { PostCard } from '../components/patterns/PostCard.js'
+import { SearchBar } from '../components/patterns/SearchBar.js'
 import { EmptyState } from '../components/patterns/EmptyState.js'
 import { Skeleton } from '../components/ui/skeleton.js'
 
 export function BlogFeedPage() {
-  const { data: posts, isPending, isError } = usePosts()
+  // The term lives in the URL, not in component state: a search is then
+  // bookmarkable, shareable, and survives a reload or the back button.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const term = searchParams.get('q') ?? ''
+  // The box tracks every keystroke; the query does not. Debouncing between the
+  // two is what makes this one request per pause instead of one per character.
+  const debouncedTerm = useDebouncedValue(term)
 
+  const { data: posts, isPending, isError } = usePosts({ q: debouncedTerm })
+
+  // `replace` so typing does not push one history entry per keystroke — back
+  // should leave the feed, not replay the search character by character.
+  const handleSearch = (next: string) =>
+    setSearchParams(next ? { q: next } : {}, { replace: true })
+
+  let content: ReactNode
   if (isPending) {
-    return (
+    content = (
       <div className="flex flex-col gap-4">
         <Skeleton className="h-32" />
         <Skeleton className="h-32" />
         <Skeleton className="h-32" />
       </div>
     )
+  } else if (isError) {
+    content = <EmptyState message="Could not load posts. Please try again." />
+  } else if (!posts || posts.length === 0) {
+    content = (
+      <EmptyState message={debouncedTerm ? `No posts match “${debouncedTerm}”.` : 'No posts yet.'} />
+    )
+  } else {
+    content = (
+      <div className="flex flex-col gap-4">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+    )
   }
 
-  if (isError) return <EmptyState message="Could not load posts. Please try again." />
-  if (!posts || posts.length === 0) return <EmptyState message="No posts yet." />
-
+  // The search box is outside every branch on purpose: it must stay on screen
+  // while results load and, above all, when a search returns nothing — hiding
+  // it there would leave the reader stranded with no way to change the term.
   return (
-    <div className="flex flex-col gap-4">
-      {posts.map((post) => (
-        <PostCard key={post.id} post={post} />
-      ))}
+    <div className="flex flex-col gap-6">
+      <SearchBar value={term} onChange={handleSearch} />
+      {content}
     </div>
   )
 }

--- a/apps/server/src/lib/services/post.test.ts
+++ b/apps/server/src/lib/services/post.test.ts
@@ -137,6 +137,39 @@ describe('postService.list — search and tag filters', () => {
   })
 })
 
+describe('postService.list — ordering', () => {
+  /** Pins createdAt through the driver: Mongoose's timestamps plugin owns the field otherwise. */
+  const backdate = (slug: string, iso: string) =>
+    PostModel.collection.updateOne({ slug }, { $set: { createdAt: new Date(iso) } })
+
+  // Three posts whose insertion order, date order and relevance order are all
+  // DIFFERENT. That is the point: with two, "most relevant" and "newest" can
+  // coincide with the order the driver happens to return, and both assertions
+  // below would pass with the sort deleted entirely.
+  //
+  //   insertion : Deep, Passing, Middling
+  //   newest    : Passing, Middling, Deep
+  //   relevance : Deep, Middling, Passing
+  beforeEach(async () => {
+    await create({ title: 'Mongo Mongo Mongo Deep', body: 'Mongo mongo mongo mongo mongo.' })
+    await create({ title: 'An Essay Passing By', body: `${LONG_BODY}\n\nOne aside about mongo.` })
+    await create({ title: 'Mongo Middling', body: `${LONG_BODY}\n\nTwo asides: mongo, mongo.` })
+    await backdate('mongo-mongo-mongo-deep', '2020-01-01')
+    await backdate('mongo-middling', '2023-01-01')
+    await backdate('an-essay-passing-by', '2026-01-01')
+  })
+
+  it('sorts an unfiltered feed newest-first', async () => {
+    const titles = (await postService.list()).map((p) => p.title)
+    expect(titles).toEqual(['An Essay Passing By', 'Mongo Middling', 'Mongo Mongo Mongo Deep'])
+  })
+
+  it('sorts a search by relevance, not by date', async () => {
+    const titles = (await postService.list(undefined, { q: 'mongo' })).map((p) => p.title)
+    expect(titles).toEqual(['Mongo Mongo Mongo Deep', 'Mongo Middling', 'An Essay Passing By'])
+  })
+})
+
 // The legacy feed read `post.body` unguarded (postsList.jsx:12) and threw on the
 // first document that had none. Such a document should not exist — so it is
 // inserted through the driver, past the Mongoose validator, on purpose.

--- a/apps/server/src/lib/services/post.test.ts
+++ b/apps/server/src/lib/services/post.test.ts
@@ -85,6 +85,85 @@ describe('postService.list', () => {
   })
 })
 
+describe('postService.list — search and tag filters', () => {
+  it('matches on the title', async () => {
+    await create({ title: 'Indexing Mongo Text' })
+    await create({ title: 'An Unrelated Essay' })
+    const found = await postService.list(undefined, { q: 'Mongo' })
+    expect(found.map((p) => p.title)).toEqual(['Indexing Mongo Text'])
+  })
+
+  it('matches on the body, not just the title', async () => {
+    await create({ title: 'A Fine Title', body: 'Nothing here.\n\nA word about kubernetes.' })
+    await create({ title: 'Another Title', body: 'Nothing here at all.' })
+    const found = await postService.list(undefined, { q: 'kubernetes' })
+    expect(found).toHaveLength(1)
+    expect(found[0]!.title).toBe('A Fine Title')
+  })
+
+  it('returns an empty list when nothing matches', async () => {
+    await create()
+    expect(await postService.list(undefined, { q: 'zzzznotaword' })).toEqual([])
+  })
+
+  // MongoDB rejects `$text: { $search: '' }`, so a blank box must not become a query.
+  it('treats an empty or whitespace-only term as no term at all', async () => {
+    await create({ title: 'One Title' })
+    await create({ title: 'Two Title' })
+    expect(await postService.list(undefined, { q: '' })).toHaveLength(2)
+    expect(await postService.list(undefined, { q: '   ' })).toHaveLength(2)
+  })
+
+  it('filters by tag', async () => {
+    await create({ title: 'Tagged Post', tags: ['express'] })
+    await create({ title: 'Other Post', tags: ['react'] })
+    const found = await postService.list(undefined, { tag: 'express' })
+    expect(found.map((p) => p.title)).toEqual(['Tagged Post'])
+  })
+
+  it('ANDs the term and the tag rather than widening to either', async () => {
+    await create({ title: 'Kubernetes Basics', tags: ['devops'] })
+    await create({ title: 'Kubernetes Advanced', tags: ['react'] })
+    await create({ title: 'An Unrelated Essay', tags: ['devops'] })
+    const found = await postService.list(undefined, { q: 'Kubernetes', tag: 'devops' })
+    expect(found.map((p) => p.title)).toEqual(['Kubernetes Basics'])
+  })
+
+  it('still gates and teases filtered results — a filter is not a bypass', async () => {
+    await create({ title: 'Kubernetes Basics' })
+    const [post] = await postService.list(undefined, { q: 'Kubernetes' })
+    expect(post!.gated).toBe(true)
+    expect(post!.body).not.toContain('Para three')
+  })
+})
+
+// The legacy feed read `post.body` unguarded (postsList.jsx:12) and threw on the
+// first document that had none. Such a document should not exist — so it is
+// inserted through the driver, past the Mongoose validator, on purpose.
+describe('postService.list — a body-less document must not crash the feed', () => {
+  const insertBodyless = () =>
+    PostModel.collection.insertOne({
+      title: 'Bodyless Curiosity',
+      slug: 'bodyless-curiosity',
+      author: new Types.ObjectId(authorId),
+      tags: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+  it('lists it instead of throwing', async () => {
+    await insertBodyless()
+    const posts = await postService.list()
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.body).toBe('')
+  })
+
+  it('survives it in a search result too', async () => {
+    await insertBodyless()
+    await expect(postService.list(undefined, { q: 'Bodyless' })).resolves.toHaveLength(1)
+  })
+})
+
 describe('postService.getBySlug — THE gating rule (spec §6)', () => {
   it('OMITS the full body for an anonymous reader', async () => {
     const { slug } = await create()

--- a/apps/server/src/lib/services/post.ts
+++ b/apps/server/src/lib/services/post.ts
@@ -7,9 +7,12 @@ import {
 import { NotFoundError } from '../errors.js'
 import { LikeModel } from '../../models/like.js'
 import { PostModel, type Post } from '../../models/post.js'
-import { Types, type HydratedDocument } from 'mongoose'
+import { Types, type FilterQuery, type HydratedDocument } from 'mongoose'
 
 export type PostAuthor = { id: string; username: string }
+
+/** Feed filters. Both are optional and combine with AND when both are given. */
+export type PostListParams = { q?: string; tag?: string }
 
 export type PostDto = {
   id: string
@@ -49,11 +52,16 @@ function toDto(
   { full, gated }: { full: boolean; gated: boolean },
 ): PostDto {
   const author = post.author
+  // REGRESSION GUARD (legacy postsList.jsx:12): `body` is required by the schema,
+  // but a document written around the validator still reaches this function, and
+  // `deriveTeaser(undefined)` threw a TypeError that took the whole feed down.
+  // One bad row must not 500 the list.
+  const body = post.body ?? ''
   return {
     id: post._id.toString(),
     title: post.title,
     slug: post.slug,
-    body: full ? post.body : deriveTeaser(post.body),
+    body: full ? body : deriveTeaser(body),
     gated,
     author: isPopulated(author)
       ? { id: author._id.toString(), username: author.username }
@@ -89,9 +97,29 @@ export const postService = {
    * The feed. Teaser bodies ALWAYS — a list endpoint never ships full bodies,
    * signed in or not. `viewerId` therefore changes only `gated`, i.e. whether
    * the card invites the reader to sign in, never how much text is sent.
+   *
+   * Search runs on the `{ title, body }` text index declared on the model, so the
+   * database does the matching — the legacy client filtered an already-downloaded
+   * array, which only ever searched the page it had.
+   *
+   * Both filters are trimmed and an empty one is dropped: Mongo rejects `$text:
+   * { $search: '' }`, so `?q=` must degrade to an unfiltered feed rather than a
+   * 500, and `?tag=` must not match the posts that happen to have no tags.
    */
-  async list(viewerId?: string): Promise<PostDto[]> {
-    const posts = await PostModel.find().sort({ createdAt: -1 }).populate('author', 'username')
+  async list(viewerId?: string, params: PostListParams = {}): Promise<PostDto[]> {
+    const term = params.q?.trim()
+    const tag = params.tag?.trim()
+    const filter: FilterQuery<Post> = {}
+    if (term) filter.$text = { $search: term }
+    if (tag) filter.tags = tag
+
+    if (process.env.DEBUG) console.log('[postService.list]', { term, tag, viewerId })
+
+    const query = PostModel.find(filter).populate('author', 'username')
+    // Relevance when there is a term to be relevant to, newest-first otherwise.
+    query.sort(term ? { score: { $meta: 'textScore' } } : { createdAt: -1 })
+    const posts = await query
+
     return Promise.all(
       posts.map(async (p) =>
         toDto(p, await countLikes(p._id), {

--- a/apps/server/src/lib/services/post.ts
+++ b/apps/server/src/lib/services/post.ts
@@ -105,6 +105,19 @@ export const postService = {
    * Both filters are trimmed and an empty one is dropped: Mongo rejects `$text:
    * { $search: '' }`, so `?q=` must degrade to an unfiltered feed rather than a
    * 500, and `?tag=` must not match the posts that happen to have no tags.
+   *
+   * Two consequences of using `$text`, both accepted deliberately:
+   *
+   * 1. It matches whole stemmed words, NOT substrings — "mongo" does not find
+   *    "MongoDB", and a half-typed word finds nothing until it is finished. A
+   *    substring search cannot use an index at all, and an unindexed scan of
+   *    every body is the thing this change exists to stop doing.
+   * 2. The index spans `body`, so an anonymous reader can learn whether a word
+   *    occurs in text they cannot read. That is a presence oracle, not a leak —
+   *    no gated byte is ever serialized (see `toDto`). It is tolerable here only
+   *    because the wall is a free signup rather than a paid tier; narrowing it
+   *    would mean a second, title-only index, since a `$text` query cannot pick
+   *    a subset of the fields its index covers.
    */
   async list(viewerId?: string, params: PostListParams = {}): Promise<PostDto[]> {
     const term = params.q?.trim()
@@ -117,7 +130,9 @@ export const postService = {
 
     const query = PostModel.find(filter).populate('author', 'username')
     // Relevance when there is a term to be relevant to, newest-first otherwise.
-    query.sort(term ? { score: { $meta: 'textScore' } } : { createdAt: -1 })
+    // `createdAt` breaks relevance ties too, so equally-scoring posts come back
+    // in a stable, meaningful order rather than whatever the index yields.
+    query.sort(term ? { score: { $meta: 'textScore' }, createdAt: -1 } : { createdAt: -1 })
     const posts = await query
 
     return Promise.all(

--- a/apps/server/src/routes/v1/posts.test.ts
+++ b/apps/server/src/routes/v1/posts.test.ts
@@ -44,6 +44,61 @@ describe('GET /api/v1/posts', () => {
   })
 })
 
+describe('GET /api/v1/posts?q= — search over the text index', () => {
+  /** Two posts, distinguishable by title and by tag. */
+  async function seed(a: ReturnType<typeof buildTestApp>) {
+    const author = await signedInAgent(a, 'author')
+    await author.post('/api/v1/posts').send({ title: 'Indexing Mongo Text', body: BODY, tags: ['db'] })
+    await author.post('/api/v1/posts').send({ title: 'An Unrelated Essay', body: BODY, tags: ['prose'] })
+  }
+
+  it('returns only the matching posts', async () => {
+    const a = app()
+    await seed(a)
+    const res = await request(a).get('/api/v1/posts').query({ q: 'Mongo' })
+    expect(res.status).toBe(200)
+    expect(res.body.map((p: { title: string }) => p.title)).toEqual(['Indexing Mongo Text'])
+  })
+
+  it('returns 200 with an empty array when nothing matches', async () => {
+    const a = app()
+    await seed(a)
+    const res = await request(a).get('/api/v1/posts').query({ q: 'zzzznotaword' })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([])
+  })
+
+  // Mongo rejects `$text: { $search: '' }` — an empty box must not 500 the feed.
+  it('treats ?q= as no filter at all rather than erroring', async () => {
+    const a = app()
+    await seed(a)
+    const res = await request(a).get('/api/v1/posts?q=')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(2)
+  })
+
+  it('filters by ?tag=, and combines it with ?q=', async () => {
+    const a = app()
+    await seed(a)
+    expect((await request(a).get('/api/v1/posts').query({ tag: 'db' })).body).toHaveLength(1)
+    expect((await request(a).get('/api/v1/posts').query({ q: 'Mongo', tag: 'prose' })).body).toEqual([])
+  })
+
+  it('keeps search results teased and gated exactly as the unfiltered feed is', async () => {
+    const a = app()
+    await seed(a)
+
+    const anon = await request(a).get('/api/v1/posts').query({ q: 'Mongo' })
+    expect(anon.body[0].gated).toBe(true)
+    expect(anon.text).not.toContain('Para three')
+
+    const reader = await signedInAgent(a, 'reader')
+    const signedIn = await reader.get('/api/v1/posts').query({ q: 'Mongo' })
+    expect(signedIn.body[0].gated).toBe(false)
+    expect(signedIn.text).not.toContain('Para three')
+  })
+})
+
 describe('POST /api/v1/posts', () => {
   it('creates a post for a signed-in user', async () => {
     const author = await signedInAgent(app(), 'author')

--- a/apps/server/src/routes/v1/posts.ts
+++ b/apps/server/src/routes/v1/posts.ts
@@ -17,8 +17,21 @@ export const postsRouter = Router()
 const loadPostOwner = (req: Request<{ slug: string }>) =>
   postService.findBySlugForOwnerCheck(req.params.slug)
 
+/**
+ * Query params arrive as `string | string[] | ParsedQs`, so each filter is
+ * narrowed to a plain string and anything else dropped. Trimming, the
+ * empty-term guard and the matching itself all belong to the service.
+ */
+const stringParam = (value: Request['query'][string]) =>
+  typeof value === 'string' ? value : undefined
+
 postsRouter.get('/', async (req, res) => {
-  res.json(await postService.list(req.session?.userId))
+  res.json(
+    await postService.list(req.session?.userId, {
+      q: stringParam(req.query.q),
+      tag: stringParam(req.query.tag),
+    }),
+  )
 })
 
 postsRouter.post('/', requireAuth, validate(CreatePostSchema), async (req, res) => {


### PR DESCRIPTION
## What

Full-text search over posts, backed by MongoDB's text index. The legacy app filtered an
array it had already downloaded, so it only ever searched the page in the browser; this
moves the matching into the database.

Trimmed P5 — search only. Cloudinary/avatars are explicitly out of scope.

## Server

- `postService.list(viewerId, { q, tag })`
  - `q` runs as `$text` against the **existing** `{ title, body }` index on the Post model
    (no new index) and sorts by `textScore`; no term keeps the newest-first sort.
  - `tag` matches the `tags` array. Given both, the two filter keys AND.
  - Both are trimmed and dropped when empty. MongoDB rejects `$text: { $search: '' }`, so
    `?q=` has to degrade to the unfiltered feed rather than 500 — that guard is the one
    non-obvious part of this change and it is asserted at both the service and HTTP layers.
- `GET /api/v1/posts` narrows `?q=` / `?tag=` to plain strings and delegates. Gating and
  teasing are untouched: a filtered feed is teased and gated exactly as the full feed is,
  which the route tests assert for anonymous and signed-in readers alike.

### Legacy bug fix

`toDto` now null-coalesces `post.body`. A document reachable through the API with no `body`
made `deriveTeaser(undefined)` throw and took the whole feed down (legacy `postsList.jsx:12`).
The regression test inserts exactly such a document via `PostModel.collection.insertOne` —
deliberately past the Mongoose validator — and asserts both the plain and the searched list
resolve.

## Client

- **Query keys restructured.** `queryKeys.posts.list` was a bare tuple doing double duty as
  a query key and as four call sites' invalidation target. Now `posts.all` is the
  invalidation target and `posts.list(params)` the query key, so each search term caches on
  its own while every mutation still drops them all. This is behaviourally identical —
  TanStack's fuzzy prefix match already covered every nested key under the old bare tuple —
  just correctly named.
- `postsApi.list(params)` builds the query string with `URLSearchParams`, omitting
  blank/whitespace-only filters.
- New `useDebouncedValue` hook and a dumb controlled `SearchBar`.
- `BlogFeedPage` holds the term in the URL via `useSearchParams` (bookmarkable, shareable,
  survives reload; `replace` so typing doesn't fill the history stack) and debounces it into
  `usePosts` — one request per pause, not per keystroke. `keepPreviousData` stops the feed
  blinking to skeletons on each new term, and the search box sits outside every branch so it
  stays on screen when a search returns nothing.

## Test plan

`npm run typecheck && npm run lint && npm run build && npm run test` — all green,
**209 tests across 26 files** (26 new).

New coverage:
- `postService.list` — match by title, match by body, no match, empty/whitespace term,
  tag-only, `q`+`tag` AND, filtered results still teased and gated (7).
- `postService.list` — body-less document does not crash the plain or the searched feed (2).
- `GET /api/v1/posts` — `?q=` filters, empty result, `?q=` behaves as no filter, `?tag=`
  and the combination, search results teased/gated for both reader kinds (5).
- `postsApi.list` — bare path, `?q=`, both filters, whitespace-only dropped, encoding (5).
- `useDebouncedValue` — initial value, withheld until the delay, timer reset on a rapid
  second change (3).
- `SearchBar` — renders the value, forwards input, stays controlled, stays labelled (4).

`npm run test:e2e` was **not** run locally (a parallel worktree was holding the same host
ports); relying on CI's isolated `e2e-smoke` job.

No new dependencies, no infra/Docker/CI changes.
