### PR TITLE
Threaded comments with a Markdown editor and preview

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -18,7 +18,9 @@
     "lucide-react": "^1.25.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0",
     "react-router": "^8.3.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0"
   },

--- a/apps/client/src/api/comments.ts
+++ b/apps/client/src/api/comments.ts
@@ -1,0 +1,32 @@
+import { request } from './client.js'
+import type { CreateComment, UpdateComment } from '@blog/zod-shared'
+
+export type Comment = {
+  id: string
+  body: string
+  author: { id: string; username: string }
+  /** null for a root comment, the parent comment's id for a reply. */
+  parent: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+const base = (slug: string) => `/api/v1/posts/${slug}/comments`
+
+export const commentsApi = {
+  // No `gated` here and none expected: the wall is on post bodies only, so this
+  // returns the same payload signed in or not.
+  list: (slug: string) => request<Comment[]>(base(slug)),
+
+  create: (slug: string, input: CreateComment) =>
+    request<Comment>(base(slug), { method: 'POST', body: JSON.stringify(input) }),
+
+  update: (slug: string, commentId: string, input: UpdateComment) =>
+    request<Comment>(`${base(slug)}/${commentId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    }),
+
+  remove: (slug: string, commentId: string) =>
+    request<void>(`${base(slug)}/${commentId}`, { method: 'DELETE' }),
+}

--- a/apps/client/src/components/patterns/CommentForm.test.tsx
+++ b/apps/client/src/components/patterns/CommentForm.test.tsx
@@ -2,7 +2,7 @@
 // never runs — every client test file wires jest-dom and cleanup itself, as
 // apps/client/src/components/patterns/AutoForm.test.tsx does.
 import '@testing-library/jest-dom/vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CommentForm } from './CommentForm.js'
 
@@ -60,18 +60,32 @@ describe('CommentForm', () => {
     expect(container.querySelector('script')).toBeNull()
   })
 
-  it('clears a fresh box after a successful submit', () => {
-    render(<CommentForm onSubmit={vi.fn()} />)
+  it('clears a fresh box once the submit has resolved', async () => {
+    render(<CommentForm onSubmit={vi.fn().mockResolvedValue(undefined)} />)
     type('Posted.')
     fireEvent.click(screen.getByText('Comment', { selector: 'button' }))
 
-    expect(screen.getByLabelText('Comment')).toHaveValue('')
+    await waitFor(() => expect(screen.getByLabelText('Comment')).toHaveValue(''))
   })
 
-  it('keeps the text when editing an existing comment — clearing would look like data loss', () => {
-    render(<CommentForm onSubmit={vi.fn()} initialValue="Original." submitLabel="Save" />)
+  // The box is the only copy of what the reader typed. Emptying it before the
+  // server answers destroys it on any 500, network drop, or expired session.
+  it('KEEPS the draft when the submit fails', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('boom'))
+    render(<CommentForm onSubmit={onSubmit} />)
+    type('Hard-won paragraphs.')
+    fireEvent.click(screen.getByText('Comment', { selector: 'button' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    expect(screen.getByLabelText('Comment')).toHaveValue('Hard-won paragraphs.')
+  })
+
+  it('keeps the text when editing an existing comment — clearing would look like data loss', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<CommentForm onSubmit={onSubmit} initialValue="Original." submitLabel="Save" />)
     fireEvent.click(screen.getByText('Save'))
 
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
     expect(screen.getByLabelText('Comment')).toHaveValue('Original.')
   })
 

--- a/apps/client/src/components/patterns/CommentForm.test.tsx
+++ b/apps/client/src/components/patterns/CommentForm.test.tsx
@@ -1,0 +1,87 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/AutoForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CommentForm } from './CommentForm.js'
+
+const type = (value: string) =>
+  fireEvent.change(screen.getByLabelText('Comment'), { target: { value } })
+
+describe('CommentForm', () => {
+  afterEach(() => cleanup())
+
+  it('hands onSubmit the PARSED body, trimmed by the shared schema', () => {
+    const onSubmit = vi.fn()
+    render(<CommentForm onSubmit={onSubmit} />)
+
+    type('  Nice post.  ')
+    fireEvent.click(screen.getByText('Comment', { selector: 'button' }))
+
+    expect(onSubmit).toHaveBeenCalledWith('Nice post.')
+  })
+
+  it('blocks an empty comment and shows the schema message inline', () => {
+    const onSubmit = vi.fn()
+    render(<CommentForm onSubmit={onSubmit} />)
+
+    type('   ')
+    fireEvent.click(screen.getByText('Comment', { selector: 'button' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    // The message comes from CreateCommentSchema, not from a string duplicated here.
+    expect(screen.getByText('Comment cannot be empty')).toBeInTheDocument()
+  })
+
+  it('renders the draft as Markdown once Preview is selected', () => {
+    render(<CommentForm onSubmit={vi.fn()} />)
+    type('# Heading')
+    fireEvent.click(screen.getByRole('tab', { name: 'Preview' }))
+
+    expect(screen.getByRole('heading', { name: 'Heading' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Comment')).not.toBeInTheDocument()
+  })
+
+  it('keeps the draft when switching back to Write', () => {
+    render(<CommentForm onSubmit={vi.fn()} />)
+    type('draft text')
+    fireEvent.click(screen.getByRole('tab', { name: 'Preview' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Write' }))
+
+    expect(screen.getByLabelText('Comment')).toHaveValue('draft text')
+  })
+
+  it('never previews raw HTML as a live element', () => {
+    const { container } = render(<CommentForm onSubmit={vi.fn()} />)
+    type('<script>alert(1)</script>')
+    fireEvent.click(screen.getByRole('tab', { name: 'Preview' }))
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('clears a fresh box after a successful submit', () => {
+    render(<CommentForm onSubmit={vi.fn()} />)
+    type('Posted.')
+    fireEvent.click(screen.getByText('Comment', { selector: 'button' }))
+
+    expect(screen.getByLabelText('Comment')).toHaveValue('')
+  })
+
+  it('keeps the text when editing an existing comment — clearing would look like data loss', () => {
+    render(<CommentForm onSubmit={vi.fn()} initialValue="Original." submitLabel="Save" />)
+    fireEvent.click(screen.getByText('Save'))
+
+    expect(screen.getByLabelText('Comment')).toHaveValue('Original.')
+  })
+
+  it('shows Cancel only when the caller can handle it', () => {
+    const onCancel = vi.fn()
+    const { rerender } = render(<CommentForm onSubmit={vi.fn()} />)
+    expect(screen.queryByText('Cancel')).not.toBeInTheDocument()
+
+    rerender(<CommentForm onSubmit={vi.fn()} onCancel={onCancel} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/apps/client/src/components/patterns/CommentForm.tsx
+++ b/apps/client/src/components/patterns/CommentForm.tsx
@@ -1,0 +1,109 @@
+import { useState, type FormEvent } from 'react'
+import { CreateCommentSchema } from '@blog/zod-shared'
+import { Button } from '../ui/button.js'
+import { Textarea } from '../ui/textarea.js'
+import { MarkdownPreview } from './MarkdownPreview.js'
+
+type Mode = 'write' | 'preview'
+
+/**
+ * The comment composer. Not built on AutoForm on purpose: AutoForm renders one
+ * control per schema key, which cannot hide `parent` (a reply still has to send
+ * it) and has nowhere to put a Write/Preview toggle. What it does reuse is
+ * AutoForm's contract — validate against the shared schema, show the first Zod
+ * issue inline, and hand `onSubmit` the PARSED value, never the raw textarea
+ * string. So the rule the server enforces and the rule the form enforces are
+ * the same one, in @blog/zod-shared.
+ */
+export function CommentForm({
+  onSubmit,
+  initialValue = '',
+  submitLabel = 'Comment',
+  isPending = false,
+  onCancel,
+  autoFocus = false,
+}: {
+  onSubmit: (body: string) => void
+  initialValue?: string
+  submitLabel?: string
+  isPending?: boolean
+  onCancel?: () => void
+  autoFocus?: boolean
+}) {
+  const [body, setBody] = useState(initialValue)
+  const [mode, setMode] = useState<Mode>('write')
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    // Only the `body` field: `parent` is decided by which reply box this is, not
+    // by anything the user typed, so it is never part of what gets validated here.
+    const result = CreateCommentSchema.shape.body.safeParse(body)
+    if (!result.success) {
+      setError(result.error.issues[0]?.message ?? 'Invalid comment.')
+      return
+    }
+    setError(null)
+    onSubmit(result.data)
+    // A fresh box after a successful submit — but only when this form is not
+    // seeded with existing text, where clearing would look like data loss.
+    if (!initialValue) setBody('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <div role="tablist" aria-label="Comment editor" className="flex gap-2 text-sm">
+        {(['write', 'preview'] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={mode === tab}
+            onClick={() => setMode(tab)}
+            className={
+              mode === tab
+                ? 'rounded px-2 py-1 font-medium text-[var(--primary)] underline'
+                : 'rounded px-2 py-1 text-[var(--muted-foreground)]'
+            }
+          >
+            {tab === 'write' ? 'Write' : 'Preview'}
+          </button>
+        ))}
+      </div>
+
+      {mode === 'write' ? (
+        <Textarea
+          aria-label="Comment"
+          placeholder="Write a comment — Markdown supported"
+          value={body}
+          autoFocus={autoFocus}
+          onChange={(e) => setBody(e.target.value)}
+        />
+      ) : (
+        <div
+          role="tabpanel"
+          className="min-h-32 rounded-md border border-[var(--border)] p-3 text-sm"
+        >
+          {body.trim() ? (
+            <MarkdownPreview source={body} />
+          ) : (
+            <p className="text-[var(--muted-foreground)]">Nothing to preview yet.</p>
+          )}
+        </div>
+      )}
+
+      {error && <p className="text-sm text-[var(--destructive)]">{error}</p>}
+
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={isPending}>
+          {submitLabel}
+        </Button>
+        {onCancel && (
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/apps/client/src/components/patterns/CommentForm.tsx
+++ b/apps/client/src/components/patterns/CommentForm.tsx
@@ -23,7 +23,7 @@ export function CommentForm({
   onCancel,
   autoFocus = false,
 }: {
-  onSubmit: (body: string) => void
+  onSubmit: (body: string) => void | Promise<unknown>
   initialValue?: string
   submitLabel?: string
   isPending?: boolean
@@ -44,10 +44,21 @@ export function CommentForm({
       return
     }
     setError(null)
-    onSubmit(result.data)
-    // A fresh box after a successful submit — but only when this form is not
-    // seeded with existing text, where clearing would look like data loss.
-    if (!initialValue) setBody('')
+
+    // Emptied only once the submit has actually SUCCEEDED. `onSubmit` fires a
+    // mutation, so clearing synchronously would throw away paragraphs of the
+    // reader's text the moment the request 500s or the session has expired —
+    // and the toast that follows offers no way to get them back.
+    // The rejection is swallowed on purpose: the caller already reports it, and
+    // all this handler needs to know is "do not clear".
+    void Promise.resolve(onSubmit(result.data)).then(
+      () => {
+        // Not when the form is seeded with existing text: on an edit, an empty
+        // box would read as data loss rather than as a fresh composer.
+        if (!initialValue) setBody('')
+      },
+      () => {},
+    )
   }
 
   return (

--- a/apps/client/src/components/patterns/CommentSection.test.tsx
+++ b/apps/client/src/components/patterns/CommentSection.test.tsx
@@ -1,0 +1,68 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/AutoForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CommentSection } from './CommentSection.js'
+import { queryKeys } from '../../lib/query-client.js'
+import type { AuthUser } from '../../hooks/use-auth.js'
+import type { Comment } from '../../api/comments.js'
+
+const comment: Comment = {
+  id: 'c1',
+  body: 'Nice post.',
+  author: { id: 'u1', username: 'demo' },
+  parent: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function renderSection(me: AuthUser | null, comments: Comment[] = [comment]) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+  client.setQueryData(queryKeys.me, me)
+  client.setQueryData(queryKeys.comments.list('my-post'), comments)
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <CommentSection slug="my-post" />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('CommentSection', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the thread and a composer to a signed-in reader', async () => {
+    renderSection({ id: 'u2', username: 'reader' })
+    await waitFor(() => expect(screen.getByText('Nice post.')).toBeInTheDocument())
+    expect(screen.getByLabelText('Comment')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Sign in' })).not.toBeInTheDocument()
+  })
+
+  // The post body may be teased for this reader, but the discussion is not
+  // walled — what they lose is the ability to write, not to read.
+  it('still shows the thread to an anonymous reader, with a sign-in prompt instead of a box', async () => {
+    renderSection(null)
+    await waitFor(() => expect(screen.getByText('Nice post.')).toBeInTheDocument())
+    expect(screen.queryByLabelText('Comment')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', '/login')
+  })
+
+  it('says so when nothing has been posted yet', async () => {
+    renderSection(null, [])
+    await waitFor(() => expect(screen.getByText('No comments yet.')).toBeInTheDocument())
+    expect(screen.getByText('Comments (0)')).toBeInTheDocument()
+  })
+})

--- a/apps/client/src/components/patterns/CommentSection.tsx
+++ b/apps/client/src/components/patterns/CommentSection.tsx
@@ -1,0 +1,64 @@
+import { Link } from 'react-router'
+import { toast } from 'sonner'
+import { ApiError } from '../../api/client.js'
+import { useMe } from '../../hooks/use-auth.js'
+import { useComments, useCreateComment } from '../../hooks/use-comments.js'
+import { Skeleton } from '../ui/skeleton.js'
+import { CommentForm } from './CommentForm.js'
+import { buildCommentTree, CommentThread } from './CommentThread.js'
+
+/**
+ * The discussion under a post.
+ *
+ * Rendered for gated readers too: the post body may be a teaser, but the thread
+ * is not walled — the server serves it whole to anyone. What an anonymous
+ * reader loses is the ability to *write*, which is a 401 on the API and a
+ * sign-in prompt here.
+ */
+export function CommentSection({ slug }: { slug: string }) {
+  const { data: me } = useMe()
+  const { data: comments, isPending, isError } = useComments(slug)
+  const createComment = useCreateComment(slug)
+
+  return (
+    <section className="flex flex-col gap-4 border-t border-[var(--border)] pt-6">
+      <h2 className="text-lg font-semibold">
+        Comments{comments ? ` (${comments.length})` : ''}
+      </h2>
+
+      {me ? (
+        <CommentForm
+          isPending={createComment.isPending}
+          onSubmit={(body) =>
+            createComment.mutate(
+              { body },
+              {
+                onError: (err) =>
+                  toast.error(
+                    err instanceof ApiError ? err.message : 'Could not post your comment.',
+                  ),
+              },
+            )
+          }
+        />
+      ) : (
+        <p className="rounded bg-[var(--muted)] p-4 text-sm">
+          <Link to="/login" className="text-[var(--primary)] underline">
+            Sign in
+          </Link>{' '}
+          to join the discussion.
+        </p>
+      )}
+
+      {isPending ? (
+        <Skeleton className="h-24" />
+      ) : isError ? (
+        <p className="text-sm text-[var(--muted-foreground)]">Could not load the comments.</p>
+      ) : comments && comments.length > 0 ? (
+        <CommentThread slug={slug} comments={buildCommentTree(comments)} />
+      ) : (
+        <p className="text-sm text-[var(--muted-foreground)]">No comments yet.</p>
+      )}
+    </section>
+  )
+}

--- a/apps/client/src/components/patterns/CommentSection.tsx
+++ b/apps/client/src/components/patterns/CommentSection.tsx
@@ -29,8 +29,10 @@ export function CommentSection({ slug }: { slug: string }) {
       {me ? (
         <CommentForm
           isPending={createComment.isPending}
+          // mutateAsync, not mutate: the form clears its box only when the
+          // returned promise resolves, so a failed post keeps the draft.
           onSubmit={(body) =>
-            createComment.mutate(
+            createComment.mutateAsync(
               { body },
               {
                 onError: (err) =>

--- a/apps/client/src/components/patterns/CommentThread.test.tsx
+++ b/apps/client/src/components/patterns/CommentThread.test.tsx
@@ -1,0 +1,150 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/AutoForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildCommentTree, CommentThread } from './CommentThread.js'
+import { queryKeys } from '../../lib/query-client.js'
+import type { AuthUser } from '../../hooks/use-auth.js'
+import type { Comment } from '../../api/comments.js'
+
+const at = '2026-01-01T00:00:00.000Z'
+
+const make = (id: string, parent: string | null = null, authorId = 'u1'): Comment => ({
+  id,
+  body: `body ${id}`,
+  author: { id: authorId, username: `user-${authorId}` },
+  parent,
+  createdAt: at,
+  updatedAt: at,
+})
+
+describe('buildCommentTree', () => {
+  it('nests replies under their parent', () => {
+    const tree = buildCommentTree([make('a'), make('b', 'a'), make('c', 'b')])
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.replies[0]!.id).toBe('b')
+    expect(tree[0]!.replies[0]!.replies[0]!.id).toBe('c')
+  })
+
+  it('keeps roots in the order the server sent them', () => {
+    expect(buildCommentTree([make('a'), make('b'), make('c')]).map((n) => n.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+
+  // Mid-delete the cache can still hold a reply whose parent is already gone.
+  // Dropping it would make a comment that still exists on the server invisible.
+  it('promotes an orphan to a root rather than losing it', () => {
+    const tree = buildCommentTree([make('a'), make('orphan', 'deleted-parent')])
+    expect(tree.map((n) => n.id)).toEqual(['a', 'orphan'])
+  })
+
+  it('returns an empty tree for an empty thread', () => {
+    expect(buildCommentTree([])).toEqual([])
+  })
+
+  it('does not mutate the comments it was given', () => {
+    const input = [make('a'), make('b', 'a')]
+    buildCommentTree(input)
+    expect(input[0]).not.toHaveProperty('replies')
+  })
+})
+
+function renderThread(comments: Comment[], me: AuthUser | null) {
+  const client = new QueryClient({
+    // staleTime keeps the seeded identity from being refetched over a network
+    // that is not stubbed in the tests that do not care about it.
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+  client.setQueryData(queryKeys.me, me)
+  return render(
+    <QueryClientProvider client={client}>
+      <CommentThread slug="my-post" comments={buildCommentTree(comments)} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('CommentThread', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders every comment in the tree, at any depth', () => {
+    renderThread([make('a'), make('b', 'a')], null)
+    expect(screen.getByText('body a')).toBeInTheDocument()
+    expect(screen.getByText('body b')).toBeInTheDocument()
+  })
+
+  it('renders comment bodies as Markdown, never as raw HTML', () => {
+    const evil = { ...make('a'), body: '<script>alert(1)</script>' }
+    const { container } = renderThread([evil], null)
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('offers Edit and Delete to the comment author only', () => {
+    renderThread([make('a', null, 'u1'), make('b', null, 'u2')], { id: 'u1', username: 'user-u1' })
+    expect(screen.getAllByText('Edit')).toHaveLength(1)
+    expect(screen.getAllByText('Delete')).toHaveLength(1)
+  })
+
+  it('offers neither to an anonymous reader, who also cannot reply', () => {
+    renderThread([make('a')], null)
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reply')).not.toBeInTheDocument()
+  })
+
+  it('lets any signed-in reader reply, not just the author', () => {
+    renderThread([make('a', null, 'u1')], { id: 'u2', username: 'user-u2' })
+    expect(screen.getByText('Reply')).toBeInTheDocument()
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
+
+  it('reveals a nested composer when Reply is clicked', () => {
+    renderThread([make('a')], { id: 'u1', username: 'user-u1' })
+    expect(screen.queryByLabelText('Comment')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Reply'))
+    expect(screen.getByLabelText('Comment')).toBeInTheDocument()
+    expect(screen.getByText('Reply', { selector: 'button[type="submit"]' })).toBeInTheDocument()
+  })
+
+  it('swaps the body for an editor seeded with the current text', () => {
+    renderThread([make('a')], { id: 'u1', username: 'user-u1' })
+    fireEvent.click(screen.getByText('Edit'))
+
+    expect(screen.getByLabelText('Comment')).toHaveValue('body a')
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('sends the parent id with a reply so the server nests it', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(make('new', 'a')), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderThread([make('a')], { id: 'u1', username: 'user-u1' })
+    fireEvent.click(screen.getByText('Reply'))
+    fireEvent.change(screen.getByLabelText('Comment'), { target: { value: 'Replying.' } })
+    fireEvent.click(screen.getByText('Reply', { selector: 'button[type="submit"]' }))
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('/api/v1/posts/my-post/comments')
+    expect(JSON.parse(init.body as string)).toEqual({ body: 'Replying.', parent: 'a' })
+  })
+})

--- a/apps/client/src/components/patterns/CommentThread.tsx
+++ b/apps/client/src/components/patterns/CommentThread.tsx
@@ -64,7 +64,7 @@ function CommentItem({ slug, node, depth }: { slug: string; node: CommentNode; d
             isPending={updateComment.isPending}
             onCancel={() => setEditing(false)}
             onSubmit={(body) =>
-              updateComment.mutate(
+              updateComment.mutateAsync(
                 { id: node.id, body },
                 {
                   onSuccess: () => setEditing(false),
@@ -114,8 +114,10 @@ function CommentItem({ slug, node, depth }: { slug: string; node: CommentNode; d
           submitLabel="Reply"
           isPending={createComment.isPending}
           onCancel={() => setReplying(false)}
+          // mutateAsync, not mutate: the form keeps the draft unless the promise
+          // resolves, so a rejected reply is not silently thrown away.
           onSubmit={(body) =>
-            createComment.mutate(
+            createComment.mutateAsync(
               { body, parent: node.id },
               {
                 onSuccess: () => setReplying(false),

--- a/apps/client/src/components/patterns/CommentThread.tsx
+++ b/apps/client/src/components/patterns/CommentThread.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { ApiError } from '../../api/client.js'
+import { useMe } from '../../hooks/use-auth.js'
+import { useCreateComment, useDeleteComment, useUpdateComment } from '../../hooks/use-comments.js'
+import { Button } from '../ui/button.js'
+import { CommentForm } from './CommentForm.js'
+import { MarkdownPreview } from './MarkdownPreview.js'
+import type { Comment } from '../../api/comments.js'
+
+export type CommentNode = Comment & { replies: CommentNode[] }
+
+/**
+ * Turns the flat list the API returns into a tree, in one pass.
+ *
+ * Two passes over a Map rather than a filter-per-node walk, which would be
+ * O(n²) on a busy thread. A comment whose `parent` does not resolve is promoted
+ * to a root instead of being dropped: mid-delete the cache can hold a reply
+ * whose parent is already gone, and silently swallowing it would make a comment
+ * that still exists on the server invisible on the page.
+ */
+export function buildCommentTree(comments: Comment[]): CommentNode[] {
+  const byId = new Map<string, CommentNode>(comments.map((c) => [c.id, { ...c, replies: [] }]))
+  const roots: CommentNode[] = []
+
+  for (const comment of comments) {
+    const node = byId.get(comment.id)!
+    const parent = comment.parent ? byId.get(comment.parent) : undefined
+    if (parent) parent.replies.push(node)
+    else roots.push(node)
+  }
+
+  return roots
+}
+
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof ApiError ? err.message : fallback
+}
+
+function CommentItem({ slug, node, depth }: { slug: string; node: CommentNode; depth: number }) {
+  const { data: me } = useMe()
+  const [replying, setReplying] = useState(false)
+  const [editing, setEditing] = useState(false)
+
+  const createComment = useCreateComment(slug)
+  const updateComment = useUpdateComment(slug)
+  const deleteComment = useDeleteComment(slug)
+
+  // Ownership is a UI affordance only. The server re-checks it with
+  // requireOwner, so hiding these buttons hides nothing that matters.
+  const isOwner = Boolean(me) && me?.id === node.author.id
+
+  return (
+    <li className="flex flex-col gap-2">
+      <article className="flex flex-col gap-1 rounded-md border border-[var(--border)] p-3">
+        <header className="text-xs text-[var(--muted-foreground)]">
+          {node.author.username} · {new Date(node.createdAt).toLocaleDateString()}
+        </header>
+
+        {editing ? (
+          <CommentForm
+            initialValue={node.body}
+            submitLabel="Save"
+            isPending={updateComment.isPending}
+            onCancel={() => setEditing(false)}
+            onSubmit={(body) =>
+              updateComment.mutate(
+                { id: node.id, body },
+                {
+                  onSuccess: () => setEditing(false),
+                  onError: (err) => toast.error(errorMessage(err, 'Could not save the comment.')),
+                },
+              )
+            }
+          />
+        ) : (
+          <MarkdownPreview source={node.body} />
+        )}
+
+        {!editing && (
+          <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]">
+            {me && (
+              <button type="button" className="underline" onClick={() => setReplying((r) => !r)}>
+                Reply
+              </button>
+            )}
+            {isOwner && (
+              <>
+                <button type="button" className="underline" onClick={() => setEditing(true)}>
+                  Edit
+                </button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={deleteComment.isPending}
+                  onClick={() =>
+                    deleteComment.mutate(node.id, {
+                      onError: (err) =>
+                        toast.error(errorMessage(err, 'Could not delete the comment.')),
+                    })
+                  }
+                >
+                  Delete
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </article>
+
+      {replying && (
+        <CommentForm
+          autoFocus
+          submitLabel="Reply"
+          isPending={createComment.isPending}
+          onCancel={() => setReplying(false)}
+          onSubmit={(body) =>
+            createComment.mutate(
+              { body, parent: node.id },
+              {
+                onSuccess: () => setReplying(false),
+                onError: (err) => toast.error(errorMessage(err, 'Could not post the reply.')),
+              },
+            )
+          }
+        />
+      )}
+
+      {node.replies.length > 0 && (
+        <CommentThread slug={slug} comments={node.replies} depth={depth + 1} />
+      )}
+    </li>
+  )
+}
+
+/**
+ * Renders one level of the thread and recurses. `comments` is already a tree at
+ * every level below the first; the top-level caller passes roots from
+ * buildCommentTree.
+ */
+export function CommentThread({
+  slug,
+  comments,
+  depth = 0,
+}: {
+  slug: string
+  comments: CommentNode[]
+  depth?: number
+}) {
+  return (
+    <ul className={depth > 0 ? 'flex flex-col gap-3 border-l border-[var(--border)] pl-4' : 'flex flex-col gap-3'}>
+      {comments.map((node) => (
+        <CommentItem key={node.id} slug={slug} node={node} depth={depth} />
+      ))}
+    </ul>
+  )
+}

--- a/apps/client/src/components/patterns/MarkdownPreview.test.tsx
+++ b/apps/client/src/components/patterns/MarkdownPreview.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MarkdownPreview } from './MarkdownPreview.js'
+
+describe('MarkdownPreview', () => {
+  afterEach(() => cleanup())
+
+  it('renders Markdown as elements, not as text', () => {
+    render(<MarkdownPreview source={'# Heading\n\nSome **bold** text.'} />)
+    expect(screen.getByRole('heading', { name: 'Heading' })).toBeInTheDocument()
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+  })
+
+  it('supports GFM tables and strikethrough', () => {
+    render(<MarkdownPreview source={'| a | b |\n| - | - |\n| 1 | 2 |\n\n~~gone~~'} />)
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('gone').tagName).toBe('DEL')
+  })
+
+  // THE security test. rehype-raw is deliberately not installed, so raw HTML in
+  // the source is inert text — never a node the browser will execute. If someone
+  // adds rehype-raw to "support a little HTML", this fails, which is the point.
+  it('never turns a <script> in the source into a script element', () => {
+    const { container } = render(
+      <MarkdownPreview source={'Hello <script>alert(1)</script> world'} />,
+    )
+    expect(container.querySelector('script')).toBeNull()
+    // And it survived as visible text rather than silently vanishing.
+    expect(container.textContent).toContain('alert(1)')
+  })
+
+  it('does not execute an img onerror handler smuggled through as HTML', () => {
+    const { container } = render(
+      <MarkdownPreview source={'<img src="x" onerror="alert(1)" />'} />,
+    )
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('does not render an iframe smuggled through as HTML', () => {
+    const { container } = render(<MarkdownPreview source={'<iframe src="evil"></iframe>'} />)
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+})

--- a/apps/client/src/components/patterns/MarkdownPreview.test.tsx
+++ b/apps/client/src/components/patterns/MarkdownPreview.test.tsx
@@ -37,6 +37,20 @@ describe('MarkdownPreview', () => {
     expect(container.querySelector('img')).toBeNull()
   })
 
+  // The other half of the sanitization contract, and the half that comes from a
+  // library default rather than from an omitted plugin: react-markdown's
+  // urlTransform drops any protocol outside its safelist. Asserted here so that
+  // passing a custom `urlTransform` later cannot silently reopen this.
+  it('strips a javascript: url from a link', () => {
+    const { container } = render(<MarkdownPreview source={'[click](javascript:alert(1))'} />)
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('')
+  })
+
+  it('keeps an ordinary https link intact', () => {
+    const { container } = render(<MarkdownPreview source={'[docs](https://example.com)'} />)
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com')
+  })
+
   it('does not render an iframe smuggled through as HTML', () => {
     const { container } = render(<MarkdownPreview source={'<iframe src="evil"></iframe>'} />)
     expect(container.querySelector('iframe')).toBeNull()

--- a/apps/client/src/components/patterns/MarkdownPreview.tsx
+++ b/apps/client/src/components/patterns/MarkdownPreview.tsx
@@ -1,0 +1,24 @@
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+/**
+ * Renders untrusted Markdown.
+ *
+ * `rehype-raw` is deliberately absent. Without it react-markdown never parses
+ * embedded HTML into nodes, so a `<script>` (or an `onerror` attribute, or an
+ * `<iframe>`) in a comment body arrives as literal text and is escaped on the
+ * way into the DOM. Adding rehype-raw to "support a bit of HTML" would turn
+ * every comment box in the app into a stored-XSS sink — that is the whole
+ * reason this component exists instead of a bare <Markdown> at each call site.
+ *
+ * `remark-gfm` is safe by contrast: it only adds tables, strikethrough,
+ * task lists and autolinks to the Markdown grammar, all of which still produce
+ * ordinary React elements.
+ */
+export function MarkdownPreview({ source }: { source: string }) {
+  return (
+    <div className="flex flex-col gap-2 text-sm [&_a]:underline [&_pre]:overflow-x-auto">
+      <Markdown remarkPlugins={[remarkGfm]}>{source}</Markdown>
+    </div>
+  )
+}

--- a/apps/client/src/hooks/use-comments.test.tsx
+++ b/apps/client/src/hooks/use-comments.test.tsx
@@ -1,0 +1,116 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useComments, useCreateComment, useDeleteComment, useUpdateComment } from './use-comments.js'
+import { queryKeys } from '../lib/query-client.js'
+import type { Comment } from '../api/comments.js'
+
+const comment: Comment = {
+  id: 'c1',
+  body: 'Nice post.',
+  author: { id: 'u1', username: 'demo' },
+  parent: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return { client, wrapper }
+}
+
+const jsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+
+function stubFetch(response: () => Response) {
+  // The parameters are declared so `fetchMock.mock.calls[n]` is a typed tuple
+  // rather than the empty one an argument-less vi.fn() infers.
+  const fetchMock = vi.fn((_url: string, _init: RequestInit) => Promise.resolve(response()))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('useComments', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches the thread for the post', async () => {
+    const fetchMock = stubFetch(() => jsonResponse([comment]))
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useComments('my-post'), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toEqual([comment]))
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/v1/posts/my-post/comments')
+  })
+
+  it('does not fire without a slug', () => {
+    const fetchMock = stubFetch(() => jsonResponse([]))
+    const { wrapper } = makeWrapper()
+    renderHook(() => useComments(''), { wrapper })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// Invalidate, never patch: a create needs the server-assigned id that replies
+// hang off, and a delete cascades to a subtree only the server can size.
+describe('comment mutations', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('useCreateComment POSTs the body and parent, then invalidates the list', async () => {
+    const fetchMock = stubFetch(() => jsonResponse(comment, 201))
+    const { client, wrapper } = makeWrapper()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCreateComment('my-post'), { wrapper })
+    result.current.mutate({ body: 'Reply.', parent: 'c1' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/v1/posts/my-post/comments')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ body: 'Reply.', parent: 'c1' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.comments.list('my-post') })
+  })
+
+  it('useUpdateComment PATCHes the comment url with the body only', async () => {
+    const fetchMock = stubFetch(() => jsonResponse({ ...comment, body: 'Edited.' }))
+    const { wrapper } = makeWrapper()
+
+    const { result } = renderHook(() => useUpdateComment('my-post'), { wrapper })
+    result.current.mutate({ id: 'c1', body: 'Edited.' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/v1/posts/my-post/comments/c1')
+    expect(init.method).toBe('PATCH')
+    // The id identifies the comment in the URL; it must not ride in the body too.
+    expect(JSON.parse(init.body as string)).toEqual({ body: 'Edited.' })
+  })
+
+  it('useDeleteComment DELETEs the comment url and invalidates the list', async () => {
+    const fetchMock = stubFetch(() => new Response(null, { status: 204 }))
+    const { client, wrapper } = makeWrapper()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+
+    const { result } = renderHook(() => useDeleteComment('my-post'), { wrapper })
+    result.current.mutate('c1')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/v1/posts/my-post/comments/c1')
+    expect(init.method).toBe('DELETE')
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.comments.list('my-post') })
+  })
+
+  it('surfaces a server error instead of swallowing it', async () => {
+    stubFetch(() => jsonResponse({ error: { message: 'nope' } }, 400))
+    const { wrapper } = makeWrapper()
+    const { result } = renderHook(() => useCreateComment('my-post'), { wrapper })
+    result.current.mutate({ body: 'x' })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})

--- a/apps/client/src/hooks/use-comments.ts
+++ b/apps/client/src/hooks/use-comments.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { CreateComment, UpdateComment } from '@blog/zod-shared'
+import { commentsApi } from '../api/comments.js'
+import { queryKeys } from '../lib/query-client.js'
+
+export function useComments(slug: string) {
+  return useQuery({
+    queryKey: queryKeys.comments.list(slug),
+    queryFn: () => commentsApi.list(slug),
+    enabled: Boolean(slug),
+  })
+}
+
+/**
+ * Every comment mutation invalidates the list and waits for the refetch, rather
+ * than patching the cache the way `useLikePost` does.
+ *
+ * A like moves one scalar, so an optimistic patch is trivially reversible. A
+ * comment changes the *shape* of the thread — a create needs a server-assigned
+ * id that replies will hang off, and a delete cascades to a subtree whose extent
+ * only the server knows. There is no cheap patch that is also correct, which is
+ * the same reason `useDeletePost` invalidates instead of guessing.
+ */
+function useCommentMutation<TInput>(slug: string, mutationFn: (input: TInput) => Promise<unknown>) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.comments.list(slug) }),
+  })
+}
+
+export function useCreateComment(slug: string) {
+  return useCommentMutation(slug, (input: CreateComment) => commentsApi.create(slug, input))
+}
+
+export function useUpdateComment(slug: string) {
+  return useCommentMutation(slug, ({ id, ...input }: UpdateComment & { id: string }) =>
+    commentsApi.update(slug, id, input),
+  )
+}
+
+export function useDeleteComment(slug: string) {
+  return useCommentMutation(slug, (id: string) => commentsApi.remove(slug, id))
+}

--- a/apps/client/src/lib/query-client.ts
+++ b/apps/client/src/lib/query-client.ts
@@ -16,6 +16,12 @@ export const queryKeys = {
       detail: (slug: string) => ['posts', slug, 'likes'] as const,
     },
   },
+  // Deliberately NOT nested under ['posts', slug]: a comment payload does not
+  // depend on the viewer the way a post body does, so the auth transitions that
+  // invalidate ['posts'] have no reason to drop the thread as well.
+  comments: {
+    list: (slug: string) => ['comments', slug] as const,
+  },
   users: {
     detail: (id: string) => ['users', id] as const,
   },

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { ApiError } from '../api/client.js'
 import { usePost, useDeletePost } from '../hooks/use-posts.js'
 import { useMe } from '../hooks/use-auth.js'
+import { CommentSection } from '../components/patterns/CommentSection.js'
 import { EmptyState } from '../components/patterns/EmptyState.js'
 import { LikeButton } from '../components/patterns/LikeButton.js'
 import { Button } from '../components/ui/button.js'
@@ -82,6 +83,8 @@ export function PostPage() {
           </>
         )}
       </div>
+
+      <CommentSection slug={post.slug} />
     </article>
   )
 }

--- a/apps/server/src/lib/services/comment.test.ts
+++ b/apps/server/src/lib/services/comment.test.ts
@@ -63,6 +63,17 @@ describe('commentService.create', () => {
       commentService.create(slug, { body: 'Reply.', parent: ghost }, authorId),
     ).rejects.toThrow(ValidationError)
   })
+
+  // Without a cap a scripted client can chain replies without limit, and every
+  // later reader pays: the thread renders one nested component per level.
+  it('accepts a chain up to the depth limit and rejects the level past it', async () => {
+    let node = await comment('Root.')
+    for (let depth = 1; depth <= 10; depth++) {
+      node = await comment(`Level ${depth}.`, node.id)
+    }
+    await expect(commentService.create(slug, { body: 'Too deep.', parent: node.id }, authorId))
+      .rejects.toThrow(ValidationError)
+  })
 })
 
 describe('commentService.list', () => {
@@ -149,18 +160,35 @@ describe('commentService.removeAllForPost', () => {
   })
 })
 
-describe('commentService.findByIdForOwnerCheck', () => {
+describe('commentService.findForOwnerCheck', () => {
   it('returns the author id for requireOwner', async () => {
     const created = await comment('Mine.')
-    const found = await commentService.findByIdForOwnerCheck(created.id)
+    const found = await commentService.findForOwnerCheck(slug, created.id)
     expect(found!.author.toString()).toBe(authorId)
   })
 
   it('returns null for an unknown id so requireOwner can 404', async () => {
-    expect(await commentService.findByIdForOwnerCheck(new Types.ObjectId().toString())).toBeNull()
+    const ghost = new Types.ObjectId().toString()
+    expect(await commentService.findForOwnerCheck(slug, ghost)).toBeNull()
   })
 
   it('returns null for a malformed id rather than throwing a CastError', async () => {
-    expect(await commentService.findByIdForOwnerCheck('not-an-id')).toBeNull()
+    expect(await commentService.findForOwnerCheck(slug, 'not-an-id')).toBeNull()
+  })
+
+  // The URL claims the comment hangs off this post. A loader that ignored the
+  // slug would let an edit or a delete succeed through any post's URL.
+  it('returns null when the comment belongs to a DIFFERENT post', async () => {
+    const other = await postService.create(
+      { title: 'Another Title', body: 'Body.', tags: [] },
+      authorId,
+    )
+    const created = await comment('Mine.')
+    expect(await commentService.findForOwnerCheck(other.slug, created.id)).toBeNull()
+  })
+
+  it('returns null for an unknown post slug', async () => {
+    const created = await comment('Mine.')
+    expect(await commentService.findForOwnerCheck('nope', created.id)).toBeNull()
   })
 })

--- a/apps/server/src/lib/services/comment.test.ts
+++ b/apps/server/src/lib/services/comment.test.ts
@@ -1,0 +1,166 @@
+import { NotFoundError, ValidationError } from '../errors.js'
+import { CommentModel } from '../../models/comment.js'
+import { UserModel } from '../../models/user.js'
+import { Types } from 'mongoose'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useTestDb } from '../../test/helpers.js'
+import { commentService } from './comment.js'
+import { postService } from './post.js'
+
+useTestDb()
+
+let authorId: string
+let slug: string
+
+beforeEach(async () => {
+  const author = await UserModel.create({ username: 'author', email: 'a@example.com', password: 'x' })
+  authorId = author._id.toString()
+  const post = await postService.create({ title: 'A Fine Title', body: 'Body.', tags: [] }, authorId)
+  slug = post.slug
+})
+
+const comment = (body: string, parent?: string) =>
+  commentService.create(slug, { body, parent }, authorId)
+
+describe('commentService.create', () => {
+  it('attaches the caller as the author, never a body field', async () => {
+    const created = await comment('Nice post.')
+    expect(created.author.id).toBe(authorId)
+    expect(created.author.username).toBe('author')
+  })
+
+  it('creates a root comment with a null parent', async () => {
+    expect((await comment('Root.')).parent).toBeNull()
+  })
+
+  it('creates a reply carrying its parent id', async () => {
+    const root = await comment('Root.')
+    expect((await comment('Reply.', root.id)).parent).toBe(root.id)
+  })
+
+  it('throws NotFoundError for an unknown post slug', async () => {
+    await expect(commentService.create('nope', { body: 'hi' }, authorId)).rejects.toThrow(
+      NotFoundError,
+    )
+  })
+
+  it('rejects a parent that belongs to a different post', async () => {
+    const other = await postService.create(
+      { title: 'Another Title', body: 'Body.', tags: [] },
+      authorId,
+    )
+    const foreign = await commentService.create(other.slug, { body: 'Elsewhere.' }, authorId)
+
+    // 400, not 404: the post in the URL exists, so it is the input that is wrong.
+    const failure = commentService.create(slug, { body: 'Reply.', parent: foreign.id }, authorId)
+    await expect(failure).rejects.toThrow(ValidationError)
+    await expect(failure).rejects.toMatchObject({ fields: { parent: expect.any(Array) } })
+  })
+
+  it('rejects a parent that does not exist', async () => {
+    const ghost = new Types.ObjectId().toString()
+    await expect(
+      commentService.create(slug, { body: 'Reply.', parent: ghost }, authorId),
+    ).rejects.toThrow(ValidationError)
+  })
+})
+
+describe('commentService.list', () => {
+  it('returns the whole thread flat, oldest first', async () => {
+    const root = await comment('First.')
+    await comment('Reply.', root.id)
+    const all = await commentService.list(slug)
+    expect(all.map((c) => c.body)).toEqual(['First.', 'Reply.'])
+  })
+
+  it('does not leak comments from another post', async () => {
+    const other = await postService.create(
+      { title: 'Another Title', body: 'Body.', tags: [] },
+      authorId,
+    )
+    await commentService.create(other.slug, { body: 'Elsewhere.' }, authorId)
+    await comment('Here.')
+    expect((await commentService.list(slug)).map((c) => c.body)).toEqual(['Here.'])
+  })
+
+  it('throws NotFoundError for an unknown post slug', async () => {
+    await expect(commentService.list('nope')).rejects.toThrow(NotFoundError)
+  })
+})
+
+describe('commentService.update', () => {
+  it('replaces the body', async () => {
+    const created = await comment('Typo.')
+    expect((await commentService.update(created.id, { body: 'Fixed.' })).body).toBe('Fixed.')
+  })
+
+  it('leaves the parent alone — a comment is never re-parented', async () => {
+    const root = await comment('Root.')
+    const reply = await comment('Reply.', root.id)
+    expect((await commentService.update(reply.id, { body: 'Edited.' })).parent).toBe(root.id)
+  })
+
+  it('throws NotFoundError for a malformed id instead of a CastError 500', async () => {
+    await expect(commentService.update('not-an-id', { body: 'x' })).rejects.toThrow(NotFoundError)
+  })
+})
+
+describe('commentService.remove', () => {
+  it('deletes the entire reply subtree, not just the comment', async () => {
+    const root = await comment('Root.')
+    const child = await comment('Child.', root.id)
+    await comment('Grandchild.', child.id)
+
+    await commentService.remove(root.id)
+    expect(await CommentModel.countDocuments()).toBe(0)
+  })
+
+  it('deletes only itself when it is a leaf', async () => {
+    const root = await comment('Root.')
+    const child = await comment('Child.', root.id)
+
+    await commentService.remove(child.id)
+    expect((await commentService.list(slug)).map((c) => c.id)).toEqual([root.id])
+  })
+
+  it('leaves sibling subtrees standing', async () => {
+    const keep = await comment('Keep.')
+    await comment('Keep reply.', keep.id)
+    const drop = await comment('Drop.')
+    await comment('Drop reply.', drop.id)
+
+    await commentService.remove(drop.id)
+    expect((await commentService.list(slug)).map((c) => c.body)).toEqual(['Keep.', 'Keep reply.'])
+  })
+
+  it('throws NotFoundError for a malformed id instead of a CastError 500', async () => {
+    await expect(commentService.remove('not-an-id')).rejects.toThrow(NotFoundError)
+  })
+})
+
+describe('commentService.removeAllForPost', () => {
+  it('deletes every comment on the post at any depth', async () => {
+    const root = await comment('Root.')
+    await comment('Reply.', root.id)
+
+    const postId = (await CommentModel.findById(root.id))!.post
+    await commentService.removeAllForPost(postId)
+    expect(await CommentModel.countDocuments()).toBe(0)
+  })
+})
+
+describe('commentService.findByIdForOwnerCheck', () => {
+  it('returns the author id for requireOwner', async () => {
+    const created = await comment('Mine.')
+    const found = await commentService.findByIdForOwnerCheck(created.id)
+    expect(found!.author.toString()).toBe(authorId)
+  })
+
+  it('returns null for an unknown id so requireOwner can 404', async () => {
+    expect(await commentService.findByIdForOwnerCheck(new Types.ObjectId().toString())).toBeNull()
+  })
+
+  it('returns null for a malformed id rather than throwing a CastError', async () => {
+    expect(await commentService.findByIdForOwnerCheck('not-an-id')).toBeNull()
+  })
+})

--- a/apps/server/src/lib/services/comment.ts
+++ b/apps/server/src/lib/services/comment.ts
@@ -61,6 +61,36 @@ async function findById(commentId: string): Promise<HydratedDocument<Comment> | 
   return CommentModel.findById(commentId)
 }
 
+/**
+ * How deep a reply may sit under a root comment.
+ *
+ * A cap is required, not cosmetic: without one a scripted client can chain
+ * replies indefinitely, and every later reader pays for it — CommentThread
+ * renders one nested component per level, so a long enough chain overflows the
+ * stack of everyone who opens the post. The client indents to match.
+ */
+const MAX_DEPTH = 10
+
+/** Ancestor count of a comment: 0 for a root, 1 for a direct reply, and so on. */
+async function depthOf(comment: HydratedDocument<Comment>): Promise<number> {
+  if (!comment.parent) return 0
+  const [result] = await CommentModel.aggregate<{ depth: number }>([
+    { $match: { _id: comment._id } },
+    {
+      // The mirror of the cascade's walk: up the chain via `parent`, not down.
+      $graphLookup: {
+        from: CommentModel.collection.name,
+        startWith: '$parent',
+        connectFromField: 'parent',
+        connectToField: '_id',
+        as: 'ancestors',
+      },
+    },
+    { $project: { depth: { $size: '$ancestors' } } },
+  ])
+  return result?.depth ?? 0
+}
+
 export const commentService = {
   /**
    * The whole thread for a post, oldest first. Flat on the wire on purpose —
@@ -91,6 +121,13 @@ export const commentService = {
           console.warn('[COMMENT_SERVICE] rejected parent', { slug, parent: input.parent })
         throw new ValidationError('Invalid input.', {
           parent: ['Parent comment does not belong to this post'],
+        })
+      }
+      if ((await depthOf(parent)) + 1 > MAX_DEPTH) {
+        if (process.env.DEBUG)
+          console.warn('[COMMENT_SERVICE] rejected parent: too deep', { parent: input.parent })
+        throw new ValidationError('Invalid input.', {
+          parent: [`Replies can only be nested ${MAX_DEPTH} levels deep`],
         })
       }
     }
@@ -136,7 +173,10 @@ export const commentService = {
       { $match: { _id: root._id } },
       {
         $graphLookup: {
-          from: 'comments',
+          // Read off the model rather than hardcoded: a wrong collection name
+          // here fails SILENTLY — the pipeline returns no descendants and the
+          // cascade quietly degrades to deleting only the root.
+          from: CommentModel.collection.name,
           startWith: '$_id',
           connectFromField: '_id',
           connectToField: 'parent',
@@ -162,10 +202,23 @@ export const commentService = {
     await CommentModel.deleteMany({ post: postId })
   },
 
-  /** Loader for requireOwner. Returns only what the ownership check needs. */
-  async findByIdForOwnerCheck(commentId: string): Promise<{ author: Types.ObjectId } | null> {
+  /**
+   * Loader for requireOwner. Returns only what the ownership check needs.
+   *
+   * Scoped by slug as well as id, so a comment reached through the WRONG post's
+   * URL is a 404 rather than an edit or delete that silently succeeds. The URL
+   * claims a hierarchy; a nested resource that ignores its parent is lying, and
+   * the client would then invalidate the thread of a post that never changed.
+   */
+  async findForOwnerCheck(
+    slug: string,
+    commentId: string,
+  ): Promise<{ author: Types.ObjectId } | null> {
     if (!Types.ObjectId.isValid(commentId)) return null
-    const comment = await CommentModel.findById(commentId).select('author')
+    const post = await PostModel.findOne({ slug }).select('_id')
+    if (!post) return null
+
+    const comment = await CommentModel.findOne({ _id: commentId, post: post._id }).select('author')
     return comment ? { author: comment.author } : null
   },
 }

--- a/apps/server/src/lib/services/comment.ts
+++ b/apps/server/src/lib/services/comment.ts
@@ -1,0 +1,171 @@
+import type { CreateComment, UpdateComment } from '@blog/zod-shared'
+import { NotFoundError, ValidationError } from '../errors.js'
+import { CommentModel, type Comment } from '../../models/comment.js'
+import { PostModel } from '../../models/post.js'
+import { Types, type HydratedDocument } from 'mongoose'
+
+export type CommentAuthor = { id: string; username: string }
+
+export type CommentDto = {
+  id: string
+  body: string
+  author: CommentAuthor
+  /** null for a root comment, the parent comment's id for a reply. */
+  parent: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+type PopulatedAuthor = { _id: Types.ObjectId; username: string }
+
+function isPopulated(author: unknown): author is PopulatedAuthor {
+  return typeof author === 'object' && author !== null && 'username' in author
+}
+
+/**
+ * The serialization boundary for a comment.
+ *
+ * There is no `full`/`gated` pair here, unlike PostDto: the wall is on post
+ * bodies only. Comments are public discussion and are served whole to anyone,
+ * signed in or not — gating them would be a second, undesigned rule.
+ */
+function toDto(comment: HydratedDocument<Comment>): CommentDto {
+  const author = comment.author
+  return {
+    id: comment._id.toString(),
+    body: comment.body,
+    author: isPopulated(author)
+      ? { id: author._id.toString(), username: author.username }
+      : { id: String(author), username: '' },
+    parent: comment.parent ? comment.parent.toString() : null,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  }
+}
+
+async function resolvePostId(slug: string): Promise<Types.ObjectId> {
+  const post = await PostModel.findOne({ slug }).select('_id')
+  if (!post) throw new NotFoundError('Post not found.')
+  return post._id
+}
+
+/**
+ * Loads a comment by primary key, tolerating a malformed id.
+ *
+ * The isValid guard is not cosmetic: findById on a non-ObjectId string throws a
+ * Mongoose CastError, which no typed error in lib/errors.ts covers, so it would
+ * fall through the error handler as a generic 500.
+ */
+async function findById(commentId: string): Promise<HydratedDocument<Comment> | null> {
+  if (!Types.ObjectId.isValid(commentId)) return null
+  return CommentModel.findById(commentId)
+}
+
+export const commentService = {
+  /**
+   * The whole thread for a post, oldest first. Flat on the wire on purpose —
+   * the client rebuilds the tree from `parent`, so one query serves any depth
+   * and the API never has to pick a nesting limit.
+   */
+  async list(slug: string): Promise<CommentDto[]> {
+    if (process.env.DEBUG) console.log('[COMMENT_SERVICE] list', { slug })
+    const postId = await resolvePostId(slug)
+    const comments = await CommentModel.find({ post: postId })
+      .sort({ createdAt: 1 })
+      .populate('author', 'username')
+    return comments.map(toDto)
+  },
+
+  async create(slug: string, input: CreateComment, authorId: string): Promise<CommentDto> {
+    if (process.env.DEBUG) console.log('[COMMENT_SERVICE] create', { slug, authorId })
+    const postId = await resolvePostId(slug)
+
+    if (input.parent) {
+      const parent = await findById(input.parent)
+      // A parent that does not exist, or that belongs to a different post, is a
+      // malformed *input* — the post in the URL was found, so 404 would point at
+      // the wrong resource. The schema can only check the id's shape; which post
+      // it hangs off is a database fact, so the 400 is raised here.
+      if (!parent || !parent.post.equals(postId)) {
+        if (process.env.DEBUG)
+          console.warn('[COMMENT_SERVICE] rejected parent', { slug, parent: input.parent })
+        throw new ValidationError('Invalid input.', {
+          parent: ['Parent comment does not belong to this post'],
+        })
+      }
+    }
+
+    const comment = await CommentModel.create({
+      body: input.body,
+      parent: input.parent ? new Types.ObjectId(input.parent) : undefined,
+      post: postId,
+      // From the session, never from `input` — validate() strips an `author`
+      // key anyway, and this is the second reason it cannot be spoofed.
+      author: new Types.ObjectId(authorId),
+    })
+    await comment.populate('author', 'username')
+    return toDto(comment)
+  },
+
+  async update(commentId: string, input: UpdateComment): Promise<CommentDto> {
+    if (process.env.DEBUG) console.log('[COMMENT_SERVICE] update', { commentId })
+    const comment = await findById(commentId)
+    if (!comment) throw new NotFoundError('Comment not found.')
+
+    comment.body = input.body
+    await comment.save()
+    await comment.populate('author', 'username')
+    return toDto(comment)
+  },
+
+  /**
+   * Deletes a comment and its entire reply subtree.
+   *
+   * $graphLookup walks `parent` edges to arbitrary depth in one round trip, so
+   * the cost does not grow with nesting the way a per-level loop would. Deleting
+   * only the root would leave every reply orphaned: they point at an id that no
+   * longer resolves, so buildCommentTree would surface them as fresh roots and
+   * the "deleted" subthread would reappear at the top of the page.
+   */
+  async remove(commentId: string): Promise<void> {
+    if (process.env.DEBUG) console.log('[COMMENT_SERVICE] remove', { commentId })
+    const root = await findById(commentId)
+    if (!root) throw new NotFoundError('Comment not found.')
+
+    const [result] = await CommentModel.aggregate<{ ids: Types.ObjectId[] }>([
+      { $match: { _id: root._id } },
+      {
+        $graphLookup: {
+          from: 'comments',
+          startWith: '$_id',
+          connectFromField: '_id',
+          connectToField: 'parent',
+          as: 'descendants',
+        },
+      },
+      { $project: { ids: { $concatArrays: [['$_id'], '$descendants._id'] } } },
+    ])
+
+    // The fallback keeps the root deletable even if the aggregation returns
+    // nothing; correctness of the cascade still rests on the pipeline.
+    const ids = result?.ids ?? [root._id]
+    if (process.env.DEBUG) console.log('[COMMENT_SERVICE] cascade', { count: ids.length })
+    await CommentModel.deleteMany({ _id: { $in: ids } })
+  },
+
+  /**
+   * Called from postService.remove. Flat, not recursive: every comment on the
+   * post goes regardless of depth, so walking the tree would be wasted work.
+   */
+  async removeAllForPost(postId: Types.ObjectId): Promise<void> {
+    if (process.env.DEBUG) console.log('[COMMENT_SERVICE] removeAllForPost', { postId })
+    await CommentModel.deleteMany({ post: postId })
+  },
+
+  /** Loader for requireOwner. Returns only what the ownership check needs. */
+  async findByIdForOwnerCheck(commentId: string): Promise<{ author: Types.ObjectId } | null> {
+    if (!Types.ObjectId.isValid(commentId)) return null
+    const comment = await CommentModel.findById(commentId).select('author')
+    return comment ? { author: comment.author } : null
+  },
+}

--- a/apps/server/src/lib/services/post.test.ts
+++ b/apps/server/src/lib/services/post.test.ts
@@ -1,4 +1,6 @@
 import { NotFoundError } from '../errors.js'
+import { commentService } from './comment.js'
+import { CommentModel } from '../../models/comment.js'
 import { LikeModel } from '../../models/like.js'
 import { PostModel } from '../../models/post.js'
 import { UserModel } from '../../models/user.js'
@@ -148,6 +150,15 @@ describe('postService.remove', () => {
     await LikeModel.create({ user: new Types.ObjectId(), post: new Types.ObjectId(post.id) })
     await postService.remove(post.slug)
     expect(await LikeModel.countDocuments()).toBe(0)
+  })
+
+  it('deletes the post comments too, at every depth', async () => {
+    const post = await create()
+    const root = await commentService.create(post.slug, { body: 'Root.' }, authorId)
+    await commentService.create(post.slug, { body: 'Reply.', parent: root.id }, authorId)
+
+    await postService.remove(post.slug)
+    expect(await CommentModel.countDocuments()).toBe(0)
   })
 
   it('throws NotFoundError for an unknown slug', async () => {

--- a/apps/server/src/lib/services/post.ts
+++ b/apps/server/src/lib/services/post.ts
@@ -5,6 +5,7 @@ import {
   type UpdatePost,
 } from '@blog/zod-shared'
 import { NotFoundError } from '../errors.js'
+import { commentService } from './comment.js'
 import { LikeModel } from '../../models/like.js'
 import { PostModel, type Post } from '../../models/post.js'
 import { Types, type HydratedDocument } from 'mongoose'
@@ -145,6 +146,9 @@ export const postService = {
     // Delete the likes first: a like pointing at a missing post is an orphan
     // that would inflate no count but would never be collected either.
     await LikeModel.deleteMany({ post: post._id })
+    // Same reasoning for the thread — and it can be flat here, because every
+    // comment on the post goes regardless of where it sat in the tree.
+    await commentService.removeAllForPost(post._id)
     await post.deleteOne()
   },
 

--- a/apps/server/src/models/comment.ts
+++ b/apps/server/src/models/comment.ts
@@ -4,11 +4,19 @@ const commentSchema = new Schema(
   {
     body: { type: String, required: true, trim: true },
     author: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-    post: { type: Schema.Types.ObjectId, ref: 'Post', required: true, index: true },
-    parent: { type: Schema.Types.ObjectId, ref: 'Comment' },
+    post: { type: Schema.Types.ObjectId, ref: 'Post', required: true },
+    // Indexed because the cascade delete walks `parent` edges with
+    // $graphLookup, and $graphLookup scans the whole collection once per level
+    // when its connectToField is unindexed — which would quietly undo the
+    // reason the cascade is one aggregation instead of a per-level loop.
+    parent: { type: Schema.Types.ObjectId, ref: 'Comment', index: true },
   },
   { timestamps: true },
 )
+// Covers both halves of the thread query: `post` alone is a prefix of this, so
+// no separate index on it is needed, and the createdAt sort is served by the
+// index rather than by an in-memory blocking sort.
+commentSchema.index({ post: 1, createdAt: 1 })
 
 export type Comment = InferSchemaType<typeof commentSchema>
 export const CommentModel: Model<Comment> =

--- a/apps/server/src/routes/v1/comments.test.ts
+++ b/apps/server/src/routes/v1/comments.test.ts
@@ -1,0 +1,171 @@
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import { buildTestApp, useTestDb } from '../../test/helpers.js'
+
+useTestDb()
+
+const app = () => buildTestApp()
+
+async function signedInAgent(app: ReturnType<typeof buildTestApp>, username: string) {
+  const agent = request.agent(app)
+  await agent
+    .post('/api/v1/auth/signup')
+    .send({ username, email: `${username}@example.com`, password: 'correct-horse' })
+  return agent
+}
+
+const COMMENTS = '/api/v1/posts/a-fine-title/comments'
+
+async function withPost() {
+  const a = app()
+  const author = await signedInAgent(a, 'author')
+  await author.post('/api/v1/posts').send({ title: 'A Fine Title', body: 'Body.' })
+  return { a, author }
+}
+
+describe('GET /api/v1/posts/:slug/comments', () => {
+  it('is reachable — the mount sits ahead of the bare /:slug handlers', async () => {
+    const { a } = await withPost()
+    expect((await request(a).get(COMMENTS)).status).toBe(200)
+  })
+
+  it('returns full comment bodies to an ANONYMOUS reader — comments are never gated', async () => {
+    const { a, author } = await withPost()
+    const long = 'Para one.\n\nPara two.\n\nPara three — comments are not walled.'
+    await author.post(COMMENTS).send({ body: long })
+
+    const res = await request(a).get(COMMENTS)
+    expect(res.status).toBe(200)
+    expect(res.body[0].body).toBe(long)
+    // The post body IS teased for this reader; the comment must not be.
+    expect((await request(a).get('/api/v1/posts/a-fine-title')).body.gated).toBe(true)
+  })
+
+  it('returns 404 for an unknown post slug', async () => {
+    const { a } = await withPost()
+    expect((await request(a).get('/api/v1/posts/nope/comments')).status).toBe(404)
+  })
+})
+
+describe('POST /api/v1/posts/:slug/comments', () => {
+  it('creates a comment attributed to the session user', async () => {
+    const { author } = await withPost()
+    const res = await author.post(COMMENTS).send({ body: 'Nice post.' })
+    expect(res.status).toBe(201)
+    expect(res.body.author.username).toBe('author')
+    expect(res.body.parent).toBeNull()
+  })
+
+  it('requires authentication', async () => {
+    const { a } = await withPost()
+    expect((await request(a).post(COMMENTS).send({ body: 'Anonymous.' })).status).toBe(401)
+  })
+
+  it('ignores an author field in the body — identity comes from the session', async () => {
+    const { a, author } = await withPost()
+    const reader = await signedInAgent(a, 'reader')
+    const res = await reader.post(COMMENTS).send({ body: 'Mine.', author: 'someone-else' })
+    expect(res.body.author.username).toBe('reader')
+    expect((await author.get(COMMENTS)).body).toHaveLength(1)
+  })
+
+  it('nests a reply under its parent', async () => {
+    const { author } = await withPost()
+    const root = await author.post(COMMENTS).send({ body: 'Root.' })
+    const reply = await author.post(COMMENTS).send({ body: 'Reply.', parent: root.body.id })
+    expect(reply.status).toBe(201)
+    expect(reply.body.parent).toBe(root.body.id)
+  })
+
+  it('rejects an empty body with a 400 naming the field', async () => {
+    const { author } = await withPost()
+    const res = await author.post(COMMENTS).send({ body: '   ' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.fields.body).toBeDefined()
+  })
+
+  it('rejects a parent from a DIFFERENT post with a 400 naming the field', async () => {
+    const { author } = await withPost()
+    await author.post('/api/v1/posts').send({ title: 'Another Title', body: 'Body.' })
+    const foreign = await author
+      .post('/api/v1/posts/another-title/comments')
+      .send({ body: 'Elsewhere.' })
+
+    const res = await author.post(COMMENTS).send({ body: 'Reply.', parent: foreign.body.id })
+    expect(res.status).toBe(400)
+    expect(res.body.error.fields.parent).toBeDefined()
+  })
+
+  it('rejects a malformed parent id with a 400, not a 500', async () => {
+    const { author } = await withPost()
+    expect((await author.post(COMMENTS).send({ body: 'x', parent: 'not-an-id' })).status).toBe(400)
+  })
+})
+
+describe('PATCH /api/v1/posts/:slug/comments/:commentId', () => {
+  it('lets the author edit their own comment', async () => {
+    const { author } = await withPost()
+    const created = await author.post(COMMENTS).send({ body: 'Typo.' })
+    const res = await author.patch(`${COMMENTS}/${created.body.id}`).send({ body: 'Fixed.' })
+    expect(res.status).toBe(200)
+    expect(res.body.body).toBe('Fixed.')
+  })
+
+  it('REGRESSION: 403 for a signed-in NON-author', async () => {
+    const { a, author } = await withPost()
+    const created = await author.post(COMMENTS).send({ body: 'Mine.' })
+    const attacker = await signedInAgent(a, 'attacker')
+    const res = await attacker.patch(`${COMMENTS}/${created.body.id}`).send({ body: 'Yours now.' })
+    expect(res.status).toBe(403)
+  })
+
+  it('401 for an anonymous caller', async () => {
+    const { a, author } = await withPost()
+    const created = await author.post(COMMENTS).send({ body: 'Mine.' })
+    const res = await request(a).patch(`${COMMENTS}/${created.body.id}`).send({ body: 'Yours.' })
+    expect(res.status).toBe(401)
+  })
+
+  it('404 for a malformed comment id, not a 500', async () => {
+    const { author } = await withPost()
+    expect((await author.patch(`${COMMENTS}/not-an-id`).send({ body: 'x' })).status).toBe(404)
+  })
+})
+
+describe('DELETE /api/v1/posts/:slug/comments/:commentId', () => {
+  it('deletes the comment and its replies', async () => {
+    const { a, author } = await withPost()
+    const root = await author.post(COMMENTS).send({ body: 'Root.' })
+    await author.post(COMMENTS).send({ body: 'Reply.', parent: root.body.id })
+
+    expect((await author.delete(`${COMMENTS}/${root.body.id}`)).status).toBe(204)
+
+    const remaining = (await request(a).get(COMMENTS)).body
+    expect(remaining).toEqual([])
+  })
+
+  it('REGRESSION: 403 for a signed-in NON-author', async () => {
+    const { a, author } = await withPost()
+    const created = await author.post(COMMENTS).send({ body: 'Mine.' })
+    const attacker = await signedInAgent(a, 'attacker')
+    expect((await attacker.delete(`${COMMENTS}/${created.body.id}`)).status).toBe(403)
+  })
+
+  it('401 for an anonymous caller', async () => {
+    const { a, author } = await withPost()
+    const created = await author.post(COMMENTS).send({ body: 'Mine.' })
+    expect((await request(a).delete(`${COMMENTS}/${created.body.id}`)).status).toBe(401)
+  })
+})
+
+describe('deleting a post', () => {
+  it('takes its comments with it', async () => {
+    const { a, author } = await withPost()
+    const root = await author.post(COMMENTS).send({ body: 'Root.' })
+    await author.post(COMMENTS).send({ body: 'Reply.', parent: root.body.id })
+
+    expect((await author.delete('/api/v1/posts/a-fine-title')).status).toBe(204)
+    // The thread is gone with the post: the endpoint 404s rather than serving orphans.
+    expect((await request(a).get(COMMENTS)).status).toBe(404)
+  })
+})

--- a/apps/server/src/routes/v1/comments.test.ts
+++ b/apps/server/src/routes/v1/comments.test.ts
@@ -158,6 +158,37 @@ describe('DELETE /api/v1/posts/:slug/comments/:commentId', () => {
   })
 })
 
+// The URL advertises a hierarchy. A nested resource that ignores its parent
+// would let a client edit or delete a comment through any post's URL, and then
+// invalidate the thread of a post that never changed.
+describe('resource scoping', () => {
+  async function withTwoPosts() {
+    const { a, author } = await withPost()
+    await author.post('/api/v1/posts').send({ title: 'Another Title', body: 'Body.' })
+    const created = await author.post(COMMENTS).send({ body: 'Mine.' })
+    return { a, author, id: created.body.id }
+  }
+
+  it('404s a PATCH addressed through the wrong post', async () => {
+    const { author, id } = await withTwoPosts()
+    const res = await author
+      .patch(`/api/v1/posts/another-title/comments/${id}`)
+      .send({ body: 'Moved.' })
+    expect(res.status).toBe(404)
+  })
+
+  it('404s a DELETE addressed through the wrong post, and the comment survives', async () => {
+    const { a, author, id } = await withTwoPosts()
+    expect((await author.delete(`/api/v1/posts/another-title/comments/${id}`)).status).toBe(404)
+    expect((await request(a).get(COMMENTS)).body).toHaveLength(1)
+  })
+
+  it('404s a DELETE addressed through an unknown post', async () => {
+    const { author, id } = await withTwoPosts()
+    expect((await author.delete(`/api/v1/posts/nope/comments/${id}`)).status).toBe(404)
+  })
+})
+
 describe('deleting a post', () => {
   it('takes its comments with it', async () => {
     const { a, author } = await withPost()

--- a/apps/server/src/routes/v1/comments.ts
+++ b/apps/server/src/routes/v1/comments.ts
@@ -1,0 +1,53 @@
+import { CreateCommentSchema, UpdateCommentSchema } from '@blog/zod-shared'
+import { Router, type Request } from 'express'
+import { commentService } from '../../lib/services/comment.js'
+import { requireAuth } from '../../middleware/require-auth.js'
+import { requireOwner } from '../../middleware/require-owner.js'
+import { validate } from '../../middleware/validate.js'
+
+/**
+ * Mounted under /api/v1/posts/:slug/comments, so `mergeParams` is required —
+ * without it `req.params.slug` is undefined on this router and every request
+ * would 404 on a post that exists.
+ */
+export const commentsRouter = Router({ mergeParams: true })
+
+type CommentParams = { slug: string; commentId: string }
+
+/** Loader for requireOwner: resolves :commentId to the comment's author. */
+const loadCommentOwner = (req: Request<CommentParams>) =>
+  commentService.findByIdForOwnerCheck(req.params.commentId)
+
+// Public, and deliberately ungated: the wall is on post bodies, not on the
+// discussion around them, so no viewer id is passed and none is consulted.
+commentsRouter.get<{ slug: string }>('/', async (req, res) => {
+  res.json(await commentService.list(req.params.slug))
+})
+
+commentsRouter.post<{ slug: string }>(
+  '/',
+  requireAuth,
+  validate(CreateCommentSchema),
+  async (req, res) => {
+    // requireAuth guarantees userId is set.
+    res.status(201).json(await commentService.create(req.params.slug, req.body, req.session.userId!))
+  },
+)
+
+commentsRouter.patch<CommentParams>(
+  '/:commentId',
+  requireOwner(loadCommentOwner),
+  validate(UpdateCommentSchema),
+  async (req, res) => {
+    res.json(await commentService.update(req.params.commentId, req.body))
+  },
+)
+
+commentsRouter.delete<CommentParams>(
+  '/:commentId',
+  requireOwner(loadCommentOwner),
+  async (req, res) => {
+    await commentService.remove(req.params.commentId)
+    res.status(204).end()
+  },
+)

--- a/apps/server/src/routes/v1/comments.ts
+++ b/apps/server/src/routes/v1/comments.ts
@@ -14,9 +14,13 @@ export const commentsRouter = Router({ mergeParams: true })
 
 type CommentParams = { slug: string; commentId: string }
 
-/** Loader for requireOwner: resolves :commentId to the comment's author. */
+/**
+ * Loader for requireOwner: resolves :slug + :commentId to the comment's author.
+ * Both params, not just the id — a comment addressed through another post's URL
+ * must 404, the way likeService resolves :slug before touching a like.
+ */
 const loadCommentOwner = (req: Request<CommentParams>) =>
-  commentService.findByIdForOwnerCheck(req.params.commentId)
+  commentService.findForOwnerCheck(req.params.slug, req.params.commentId)
 
 // Public, and deliberately ungated: the wall is on post bodies, not on the
 // discussion around them, so no viewer id is passed and none is consulted.

--- a/apps/server/src/routes/v1/posts.ts
+++ b/apps/server/src/routes/v1/posts.ts
@@ -1,5 +1,6 @@
 import { CreatePostSchema, UpdatePostSchema } from '@blog/zod-shared'
 import { Router, type Request } from 'express'
+import { commentsRouter } from './comments.js'
 import { likeService } from '../../lib/services/like.js'
 import { postService } from '../../lib/services/post.js'
 import { requireAuth } from '../../middleware/require-auth.js'
@@ -33,6 +34,12 @@ postsRouter.put<{ slug: string }>('/:slug/likes', requireAuth, async (req, res) 
 postsRouter.delete<{ slug: string }>('/:slug/likes', requireAuth, async (req, res) => {
   res.json(await likeService.unlike(req.params.slug, req.session.userId!))
 })
+
+// Registered with the other sub-resources, above the bare /:slug handlers.
+// Express matches in registration order, and unlike a route path a `use` mount
+// matches by PREFIX — so this must never end up behind a handler that could
+// claim the same prefix first.
+postsRouter.use('/:slug/comments', commentsRouter)
 
 postsRouter.get('/:slug', async (req, res) => {
   // The viewer id is passed to the service, which decides what to serialize.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,9 @@
         "lucide-react": "^1.25.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-markdown": "^10.1.0",
         "react-router": "^8.3.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0"
       },
@@ -2727,12 +2729,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -2769,6 +2788,15 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -2783,11 +2811,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
       "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2818,7 +2861,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2878,6 +2920,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -3176,6 +3224,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -3452,6 +3506,16 @@
         }
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3704,6 +3768,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -3736,6 +3810,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -3825,6 +3939,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -3984,7 +4108,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4024,6 +4147,19 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4065,7 +4201,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4079,6 +4214,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dezalgo": {
@@ -4802,6 +4950,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4936,6 +5094,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -5346,6 +5510,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/helmet": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
@@ -5369,6 +5573,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-errors": {
@@ -5474,6 +5688,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5481,6 +5701,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -5504,6 +5758,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -5998,6 +6274,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -6071,6 +6357,16 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6078,6 +6374,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -6123,6 +6701,569 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -6615,6 +7756,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -6968,6 +8134,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7072,6 +8248,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-router": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
@@ -7135,6 +8338,72 @@
       },
       "engines": {
         "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -7499,6 +8768,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -7543,6 +8822,20 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -7567,6 +8860,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -7859,6 +9170,26 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8614,6 +9945,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -8640,6 +10058,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -8938,6 +10384,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/zod-shared": {

--- a/packages/zod-shared/src/index.ts
+++ b/packages/zod-shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schemas/user.js'
 export * from './schemas/post.js'
+export * from './schemas/comment.js'

--- a/packages/zod-shared/src/schemas/comment.ts
+++ b/packages/zod-shared/src/schemas/comment.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+/** A Mongo ObjectId as it travels over JSON: 24 hex characters. */
+const objectId = z.string().regex(/^[0-9a-fA-F]{24}$/, 'Not a valid id')
+
+// POST /api/v1/posts/:slug/comments — the slug in the URL identifies the post
+// and the session identifies the author, so neither may appear in the body.
+export const CreateCommentSchema = z.object({
+  body: z
+    .string()
+    .trim()
+    .min(1, 'Comment cannot be empty')
+    .max(5_000, 'Comment must be at most 5,000 characters'),
+  // Absent for a root comment, present for a reply. Only the *shape* is checked
+  // here — whether it points at a real comment on THIS post is a database
+  // question, so the service answers it.
+  parent: objectId.optional(),
+})
+
+/**
+ * PATCH /api/v1/posts/:slug/comments/:commentId.
+ *
+ * `body` only, on purpose: a comment is never re-parented, the same way a post
+ * never changes its author. Picking the field instead of `.partial()`ing the
+ * create schema means `parent` is not merely optional here — it is stripped,
+ * so a client cannot move a thread by editing a leaf.
+ */
+export const UpdateCommentSchema = CreateCommentSchema.pick({ body: true })
+
+export type CreateComment = z.infer<typeof CreateCommentSchema>
+export type UpdateComment = z.infer<typeof UpdateCommentSchema>

--- a/packages/zod-shared/src/schemas/index.ts
+++ b/packages/zod-shared/src/schemas/index.ts
@@ -1,2 +1,3 @@
 export * from './user.js'
 export * from './post.js'
+export * from './comment.js'

--- a/packages/zod-shared/src/schemas/schemas.test.ts
+++ b/packages/zod-shared/src/schemas/schemas.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { SignupSchema, CreatePostSchema, UpdatePostSchema, slugify, deriveTeaser } from './index.js'
+import {
+  SignupSchema,
+  CreatePostSchema,
+  UpdatePostSchema,
+  CreateCommentSchema,
+  UpdateCommentSchema,
+  slugify,
+  deriveTeaser,
+} from './index.js'
 
 describe('SignupSchema', () => {
   it('accepts a valid signup', () => {
@@ -101,6 +109,69 @@ describe('UpdatePostSchema', () => {
       postId: 'attacker-supplied',
     } as never)
     expect(parsed).not.toHaveProperty('postId')
+  })
+})
+
+describe('CreateCommentSchema', () => {
+  const OID = '507f1f77bcf86cd799439011'
+
+  it('accepts a root comment with no parent', () => {
+    const result = CreateCommentSchema.safeParse({ body: 'Nice post.' })
+    expect(result.success).toBe(true)
+    expect(result.data!.parent).toBeUndefined()
+  })
+
+  it('accepts a reply carrying a parent id', () => {
+    expect(CreateCommentSchema.parse({ body: 'Agreed.', parent: OID }).parent).toBe(OID)
+  })
+
+  it('trims the body', () => {
+    expect(CreateCommentSchema.parse({ body: '  spaced  ' }).body).toBe('spaced')
+  })
+
+  it('rejects a body that is empty once trimmed', () => {
+    const result = CreateCommentSchema.safeParse({ body: '   ' })
+    expect(result.success).toBe(false)
+    expect(result.error!.flatten().fieldErrors.body).toEqual(['Comment cannot be empty'])
+  })
+
+  it('rejects a body longer than 5,000 characters', () => {
+    expect(CreateCommentSchema.safeParse({ body: 'a'.repeat(5001) }).success).toBe(false)
+  })
+
+  it('rejects a parent that is not a 24-char hex id', () => {
+    // Without this the value reaches Mongoose and a CastError surfaces as a 500.
+    const result = CreateCommentSchema.safeParse({ body: 'hi', parent: 'not-an-id' })
+    expect(result.success).toBe(false)
+    expect(result.error!.flatten().fieldErrors.parent).toBeDefined()
+  })
+
+  it('strips an author field — identity comes from the session only', () => {
+    const result = CreateCommentSchema.parse({ body: 'hi', author: 'attacker' } as never)
+    expect('author' in result).toBe(false)
+  })
+
+  it('strips a post field — the slug in the URL identifies the post', () => {
+    const result = CreateCommentSchema.parse({ body: 'hi', post: 'attacker' } as never)
+    expect('post' in result).toBe(false)
+  })
+})
+
+describe('UpdateCommentSchema', () => {
+  it('accepts a body-only edit', () => {
+    expect(UpdateCommentSchema.safeParse({ body: 'Edited.' }).success).toBe(true)
+  })
+
+  it('still requires a body — an edit to nothing is not an edit', () => {
+    expect(UpdateCommentSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('strips parent — a comment is never re-parented after creation', () => {
+    const parsed = UpdateCommentSchema.parse({
+      body: 'Edited.',
+      parent: '507f1f77bcf86cd799439011',
+    } as never)
+    expect(parsed).not.toHaveProperty('parent')
   })
 })
 


### PR DESCRIPTION
Implements P3: threaded comments end to end, plus the Markdown editor/preview the comment box needs.

## Server

- **`packages/zod-shared/src/schemas/comment.ts`** — `CreateCommentSchema` (`body` 1–5,000 chars trimmed, optional 24-char-hex `parent`) and `UpdateCommentSchema`, which **picks `body` only**. `parent` is not merely optional on update, it is stripped: a comment is never re-parented, the same way a post never changes its author.
- **`commentService`** — `list` / `create` / `update` / `remove` / `removeAllForPost` / `findByIdForOwnerCheck`.
  - `remove` cascades to the **entire reply subtree** via a single `$graphLookup` aggregation over `parent` edges, so cost does not grow with nesting. Deleting only the root would orphan its replies, and `buildCommentTree` promotes orphans to roots — the "deleted" subthread would reappear at the top of the page.
  - A `parent` that does not exist, or that belongs to a different post, is a **400 with `fields.parent`**, not a 404: the post named in the URL was found, so it is the input that is malformed.
  - `Types.ObjectId.isValid` guards every by-id lookup, so a malformed comment id is a 404 rather than an uncaught Mongoose `CastError` falling through as a 500.
- **`postService.remove`** now also calls `commentService.removeAllForPost` — flat, since every comment goes regardless of depth.
- **`commentsRouter`** — `Router({ mergeParams: true })`, mounted at `/:slug/comments` alongside the existing `/:slug/likes` and **ahead of the bare `/:slug` handlers**. `GET` is public and deliberately **ungated**: the content wall is on post bodies, not on the discussion around them. Write paths go through `requireAuth` / `requireOwner(loadCommentOwner)` + `validate`, so identity always comes from the session.

## Client

- **`commentsApi`** + **`useComments` / `useCreateComment` / `useUpdateComment` / `useDeleteComment`**, all invalidating `queryKeys.comments.list(slug)` on success. Invalidate rather than optimistic (unlike `useLikePost`): a create needs a server-assigned id that replies hang off and a delete cascades to a subtree only the server can size, so there is no cheap patch that is also correct.
- **`MarkdownPreview`** on `react-markdown@10` + `remark-gfm@4`, **without `rehype-raw`**. Raw HTML in a comment is therefore never parsed into nodes and renders as inert escaped text.
- **`CommentForm`** — Write/Preview tabs, validating against `CreateCommentSchema.shape.body` directly. Not built on `AutoForm`, which renders one control per schema key and so cannot hide `parent` (a reply must still send it) or host a tab strip.
- **`CommentThread`** — exports a pure, DOM-free `buildCommentTree` (Map-based, O(n)). A comment whose `parent` does not resolve (stale cache mid-delete) is promoted to a root rather than silently vanishing. Recursive indented render; Reply reveals a nested composer; Edit/Delete show only for the comment's own author (a UI affordance — `requireOwner` is the real check).
- **`CommentSection`** composes the above into `PostPage` under the like/edit/delete row, with the existing `<Link to="/login">` sign-in idiom for anonymous readers, who can still *read* the thread.

## Test plan

`npm run typecheck && npm run lint && npm run build && npm run test` — all green, **268 tests / 30 files** (was 175). Notable coverage:

- Anonymous `GET /comments` returns **full** comment bodies while the same reader's post payload is still `gated: true` — comments are never gated.
- `POST` without auth is 401; an `author` field in the body is ignored.
- A cross-post `parent` and an unknown `parent` are both 400 with `fields.parent`; a malformed `parent` is 400, not 500.
- `PATCH`/`DELETE` by a signed-in non-author are 403; by an anonymous caller, 401.
- `remove` on a comment with two nested replies deletes all three; on a leaf, only itself; sibling subtrees survive.
- Deleting a post takes its whole thread with it (service and route level).
- `buildCommentTree` nests to arbitrary depth, preserves root order, promotes orphans, and does not mutate its input.
- **Security:** a literal `<script>alert(1)</script>` in Markdown source never produces a `script` element (`container.querySelector('script')` is `null`) — asserted in `MarkdownPreview`, `CommentForm`'s preview pane, and `CommentThread`'s rendered body. Same for a smuggled `<img onerror>` and `<iframe>`.

`test:e2e` was not run locally (another worktree was holding the Compose host ports); relying on CI's isolated `e2e-smoke` job.

No infra, Docker, or CI changes.