### PR TITLE
fix(search): stop the search box from dropping keystrokes

### DIFF
--- a/apps/client/src/pages/BlogFeedPage.test.tsx
+++ b/apps/client/src/pages/BlogFeedPage.test.tsx
@@ -1,0 +1,92 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/AutoForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { queryKeys } from '../lib/query-client.js'
+
+// Real browsers don't apply a router's `setSearchParams` synchronously — it
+// round-trips through history/context, same as it did in production when this
+// bug shipped. RTL's `fireEvent` flushes React synchronously, which hides that
+// gap entirely: a naive test typing into the box passes identically whether
+// the box's value comes from local state or straight from the URL. This mock
+// puts a real, fake-timer-controlled delay on `setSearchParams` so the gap
+// that caused the bug is reproducible on demand.
+let mockParams = new URLSearchParams()
+let notify: (() => void) | undefined
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>()
+  return {
+    ...actual,
+    useSearchParams: () => {
+      const [, setTick] = useState(0)
+      notify = () => setTick((n) => n + 1)
+      const setSearchParams = (
+        updater: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams),
+      ) => {
+        const prevAtCallTime = mockParams
+        setTimeout(() => {
+          mockParams = typeof updater === 'function' ? updater(prevAtCallTime) : updater
+          notify?.()
+        }, 100)
+      }
+      return [mockParams, setSearchParams] as const
+    },
+  }
+})
+
+// Imported after the mock so BlogFeedPage picks up the mocked useSearchParams.
+const { BlogFeedPage } = await import('./BlogFeedPage.js')
+
+function renderFeed() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  client.setQueryData(queryKeys.posts.list({}), [])
+  client.setQueryData(queryKeys.posts.list({ q: 'identity' }), [])
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <BlogFeedPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('BlogFeedPage search box', () => {
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    mockParams = new URLSearchParams()
+    notify = undefined
+  })
+
+  // Regression: the box's value used to be read straight from the URL
+  // (`searchParams.get('q')`) on every render. A keystroke that landed before
+  // a prior `setSearchParams` round trip resolved got overwritten by the
+  // still-stale value once that round trip finally landed — typing "identity"
+  // at a normal pace left only the last keystroke on screen. Each `fireEvent`
+  // below appends to whatever the DOM currently shows, exactly like a real
+  // keypress does, so a mid-typing reset shows up as a garbled string instead
+  // of "identity".
+  it('keeps every keystroke on screen even when a stale URL round trip lands mid-typing', () => {
+    vi.useFakeTimers()
+    renderFeed()
+    const input = screen.getByPlaceholderText('Search posts…') as HTMLInputElement
+
+    for (const ch of 'identity') {
+      fireEvent.change(input, { target: { value: input.value + ch } })
+      // Faster than the mocked 100ms round trip: several keystrokes land
+      // before any of their setSearchParams calls have resolved.
+      act(() => void vi.advanceTimersByTime(30))
+    }
+    // Drain every round trip that's still pending.
+    act(() => void vi.advanceTimersByTime(200))
+
+    expect(input.value).toBe('identity')
+  })
+})

--- a/apps/client/src/pages/BlogFeedPage.tsx
+++ b/apps/client/src/pages/BlogFeedPage.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import { usePosts } from '../hooks/use-posts.js'
 import { useDebouncedValue } from '../hooks/use-debounced-value.js'
@@ -8,10 +9,13 @@ import { EmptyState } from '../components/patterns/EmptyState.js'
 import { Skeleton } from '../components/ui/skeleton.js'
 
 export function BlogFeedPage() {
-  // The term lives in the URL, not in component state: a search is then
-  // bookmarkable, shareable, and survives a reload or the back button.
   const [searchParams, setSearchParams] = useSearchParams()
-  const term = searchParams.get('q') ?? ''
+  // What's shown in the box is local state, updated synchronously on every
+  // keystroke. It must NOT be derived from the URL on every render: router
+  // state updates round-trip through history/context, and a keystroke that
+  // lands before that round trip resolves would otherwise get overwritten by
+  // the still-stale value, so fast typing loses every character but the last.
+  const [term, setTerm] = useState(() => searchParams.get('q') ?? '')
   // The box tracks every keystroke; the query does not. Debouncing between the
   // two is what makes this one request per pause instead of one per character.
   // Trimmed for the same reason the API drops a blank filter: "   " is not a
@@ -20,21 +24,26 @@ export function BlogFeedPage() {
 
   const { data: posts, isPending, isError } = usePosts({ q: debouncedTerm })
 
-  // Edits `q` in place instead of replacing the whole search string: passing an
-  // object would drop every other param, and `tag` is already plumbed through
-  // the API — a keystroke silently clearing a tag filter would be a confusing
-  // bug to trace back here. `replace` so typing does not push one history entry
-  // per keystroke; back should leave the feed, not replay the search.
-  const handleSearch = (next: string) =>
+  // The URL is synced from the debounced term, not from every keystroke, so
+  // it settles well after the round trip that caused the original bug — a
+  // search stays bookmarkable/shareable without fighting the input for control
+  // of what's on screen. Edits `q` in place: passing an object would drop
+  // every other param, and `tag` is already plumbed through the API — a
+  // keystroke silently clearing a tag filter would be a confusing bug to trace
+  // back here. `replace` so typing does not push one history entry per pause.
+  useEffect(() => {
     setSearchParams(
       (prev) => {
         const params = new URLSearchParams(prev)
-        if (next) params.set('q', next)
+        if (debouncedTerm) params.set('q', debouncedTerm)
         else params.delete('q')
         return params
       },
       { replace: true },
     )
+  }, [debouncedTerm, setSearchParams])
+
+  const handleSearch = (next: string) => setTerm(next)
 
   let content: ReactNode
   if (isPending) {


### PR DESCRIPTION
## Summary
- Found while manually testing the just-merged search feature (PR #31) in a real browser: typing into the feed's search box at normal speed left only the last keystroke on screen (e.g. typing "identity" showed "y").
- Root cause: the box's `value` was bound directly to `searchParams.get('q')`. Every keystroke round-tripped through `setSearchParams` (an async router/history update) before the box re-rendered; a keystroke landing before a prior round trip resolved got clobbered once that update finally landed.
- Fix: the box's displayed value is now local component state (synchronous, never lags); the URL is synced from the *debounced* term instead of every keystroke, so bookmarking/sharing still works.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (309 passed) — includes a new regression test that mocks a delayed `setSearchParams` to reproduce the real async gap (confirmed it fails against the old code: `"identity"` → `"ny"`)
- [x] Manually verified in a live browser: fast typing now shows the full term and returns the correct filtered result