### PR TITLE
feat: add readme-maintenance skill, un-ignore .claude/skills/

### DIFF
--- a/.claude/skills/docker-compose-rebuild/SKILL.md
+++ b/.claude/skills/docker-compose-rebuild/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: docker-compose-rebuild
+description: >-
+  Use on the Blog-Chat-app repo whenever a code edit (bug fix or new feature) does not show up in the
+  running app, or as the FIRST troubleshooting step when the user says a fix "didn't work," they "don't
+  see the change," or the UI/API still shows old behavior after edits. Docker containers here bake source
+  at build time and serve stale code, so this skill asks permission and then rebuilds the compose stack so
+  the edits actually take effect. Trigger it before debugging the code itself when changes seem to have no visible effect.
+---
+
+# Docker Compose Rebuild
+
+## Why this exists
+
+On this repo the dev stack runs in Docker. A container started with `up -d` **freezes the app code at
+image-build time** — editing a file afterward and running `restart` keeps serving the code baked into the
+image (see the `docker-compose-dev-sync-gotcha` project memory, confirmed during P2 signup debugging). So
+when a bug fix or new feature "doesn't work," the most common cause is not the code — it's that the running
+container never picked up the edit.
+
+**Rule of thumb:** if the user just changed code and the change isn't visible, suspect a stale container
+*before* you re-read the logic. Rebuilding is the cheap first move; debugging code that's correct but not
+running is wasted effort.
+
+## When to trigger
+
+- The user reports that a recent bug fix or new feature has no visible effect.
+- "I don't see my changes," "the fix didn't work," "still shows the old behavior," "nothing changed."
+- Right after you (or the user) edit source while the stack is already running.
+- As the **first** step of troubleshooting a "my change isn't showing" symptom, before diving into the code.
+
+## What to do
+
+1. **Ask for permission first.** A full `--no-cache` rebuild is slow, and `up --watch` runs in the
+   foreground and takes over the terminal. Never rebuild silently — confirm with the user, e.g.:
+   > "Your change may not be showing because the container is serving stale code. Want me to rebuild the
+   > compose stack? This does a clean `--no-cache` build and can take a few minutes."
+
+2. **Only after they agree**, run these two commands from the **repo root** (not from `infra/`):
+
+   ```bash
+   docker compose --project-directory . -f infra/compose.yaml build --no-cache
+   docker compose --project-directory . -f infra/compose.yaml up --watch
+   ```
+
+   - `--project-directory .` is mandatory — the compose file lives in `infra/` but its `context` /
+     `develop.watch` / secrets paths are written relative to the repo root; Compose resolves them wrong
+     without it.
+   - `up --watch` is long-running and blocks the terminal (it keeps syncing edits live). Run it in the
+     background if you need the terminal back, and tell the user it stays running.
+
+3. If the user only wants the change picked up (not a full clean rebuild), a lighter option is a targeted
+   rebuild of the one changed service — `docker compose --project-directory . -f infra/compose.yaml up -d --build <service>`
+   — or just `docker compose watch` (what `npm run dev` does), which syncs edits live without the slow
+   `--no-cache` pass. Offer this when a full clean rebuild is overkill.
+
+## After rebuilding
+
+Confirm the change is actually present before assuming success — e.g. reload the page, hit the endpoint, or
+`docker compose exec <service> grep` for the edited string inside the container. Don't declare it fixed until
+you've seen the new behavior.

--- a/.claude/skills/plan-status/SKILL.md
+++ b/.claude/skills/plan-status/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: plan-status
+description: >-
+  Use on the Blog-Chat-app repo whenever the question is "where are we?" or "what's next?" — status of the
+  current phase plan, which tasks are done, what task to pick up, what's left before a phase ships, or
+  orienting at the start of a session after time away. Reads docs/superpowers/plans/ and derives real
+  status from git and the code rather than the plan's checkboxes (which are never ticked and always read
+  0% done). Trigger it on "what's the status", "where did we leave off", "what should I work on next",
+  "what's left in P2", "catch me up", "is task N done", or before starting any new task on this project —
+  even when the user doesn't name the plan.
+---
+
+# Plan Status
+
+## Why this exists
+
+Phase plans live in `docs/superpowers/plans/`. They are long (P2 is ~2,200 lines) and they track steps with
+`- [ ]` checkboxes — **but nobody ever ticks them.** P2 is 0-of-75 checked while Tasks 1–6 are merged to
+`staging`. So the two obvious ways to answer "where are we" both fail: reading the checkboxes reports 0%
+and sends you to redo Task 1, and reading the whole plan burns thousands of tokens to reach the same wrong
+answer.
+
+The plan is the **specification**; git and the working tree are the **record of what shipped**. This skill
+reads the plan for *what the work is* and reads the repo for *what's done*, then reports the join.
+
+## Step 1 — Scan
+
+```bash
+python .claude/skills/plan-status/scripts/scan_plan.py
+```
+
+Add `--plan <path>` for a specific phase, `--base <branch>` to change what counts as already-merged
+(default `master`). The script picks the newest plan not marked complete, and emits JSON with: the task
+ledger (number, title, line number, declared files, `Produces` interfaces, planned commit message),
+per-task evidence, amendment blocks, and git position.
+
+**Do not read the plan file top-to-bottom.** The scan plus a targeted read of the next task's line range is
+the whole job; reading 2,000 lines to report six facts is the failure mode this skill exists to prevent.
+
+Each task carries a `signal` built from two independent axes — do its declared files exist, and did a
+commit matching its planned message land:
+
+| signal | meaning | what to do |
+|---|---|---|
+| `LIKELY_DONE` | files present **and** a matching commit | trust it |
+| `NOT_STARTED` | declared files absent, nothing shipped | trust it |
+| `NEEDS_CHECK` | the axes disagree | resolve it in Step 2 |
+| `NO_EVIDENCE` | task declares no files (docs/gate tasks) | resolve it in Step 2 |
+
+## Step 2 — Resolve the frontier
+
+Only resolve tasks the scan left uncertain, and usually only the first one or two — a `NEEDS_CHECK` at
+Task 11 doesn't matter when Task 7 is the frontier. Two things routinely make the mechanical signals
+disagree, and both need judgment:
+
+**Commit messages drift.** The plan prescribes `feat(client): typed API wrappers (client.ts + auth/posts/users)`;
+the commit that actually shipped it says `feat(client): api client layer with typed wrappers`. Token
+matching misses this, so a done task shows `NEEDS_CHECK` with no evidence. Scan `git log --oneline -40`
+yourself for a commit that plainly covers the task's subject.
+
+**Files exist as stubs.** Earlier tasks create placeholder pages so the app compiles — `PostPage.tsx`
+exists from Task 5, but Task 7 is what fills it in. Existence proves nothing here; the plan itself says
+"replace the Task 5 stub". This is what the task's **`Produces`** line is for: it names the exact symbols
+the task must yield (`usePost(slug)`, `<LikeButton />`, `AutoForm`). Grep for those:
+
+```bash
+grep -rn "export function usePost\b" apps/client/src/hooks/
+```
+
+Present and substantive → done. Absent, or the file is a few lines returning a heading → not done. When
+still genuinely ambiguous after that, say so in the report rather than picking a side; a wrong "done"
+costs more than an honest question.
+
+## Step 3 — Report
+
+Lead with this block. It is deliberately compact — the user asked where things stand, not for a recital of
+the plan. Task count, titles, and line numbers all come from the scan; never assume a phase's task count
+from memory.
+
+```
+P2 — React Client · 6/13 tasks shipped
+Branch: staging (clean, up to date with origin)
+
+✅ 1 Vite scaffold       ✅ 4 Query/router/shell
+✅ 2 UI primitives       ✅ 5 Auth pages
+✅ 3 API client layer    ✅ 6 Blog feed
+▶  7 Post detail page (gating UI)
+○  8 AutoForm   ○ 9 Delete   ○ 10 Likes
+○  11 Docker    ○ 12 E2E     ○ 13 Final gate
+
+⚠ Amendment 2026-07-25: `premium` is gone — ignore that
+  line in the Tasks 8/10/12 snippets.
+
+Next: Task 7 (plan L1284)
+  hooks/use-posts.ts   + usePost
+  pages/PostPage.tsx   replace the Task-5 stub
+  git checkout -b dev/post-detail-page
+```
+
+Rules for the block:
+
+- **Surface amendments.** Plans get amended in place (`> **Amendment ...**`) and those notes supersede the
+  code snippets below them. Someone following an amended snippet reintroduces work that was deliberately
+  removed — that's why this gets a line of its own rather than a footnote.
+- **Flag git position honestly.** Uncommitted changes, a `dev/*` branch with unmerged work, or local
+  `staging` behind `origin/staging` all change what "next" means. CLAUDE.md requires feature branches off
+  an up-to-date `staging`, so a stale `staging` is a blocker to state, not a detail to skip.
+- **Propose the branch, don't create it.** Name it after the feature, never the task number
+  (`dev/post-detail-page`, not `dev/task-7`) — a CLAUDE.md rule. Give the command; let the user run it.
+- Keep to the shipped/next/remaining shape. Offer the detail ("want the full step list for Task 7?")
+  instead of pre-emptying it into the reply.
+
+## Scope
+
+This skill reports; it doesn't act. It never edits the plan (the checkboxes stay untouched — deriving
+status fresh each time can't go stale, and a wrong verdict written into a doc outlives the mistake), never
+creates branches, and never starts the next task. When the user then says "go", that's implementation
+work — hand off to `superpowers:subagent-driven-development` or `superpowers:executing-plans`, which is
+what the plan's own header asks for.
+
+**Completed plans** announce themselves — `(COMPLETE)` in the title or a `**Status:** all N tasks shipped`
+line — and record their history in a prose "Completion log" rather than checkbox tasks. The scan flags
+them in `plans[].complete`. Summarize from the Status line; don't build a ledger for a phase that's done.
+
+If the user asks about a phase with no plan file yet (P3–P6), say so plainly and point at spec §13, which
+is where the phase table lives.

--- a/.claude/skills/plan-status/scripts/scan_plan.py
+++ b/.claude/skills/plan-status/scripts/scan_plan.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Scan the phase plans under docs/superpowers/plans/ and emit a compact JSON
+status scan: task ledger, per-task evidence, amendments, and git position.
+
+This does the *mechanical* half of a status check — parsing, file existence,
+commit matching. It deliberately does NOT decide whether a task is done; it
+reports evidence and lets the caller judge the frontier. See SKILL.md.
+
+Usage:
+    python .claude/skills/plan-status/scripts/scan_plan.py [--plan PATH] [--base BRANCH]
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def git(*args: str, cwd: Path) -> str:
+    out = subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd)
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+# --- plan parsing ----------------------------------------------------------
+
+TASK_RE = re.compile(r"^##\s+Task\s+(\d+)\s*[:—-]\s*(.+?)\s*$", re.M)
+COMMIT_RE = re.compile(r'git commit -m ["\'](.+?)["\']')
+PATH_RE = re.compile(r"`([^`]+\.[A-Za-z0-9]+)`")
+PRODUCES_RE = re.compile(r"^-\s*Produces:\s*(.+)$", re.M)
+STEP_RE = re.compile(r"^-\s*\[( |x|X)\]\s*\*\*(.+?)\*\*", re.M)
+
+
+def is_complete(text: str) -> bool:
+    """A finished plan announces itself in the title or a Status line."""
+    head = text[:1200]
+    if re.search(r"^#\s+.*\(COMPLETE\)", head, re.M):
+        return True
+    return bool(re.search(r"^\*\*Status:\*\*\s*all\s+\d+\s+tasks?\s+shipped", head, re.M))
+
+
+def parse_amendments(text: str, lines: list[str]) -> list[dict]:
+    """Amendment blocks supersede the snippets below them — surfacing these is
+    the difference between following the plan and following a stale plan."""
+    out = []
+    for m in re.finditer(r"^>\s*\*\*(Amendment[^*]*)\*\*(.*)$", text, re.M):
+        line_no = text[: m.start()].count("\n") + 1
+        body = []
+        for ln in lines[line_no - 1 : line_no + 12]:
+            if not ln.startswith(">"):
+                break
+            body.append(ln.lstrip("> ").rstrip())
+        out.append({
+            "line": line_no,
+            "title": m.group(1).strip(),
+            "body": " ".join(body)[:600],
+        })
+    return out
+
+
+def resolve_paths(files_block: str, index: dict[str, list[str]]) -> list[str]:
+    """The plan writes continuation paths — `.../patterns/PostCard.tsx`, `EmptyState.tsx`
+    — where a bare filename inherits the previous path's directory. Taking those
+    literally makes shipped tasks look unstarted, so resolve them in reading order
+    against the last directory seen, then fall back to a unique basename match."""
+    resolved, last_dir = [], ""
+    for raw in PATH_RE.findall(files_block):
+        p = raw.strip()
+        if p.startswith("./"):
+            p = p[2:]
+        base = p.rsplit("/", 1)[-1]
+        hits = index.get(base, [])
+
+        if "/" in p:
+            # Plans abbreviate ("src/index.css" for "apps/client/src/index.css"),
+            # so accept a unique suffix match before calling it missing.
+            suffix = [h for h in hits if h == p or h.endswith("/" + p)]
+            chosen = p if p in hits else (suffix[0] if len(suffix) == 1 else p)
+        elif last_dir and f"{last_dir}/{base}" in hits:
+            chosen = f"{last_dir}/{base}"
+        elif len(hits) == 1:
+            chosen = hits[0]
+        elif hits and last_dir:
+            # e.g. `.env.example` exists under both apps/*; pick the one sharing
+            # the most path with where we already are.
+            chosen = max(hits, key=lambda h: len(os.path.commonprefix([h, last_dir])))
+        else:
+            chosen = f"{last_dir}/{base}" if last_dir else base
+
+        if "/" in chosen:
+            last_dir = chosen.rsplit("/", 1)[0]
+        resolved.append(chosen)
+    return sorted(set(resolved))
+
+
+def parse_tasks(text: str, lines: list[str], index: dict[str, list[str]]) -> list[dict]:
+    marks = [(m.start(), int(m.group(1)), m.group(2)) for m in TASK_RE.finditer(text)]
+    tasks = []
+    for i, (start, num, title) in enumerate(marks):
+        end = marks[i + 1][0] if i + 1 < len(marks) else len(text)
+        block = text[start:end]
+        line_no = text[:start].count("\n") + 1
+
+        files_m = re.search(r"\*\*Files:\*\*(.*?)(?:\n\s*\n|\*\*Interfaces)", block, re.S)
+        files = resolve_paths(files_m.group(1), index) if files_m else []
+
+        produces_m = PRODUCES_RE.search(block)
+        produces = produces_m.group(1).strip() if produces_m else ""
+
+        commits = COMMIT_RE.findall(block)
+        steps = [{"checked": c.lower() == "x", "title": t} for c, t in STEP_RE.findall(block)]
+
+        tasks.append({
+            "num": num,
+            "title": title.strip(),
+            "line": line_no,
+            "end_line": text[:end].count("\n") + 1,
+            "files": files,
+            "produces": produces,
+            "commit_msgs": commits,
+            "steps": steps,
+            "mentions_stub": "stub" in block.lower(),
+        })
+    return tasks
+
+
+# --- evidence --------------------------------------------------------------
+
+STOP = {"feat", "fix", "chore", "docs", "refactor", "test", "client", "server",
+        "api", "and", "the", "a", "an", "with", "for", "to", "of", "in", "on"}
+
+
+def tokens(subject: str) -> set[str]:
+    subject = re.sub(r"^[a-z]+(\([^)]*\))?!?:\s*", "", subject.lower())
+    return {w for w in re.findall(r"[a-z0-9]+", subject) if w not in STOP and len(w) > 2}
+
+
+def match_commit(planned: str, log: list[tuple[str, str]]) -> dict | None:
+    """Commit subjects drift from what the plan prescribed (the plan says
+    'blog feed page and PostCard', the real commit says 'blog feed with
+    PostCard and gating prompt'), so match on token overlap, not equality."""
+    want = tokens(planned)
+    if not want:
+        return None
+    best, best_score = None, 0.0
+    for sha, subject in log:
+        score = len(want & tokens(subject)) / len(want)
+        if score > best_score:
+            best, best_score = (sha, subject), score
+    if best and best_score >= 0.7:
+        return {"sha": best[0], "subject": best[1], "confidence": round(best_score, 2)}
+    return None
+
+
+def build_index(root: Path) -> dict[str, list[str]]:
+    """basename -> tracked paths. git ls-files keeps node_modules out for free."""
+    index: dict[str, list[str]] = {}
+    for line in git("ls-files", cwd=root).splitlines():
+        index.setdefault(line.rsplit("/", 1)[-1], []).append(line)
+    return index
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plan", help="path to a specific plan file (default: the active one)")
+    ap.add_argument("--base", default="master", help="branch the merged work lands beyond (default: master)")
+    args = ap.parse_args()
+
+    root = repo_root()
+    plans_dir = root / "docs" / "superpowers" / "plans"
+    if not plans_dir.is_dir():
+        print(json.dumps({"error": f"no plans directory at {plans_dir}"}))
+        return 1
+
+    all_plans = sorted(plans_dir.glob("*.md"))
+    catalog = []
+    for p in all_plans:
+        t = p.read_text(encoding="utf-8", errors="replace")
+        catalog.append({"path": str(p.relative_to(root)).replace("\\", "/"),
+                        "complete": is_complete(t)})
+
+    if args.plan:
+        plan_path = Path(args.plan)
+        if not plan_path.is_absolute():
+            plan_path = root / plan_path
+    else:
+        active = [c for c in catalog if not c["complete"]]
+        if not active:
+            print(json.dumps({"plans": catalog, "active_plan": None,
+                              "note": "every plan reports itself complete"}, indent=2))
+            return 0
+        plan_path = root / active[-1]["path"]
+
+    text = plan_path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    tasks = parse_tasks(text, lines, build_index(root))
+
+    branch = git("rev-parse", "--abbrev-ref", "HEAD", cwd=root)
+    log_raw = git("log", "--oneline", "--no-merges", "-80", cwd=root)
+    log = []
+    for ln in log_raw.splitlines():
+        sha, _, subject = ln.partition(" ")
+        log.append((sha, subject))
+
+    merged_raw = git("log", "--oneline", "--no-merges", f"{args.base}..HEAD", cwd=root)
+    merged_shas = {ln.split(" ", 1)[0] for ln in merged_raw.splitlines()}
+
+    for t in tasks:
+        t["file_status"] = {
+            f: ("present" if (root / f).exists() else "MISSING") for f in t["files"]
+        }
+        hits = [h for h in (match_commit(m, log) for m in t["commit_msgs"]) if h]
+        for h in hits:
+            h["on_current_branch"] = h["sha"] in merged_shas
+        t["commit_evidence"] = hits
+        missing = [f for f, s in t["file_status"].items() if s == "MISSING"]
+        # Two independent axes: do the artifacts exist, and did something ship them.
+        # They only agree at the extremes; the disagreements are exactly the tasks
+        # worth verifying by hand, so name them rather than guessing.
+        if not t["files"] and not hits:
+            t["signal"] = "NO_EVIDENCE"
+        elif missing and not hits:
+            t["signal"] = "NOT_STARTED"
+        elif not missing and hits:
+            t["signal"] = "LIKELY_DONE"
+        else:
+            t["signal"] = "NEEDS_CHECK"          # mixed — verify against Produces
+
+    result = {
+        "plans": catalog,
+        "active_plan": str(plan_path.relative_to(root)).replace("\\", "/"),
+        "plan_title": lines[0].lstrip("# ").strip() if lines else "",
+        "plan_lines": len(lines),
+        "task_count": len(tasks),
+        "checkbox_stats": {
+            "checked": text.count("- [x]") + text.count("- [X]"),
+            "unchecked": text.count("- [ ]"),
+        },
+        "git": {
+            "branch": branch,
+            "base": args.base,
+            "dirty": bool(git("status", "--porcelain", cwd=root)),
+            "ahead_of_base": len(merged_shas),
+            "recent": [f"{s} {m}" for s, m in log[:12]],
+        },
+        "amendments": parse_amendments(text, lines),
+        "tasks": tasks,
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/readme-maintenance/SKILL.md
+++ b/.claude/skills/readme-maintenance/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: readme-maintenance
+description: >-
+  Use on the Blog-Chat-app repo right before opening a PR from a dev/* branch — check whether README.md
+  needs an update given what the branch actually changed, and update it if so, BEFORE the PR is opened, so
+  the README update lands in the same PR as the change it documents. Also use whenever the user explicitly
+  asks to check, update, or review README.md, independent of any PR. Trigger on "open a PR", "ready to PR",
+  "create the PR", "let's ship this", "update the README", "does the README need updating", or any point in
+  the git-feature-branch workflow where a PR is about to be created — even if the user doesn't mention the
+  README themselves.
+---
+
+# README Maintenance
+
+## Why this exists
+
+`README.md` on `staging` is a deliberately maintained baseline (rewritten 2026-07-29) covering six things:
+project summary, architecture diagram, core-flow diagrams, tech stack, core features, and local-run
+commands. A baseline like that only stays true if every PR that changes one of those six things updates
+the matching section — otherwise it drifts the same way the pre-rewrite README did (still describing a
+CRA/Redux app years after the rebuild started). This skill is the checkpoint that catches that drift at
+the one moment it's cheapest to fix: before the PR opens, using the diff that's already sitting there.
+
+**This skill never invents a new baseline.** If README.md looks structurally wrong for reasons unrelated to
+the current branch's diff (sections missing entirely, describing a different architecture altogether),
+that's a signal the baseline itself needs redoing — stop and say so rather than trying to patch it
+piecemeal.
+
+## Step 1 — Check whether README.md already moved on this branch
+
+```bash
+python .claude/skills/readme-maintenance/scripts/check_readme.py --base origin/staging
+```
+
+Swap `--base` if the branch stacks on something other than `staging` (dev-off-dev, per the
+feature-branch-discipline rule). The script only gathers facts — merge-base, every changed file, the
+branch's commit subjects, any `package.json` diffs, and which `apps/*`/`packages/*` directories were
+touched — it makes no judgment call.
+
+**If `readme_already_touched_on_this_branch` is true, stop here.** Skip straight to opening the PR. Don't
+second-guess an update that's already part of the branch's own commits — that's the "check git commits"
+part of this skill's job, and it's mechanical, not a judgment call.
+
+## Step 2 — Decide if the diff actually touches one of the six sections
+
+README.md has exactly six load-bearing sections (`## About`, `## Architecture`, `## Core flows, in a
+nutshell`, `## Tech stack`, `## Core features`, `## Quick start` + `## Scripts`). Map the script's output
+onto them:
+
+| Signal from Step 1 | Section likely affected |
+|---|---|
+| A new top-level dir under `apps/*` or `packages/*` (e.g. a brand-new `apps/realtime`) | Architecture diagram |
+| A new REST resource, a new primary user-facing capability, or removal of one | Core features |
+| `package_json_diff` adding/removing a real dependency (not a devDependency version bump) | Tech stack table |
+| A new root `npm run <script>` in `package.json`, or a changed `docker compose` invocation | Quick start / Scripts |
+| A new or materially changed primary flow (how auth works, how gating works, a new one entirely) | Core flows diagrams |
+| Bugfixes, refactors, test-only changes, internal renames, dependency patch bumps, anything that doesn't change what a reader of the README would need to know | **None — no update needed** |
+
+A branch can legitimately touch none of these. **Say so explicitly** ("this is a pure bugfix, no README
+section is affected") rather than silently doing nothing — the difference between "I checked and it
+doesn't need one" and "I forgot to check" matters to whoever reads this later.
+
+When in doubt about whether a change is "core" enough to document (a small tag-filter addition to search,
+say, vs. the search feature itself already being documented): favor a small, surgical addition to the
+existing section over either silence or a rewrite. The README describes what the project *is*, not a
+changelog of every diff that ever touched it.
+
+## Step 3 — Update surgically, not wholesale
+
+Edit only the section(s) Step 2 identified, in place. Match the existing style exactly:
+
+- **Architecture / flow diagrams** are Mermaid, in the same terse style as the existing ones (a handful of
+  nodes, not every internal function). Look at the diagram you're editing before adding to it — a new node
+  that doesn't match the existing diagram's level of abstraction (e.g. naming a specific function inside a
+  box that otherwise names only services) will look out of place immediately.
+- **Tech stack** is one row per layer (Server / Client / Shared / Testing / Tooling), not one row per
+  package — add to the relevant row's list rather than creating a new row for one dependency.
+- **Core features** is a flat bullet list of user-facing capabilities, past tense implied ("Threaded
+  comments" not "Add threaded comments"). The "Not yet built" note directly underneath it exists on
+  purpose — if the branch just built one of those items, move it up into the feature list and remove it
+  from that note, don't leave it duplicated in both places.
+- **Quick start / Scripts** only changes when a command actually changed — don't reformat the whole table
+  for one new row.
+
+Never touch `## Search semantics` or `## The API, if you want to bypass the UI` unless the branch's diff
+specifically changes the mechanism those sections describe (e.g. a branch that changes how `$text` search
+works, not one that just adds a filter alongside it).
+
+## Step 4 — Commit it onto the current branch, then proceed to the PR
+
+The README update is part of the same change it documents, so it belongs in the same commit or a
+same-branch follow-up commit — never a separate branch, and never pushed straight to `staging` (the
+README-direct-to-staging exception in `CLAUDE.md` is for README-*only* branches; a README edit that rides
+along with a feature branch is just part of that feature's normal PR flow). Once committed, continue with
+the rest of the git-feature-branch workflow (push, open the PR, review, CI, merge) as normal.
+
+## Scope
+
+This skill decides *whether* and *what* to edit in `README.md`; it doesn't touch
+`docs/architecture/deployment-architecture.md` or the phase plans under `docs/superpowers/plans/` — those
+are separate living/point-in-time docs with their own update points (P2 Task 13 established the pattern for
+`deployment-architecture.md`; there's no equivalent automated check for it yet). It also never opens the PR
+itself or runs CI — it's the one step that happens *before* those, not a replacement for them.

--- a/.claude/skills/readme-maintenance/scripts/check_readme.py
+++ b/.claude/skills/readme-maintenance/scripts/check_readme.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Gathers mechanical evidence for whether README.md needs an update before a PR opens or when user explicitly ask.
+
+Usage:
+    python .claude/skills/readme-maintenance/scripts/check_readme.py [--base BRANCH]
+
+Prints JSON. This script only gathers facts — it never edits README.md and never
+decides whether an update is warranted. That judgment call (does this diff actually
+touch one of the six tracked README sections?) belongs to whoever is running the
+skill, informed by this output.
+"""
+import argparse
+import json
+import subprocess
+
+
+def run(cmd: str) -> str:
+    return subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout.strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base",
+        default="origin/staging",
+        help="Branch this feature branch is stacked on (default: origin/staging).",
+    )
+    args = parser.parse_args()
+
+    base = args.base
+    merge_base = run(f"git merge-base {base} HEAD") or base
+
+    changed_files = [f for f in run(f"git diff --name-only {merge_base}..HEAD").splitlines() if f]
+    readme_touched = "README.md" in changed_files
+
+    commits = [c for c in run(f"git log --oneline {merge_base}..HEAD").splitlines() if c]
+
+    package_json_files = [f for f in changed_files if f.endswith("package.json")]
+    package_json_diff = (
+        run(f"git diff {merge_base}..HEAD -- {' '.join(package_json_files)}")
+        if package_json_files
+        else ""
+    )
+
+    # New top-level directories under apps/ or packages/ are the strongest signal
+    # of an architecture-diagram-worthy change (a new service, a new shared package).
+    new_top_level_dirs = sorted(
+        {
+            f.split("/", 2)[1]
+            for f in changed_files
+            if f.startswith(("apps/", "packages/")) and len(f.split("/")) > 2
+        }
+    )
+
+    result = {
+        "base": base,
+        "merge_base": merge_base,
+        "readme_already_touched_on_this_branch": readme_touched,
+        "changed_files": changed_files,
+        "commit_subjects": commits,
+        "package_json_files_changed": package_json_files,
+        "package_json_diff": package_json_diff,
+        "apps_or_packages_touched": new_top_level_dirs,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ test-results/
 playwright-report/
 .DS_Store
 .local
-.claude
+.claude/settings.local.json
+.claude/*.local.md
+.claude/worktrees/
 infra/secrets/**/*.txt


### PR DESCRIPTION
## Summary
- New project skill \`.claude/skills/readme-maintenance\`: checks whether README.md needs an update before a \`dev/*\` branch opens its PR (skip if the branch already touched it; otherwise map the diff onto the six tracked README sections and update surgically).
- Baseline README rewrite already landed directly on \`staging\` (per the new README-direct-push rule) — this PR is the skill that keeps it from drifting again.
- Fixed \`.gitignore\`: it blanket-ignored \`.claude\`, so the two pre-existing project skills (\`docker-compose-rebuild\`, \`plan-status\`) were never actually committed despite CLAUDE.md documenting them as repo conventions. Narrowed the ignore to the genuinely local-only pieces (\`settings.local.json\`, \`*.local.md\`, \`worktrees/\`) so \`.claude/skills/\` is tracked and shared going forward.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run build\`
- Dogfooded the new skill's check script on this very branch: correctly reports no README section is affected (pure tooling/config change).