### PR TITLE
chore: ignore .playwright-mcp scratch output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ playwright-report/
 .claude/*.local.md
 .claude/worktrees/
 infra/secrets/**/*.txt
+.playwright-mcp


### PR DESCRIPTION
The Playwright MCP server writes session artifacts into `.playwright-mcp/` at the repo root. They are local tooling output and should never be committed.

One line in `.gitignore`, no code touched.

**Why this is a branch and not a direct push:** `CLAUDE.md`'s direct-to-`staging` exception is scoped to `README.md` only, and says explicitly *"never use that opening for anything beyond `README.md`."* A `.gitignore` change goes through the normal flow.

**README:** no update needed — tooling-only change, touches none of the six load-bearing sections.