### PR TITLE
fix(security): stop logging plaintext passwords on the auth paths

### DIFF
--- a/apps/client/src/api/client.test.ts
+++ b/apps/client/src/api/client.test.ts
@@ -34,3 +34,35 @@ describe('request', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/v1/posts', expect.objectContaining({ credentials: 'include' }))
   })
 })
+
+/**
+ * `request` is the single path every API call takes, so its DEBUG trace sees
+ * the signup and login bodies — plaintext passwords included. Per-endpoint
+ * fixes cannot cover this: a wrapper that logs whatever it is handed re-leaks
+ * anything its callers were careful about.
+ */
+describe('request credential logging', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('never logs a password from a request body, even with DEBUG on', async () => {
+    vi.stubEnv('VITE_DEBUG', 'true')
+    vi.resetModules()
+    const { request: freshRequest } = await import('./client.js')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await freshRequest('/api/v1/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username: 'recruiter', password: 'super-secret-value' }),
+    })
+
+    // Without this the test passes vacuously whenever DEBUG resolves false.
+    expect(log).toHaveBeenCalled()
+    expect(JSON.stringify(log.mock.calls)).not.toContain('super-secret-value')
+  })
+})

--- a/apps/client/src/api/client.ts
+++ b/apps/client/src/api/client.ts
@@ -1,4 +1,5 @@
 import { DEBUG } from '../lib/constants.js'
+import { redactSecrets } from '../lib/redact.js'
 
 export class ApiError extends Error {
   readonly status: number
@@ -16,7 +17,16 @@ export async function request<T>(path: string, init?: RequestInit): Promise<T | 
   const method = init?.method || 'GET'
 
   if (DEBUG) {
-    const body = init?.body ? JSON.parse(init.body as string) : null
+    // Every API call funnels through here, signup and login included, so this
+    // trace sees plaintext passwords. Redacting at the wrapper is what actually
+    // closes it — a per-endpoint fix cannot, since the wrapper logs whatever it
+    // is handed. Non-JSON bodies (FormData, Blob) are simply not traced.
+    let body: unknown = null
+    try {
+      body = typeof init?.body === 'string' ? redactSecrets(JSON.parse(init.body)) : null
+    } catch {
+      body = '[unparsed body]'
+    }
     console.log(`[API] ${method} ${path}`, body)
   }
 

--- a/apps/client/src/lib/redact.ts
+++ b/apps/client/src/lib/redact.ts
@@ -1,0 +1,26 @@
+/**
+ * Masks credential-bearing keys before a value reaches a log sink.
+ *
+ * NOTE: a deliberate copy of apps/server/src/lib/redact.ts. packages/zod-shared
+ * is Zod-schemas-only by design, so there is nowhere shared for a plain utility
+ * to live yet. The two must change together. A second non-Zod util wanting to be
+ * shared (the P4 JWT verifier is the other candidate, flagged open in the design
+ * spec) is the signal to create a real shared package and delete both copies.
+ */
+const SENSITIVE_KEY =
+  /^(password|confirmPassword|currentPassword|newPassword|token|secret|apiKey|authorization|cookie)$/i
+
+/**
+ * Recurses through plain objects and arrays. Inputs come from JSON.parse'd
+ * request bodies, which cannot contain cycles, so no seen-set is needed.
+ */
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecrets)
+  if (value === null || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) =>
+      SENSITIVE_KEY.test(key) ? [key, '[redacted]'] : [key, redactSecrets(nested)],
+    ),
+  )
+}

--- a/apps/server/src/lib/redact.test.ts
+++ b/apps/server/src/lib/redact.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { redactSecrets } from './redact.js'
+
+describe('redactSecrets', () => {
+  it('masks a password while keeping the rest of the body readable', () => {
+    expect(redactSecrets({ username: 'recruiter', password: 'hunter2' })).toEqual({
+      username: 'recruiter',
+      password: '[redacted]',
+    })
+  })
+
+  it('matches the key regardless of case, so Password and PASSWORD are covered too', () => {
+    expect(redactSecrets({ Password: 'a', TOKEN: 'b' })).toEqual({
+      Password: '[redacted]',
+      TOKEN: '[redacted]',
+    })
+  })
+
+  it('reaches secrets nested inside objects and arrays', () => {
+    expect(redactSecrets({ users: [{ name: 'a', password: 'hunter2' }] })).toEqual({
+      users: [{ name: 'a', password: '[redacted]' }],
+    })
+  })
+
+  it('leaves primitives and non-secret values untouched', () => {
+    expect(redactSecrets({ n: 1, s: 'x', b: true, nil: null })).toEqual({
+      n: 1,
+      s: 'x',
+      b: true,
+      nil: null,
+    })
+  })
+
+  // A confirmation field holds the same credential as the field it confirms.
+  it('masks confirmPassword, not just password', () => {
+    expect(redactSecrets({ confirmPassword: 'hunter2' })).toEqual({
+      confirmPassword: '[redacted]',
+    })
+  })
+})

--- a/apps/server/src/lib/redact.ts
+++ b/apps/server/src/lib/redact.ts
@@ -1,0 +1,33 @@
+/**
+ * Masks credential-bearing keys before a value reaches a log sink.
+ *
+ * The project's guidance is to trace requests during development, and the
+ * signup/login bodies that tracing sees carry a plaintext password. Gating the
+ * trace behind DEBUG keeps production silent, but DEBUG gets switched on
+ * precisely when someone is chasing a bug — so the value itself is masked too,
+ * and neither guarantee depends on the other.
+ *
+ * NOTE: apps/client/src/lib/redact.ts is a deliberate copy of this file.
+ * packages/zod-shared is Zod-schemas-only by design, so there is nowhere shared
+ * for a plain utility to live yet. The two must change together. A second
+ * non-Zod util wanting to be shared (the P4 JWT verifier is the other candidate,
+ * flagged open in the design spec) is the signal to create a real shared package
+ * and delete both copies.
+ */
+const SENSITIVE_KEY =
+  /^(password|confirmPassword|currentPassword|newPassword|token|secret|apiKey|authorization|cookie)$/i
+
+/**
+ * Recurses through plain objects and arrays. Inputs come from JSON.parse'd
+ * request bodies, which cannot contain cycles, so no seen-set is needed.
+ */
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecrets)
+  if (value === null || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) =>
+      SENSITIVE_KEY.test(key) ? [key, '[redacted]'] : [key, redactSecrets(nested)],
+    ),
+  )
+}

--- a/apps/server/src/middleware/validate.test.ts
+++ b/apps/server/src/middleware/validate.test.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import { ValidationError } from '../lib/errors.js'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { validate } from './validate.js'
 
@@ -44,5 +44,44 @@ describe('validate', () => {
     const { req, res, next } = ctx(undefined)
     validate(Schema)(req, res, next)
     expect(next.mock.calls[0]?.[0]).toBeInstanceOf(ValidationError)
+  })
+})
+
+/**
+ * This middleware wraps every validated route, including POST /auth/signup and
+ * /auth/login — so whatever it logs, it logs a plaintext password. Two separate
+ * guarantees, because either alone is insufficient: the gate keeps production
+ * silent, and the redaction means turning DEBUG on to chase a bug (which is
+ * exactly when someone would) still cannot spill a credential.
+ */
+describe('validate credential logging', () => {
+  const originalDebug = process.env.DEBUG
+
+  afterEach(() => {
+    if (originalDebug === undefined) delete process.env.DEBUG
+    else process.env.DEBUG = originalDebug
+    vi.restoreAllMocks()
+  })
+
+  it('never logs a password, even with DEBUG on', () => {
+    process.env.DEBUG = '1'
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const { req, res, next } = ctx({ title: 'A Good Title', password: 'super-secret-value' })
+
+    validate(Schema)(req, res, next)
+
+    // Without this the test passes vacuously if the gate suppresses everything.
+    expect(log).toHaveBeenCalled()
+    expect(JSON.stringify(log.mock.calls)).not.toContain('super-secret-value')
+  })
+
+  it('logs nothing at all when DEBUG is off', () => {
+    delete process.env.DEBUG
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const { req, res, next } = ctx({ title: 'A Good Title', password: 'super-secret-value' })
+
+    validate(Schema)(req, res, next)
+
+    expect(log).not.toHaveBeenCalled()
   })
 })

--- a/apps/server/src/middleware/validate.ts
+++ b/apps/server/src/middleware/validate.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express'
 import { ValidationError } from '../lib/errors.js'
+import { redactSecrets } from '../lib/redact.js'
 import type { ZodTypeAny } from 'zod'
 
 /**
@@ -13,15 +14,24 @@ import type { ZodTypeAny } from 'zod'
 export const validate =
   (schema: ZodTypeAny): RequestHandler =>
   (req, _res, next) => {
-    console.log(`[VALIDATE] Validating ${req.method} ${req.path}`, req.body ?? {})
+    // Gated AND redacted. This middleware wraps /auth/signup and /auth/login, so
+    // an ungated body trace writes plaintext passwords into the platform's
+    // production logs on every auth request.
+    if (process.env.DEBUG) {
+      console.log(`[VALIDATE] Validating ${req.method} ${req.path}`, redactSecrets(req.body ?? {}))
+    }
     const result = schema.safeParse(req.body ?? {})
     if (!result.success) {
-      console.error(`[VALIDATE] Validation failed:`, result.error.flatten())
+      // fieldErrors carries Zod's messages, never the submitted values — the
+      // full flatten() is not logged, because formErrors can echo input.
+      if (process.env.DEBUG) {
+        console.error(`[VALIDATE] Validation failed:`, result.error.flatten().fieldErrors)
+      }
       const fields = result.error.flatten().fieldErrors as Record<string, string[]>
       next(new ValidationError('Invalid input.', fields))
       return
     }
-    console.log(`[VALIDATE] Validation passed`)
+    if (process.env.DEBUG) console.log(`[VALIDATE] Validation passed`)
     req.body = result.data
     next()
   }


### PR DESCRIPTION
Found during a full-codebase security audit. Two request-body traces sat on the signup and login paths and logged the credential in the clear.

## The serious one — `apps/server/src/middleware/validate.ts`

```ts
console.log(`[VALIDATE] Validating ${req.method} ${req.path}`, req.body ?? {})
```

No `DEBUG` gate, no `NODE_ENV` check. This middleware wraps **every** validated route, and `POST /auth/signup` + `POST /auth/login` both carry a plaintext password in `req.body`. Once promoted, this writes user credentials into Render's platform-retained service logs on every auth request.

Nothing has leaked — `staging` is not deployed. But `CLAUDE.md` requires this tracing be `DEBUG`-gated, and this line predates that rule.

## The one that survived an earlier fix — `apps/client/src/api/client.ts`

```ts
const body = init?.body ? JSON.parse(init.body as string) : null
console.log(`[API] ${method} ${path}`, body)
```

An earlier branch fixed the same leak in `authApi.signup` and `SignupPage`. That was **not sufficient**, and I reported it as closed when it wasn't: `request` is the single wrapper every API call funnels through, so it re-leaks whatever its callers were careful about. Per-endpoint fixes cannot close a wrapper-level leak.

The earlier test mocked `request`, which is exactly why it passed while the leak survived.

## Approach — gated **and** redacted

Either alone is insufficient. The gate keeps production silent; the redaction means switching `DEBUG` on to chase a bug — precisely when someone would — still cannot spill a credential.

`redactSecrets` masks `password`, `confirmPassword`, `token`, `secret`, `apiKey`, `authorization`, `cookie` (case-insensitive), recursing through objects and arrays.

**On the duplication:** it exists in both apps rather than shared, because `packages/zod-shared` is Zod-schemas-only by design and a plain utility has nowhere to live yet. Both copies carry a note that they must move together. A second shared non-Zod util — the P4 JWT verifier is the other candidate, already flagged open in the design spec — is the signal to create a real package and delete both copies.

## Tests

Each fix has a regression test driving the **real** code path, asserting the log actually fired before asserting the password is absent, so neither can pass vacuously. I verified each failed first for the right reason.

- typecheck ✅
- lint ✅
- 317/317 tests ✅

**README:** no update needed — security bugfix, touches none of the six load-bearing sections.

## Still open from the same audit (not in this PR)

- Timing-based username enumeration in `verifyCredentials` — unknown user returns before bcrypt runs, so response time reveals what the response body deliberately hides
- Ungated PII logging (usernames/emails) in `auth.ts` and `user.ts`
- Three low-severity bounds gaps

Audit also confirmed clean: **0 production dependency vulnerabilities**, no hardcoded secrets, no XSS sinks, NoSQL injection blocked, authorization complete on every mutating route.