### PR TITLE
feat(client): confirm password on signup, validated before the request

### DIFF
--- a/apps/client/src/api/auth.test.ts
+++ b/apps/client/src/api/auth.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./client.js', () => ({ request: vi.fn() }))
+
+describe('authApi debug logging', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  // The page-level guard in SignupPage.test.tsx cannot see this: it mocks
+  // authApi wholesale, so a leak inside authApi itself passes straight through.
+  // This is the layer that actually holds the credential on its way to the wire.
+  it('never logs the plaintext password when tracing a signup', async () => {
+    vi.stubEnv('VITE_DEBUG', 'true')
+    vi.resetModules()
+    const { request } = await import('./client.js')
+    const { authApi } = await import('./auth.js')
+    vi.mocked(request).mockResolvedValue({
+      id: 'u1',
+      username: 'recruiter',
+      email: 'recruiter@example.com',
+    })
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await authApi.signup({
+      username: 'recruiter',
+      email: 'recruiter@example.com',
+      password: 'a-valid-password',
+    })
+
+    // Without this the test passes vacuously whenever DEBUG resolves false.
+    expect(log).toHaveBeenCalled()
+    expect(JSON.stringify(log.mock.calls)).not.toContain('a-valid-password')
+  })
+})

--- a/apps/client/src/api/auth.ts
+++ b/apps/client/src/api/auth.ts
@@ -7,7 +7,10 @@ export type User = { id: string; username: string; email: string }
 
 export const authApi = {
   signup: (input: z.infer<typeof SignupSchema>) => {
-    if (DEBUG) console.log('[AUTH_API] signup called with:', input)
+    // Never spread `input` into a log: it carries the plaintext password, and
+    // the hardening pass forbids a credential reaching any log sink. Trace the
+    // identifying fields only.
+    if (DEBUG) console.log('[AUTH_API] signup called for:', input.username, input.email)
     return request<User>('/api/v1/auth/signup', { method: 'POST', body: JSON.stringify(input) })
   },
 

--- a/apps/client/src/lib/signup-form-schema.ts
+++ b/apps/client/src/lib/signup-form-schema.ts
@@ -1,0 +1,24 @@
+import { SignupSchema } from '@blog/zod-shared'
+import { z } from 'zod'
+
+/**
+ * Client-only, and deliberately NOT in packages/zod-shared.
+ *
+ * Confirmation is a typo guard for the person typing, not a security control:
+ * the server gains nothing from a second copy of a password it already has, and
+ * publishing a `confirmPassword` field in the shared schema would imply the API
+ * validates something it has no reason to see. So the shared schema stays the
+ * wire contract and this extends it for the form only — `handleSubmit` parses
+ * with this, then sends the shared schema's fields.
+ *
+ * Extended from SignupSchema rather than redeclared, so the username, email and
+ * password rules cannot drift from the ones the server enforces.
+ */
+export const SignupFormSchema = SignupSchema.extend({
+  confirmPassword: z.string().min(1, 'Re-enter your password'),
+}).refine((values) => values.password === values.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+})
+
+export type SignupForm = z.infer<typeof SignupFormSchema>

--- a/apps/client/src/pages/SignupPage.test.tsx
+++ b/apps/client/src/pages/SignupPage.test.tsx
@@ -1,0 +1,119 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/AutoForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mocked at the API boundary rather than at `useSignup`, so the assertion on the
+// outgoing payload is about what actually reaches the wire.
+vi.mock('../api/auth.js', () => ({
+  authApi: { signup: vi.fn(), login: vi.fn(), logout: vi.fn(), me: vi.fn() },
+}))
+
+const { authApi } = await import('../api/auth.js')
+const { SignupPage } = await import('./SignupPage.js')
+
+function renderSignup(Page: typeof SignupPage = SignupPage) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <Page />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const fill = (label: string, value: string) =>
+  fireEvent.change(screen.getByLabelText(label), { target: { value } })
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+function fillValidForm({ confirmWith }: { confirmWith?: string } = {}) {
+  fill('Username', 'recruiter')
+  fill('Email', 'recruiter@example.com')
+  fill('Password', 'a-valid-password')
+  fill('Confirm password', confirmWith ?? 'a-valid-password')
+}
+
+describe('SignupPage password confirmation', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => cleanup())
+
+  // The regression this closes (spec §14): the legacy app compared the
+  // confirmation only after the request had already been sent.
+  it('does not send the request when the confirmation does not match', () => {
+    renderSignup()
+    fillValidForm({ confirmWith: 'a-valid-passwerd' })
+    submit()
+
+    expect(authApi.signup).not.toHaveBeenCalled()
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument()
+  })
+
+  // confirmPassword is a client-only field. Sending it would imply the API
+  // validates something it has no schema for.
+  it('sends only the API schema fields — never confirmPassword', async () => {
+    vi.mocked(authApi.signup).mockResolvedValue({ id: 'u1', username: 'recruiter', email: 'recruiter@example.com' })
+    renderSignup()
+    fillValidForm()
+    submit()
+
+    await waitFor(() => expect(authApi.signup).toHaveBeenCalledTimes(1))
+    // An exact object: an extra key fails this assertion.
+    expect(authApi.signup).toHaveBeenCalledWith({
+      username: 'recruiter',
+      email: 'recruiter@example.com',
+      password: 'a-valid-password',
+    })
+  })
+
+  // Confirming and then editing the password above it must not leave the
+  // earlier "matched" state standing.
+  it('re-flags the mismatch when the password is edited after confirming', () => {
+    renderSignup()
+    fill('Password', 'a-valid-password')
+    fill('Confirm password', 'a-valid-password')
+    expect(screen.queryByText('Passwords do not match')).not.toBeInTheDocument()
+
+    fill('Password', 'a-different-password')
+
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument()
+  })
+})
+
+describe('SignupPage debug logging', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+    vi.restoreAllMocks()
+    cleanup()
+  })
+
+  // This repo leaked a credential once already (2026-07-16) and the hardening
+  // pass forbids a plaintext password reaching ANY log sink — a developer's
+  // console included. DEBUG is read at module load, so the env is stubbed and
+  // the module re-imported before rendering.
+  it('never logs the plaintext password, even with DEBUG on', async () => {
+    vi.stubEnv('VITE_DEBUG', 'true')
+    vi.resetModules()
+    const { authApi: api } = await import('../api/auth.js')
+    const { SignupPage: Page } = await import('./SignupPage.js')
+    vi.mocked(api.signup).mockResolvedValue({ id: 'u1', username: 'recruiter', email: 'recruiter@example.com' })
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    renderSignup(Page)
+    fillValidForm()
+    submit()
+
+    await waitFor(() => expect(api.signup).toHaveBeenCalled())
+    // Without this the test passes vacuously whenever DEBUG resolves false.
+    expect(log).toHaveBeenCalled()
+    expect(JSON.stringify(log.mock.calls)).not.toContain('a-valid-password')
+  })
+})

--- a/apps/client/src/pages/SignupPage.tsx
+++ b/apps/client/src/pages/SignupPage.tsx
@@ -5,6 +5,7 @@ import { Input } from '../components/ui/input.js'
 import { Label } from '../components/ui/label.js'
 import { useSignup } from '../hooks/use-auth.js'
 import { DEBUG } from '../lib/constants.js'
+import { SignupFormSchema } from '../lib/signup-form-schema.js'
 import { SignupSchema } from '@blog/zod-shared'
 
 export function SignupPage() {
@@ -13,6 +14,7 @@ export function SignupPage() {
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   const validateField = (field: string, value: string) => {
@@ -36,25 +38,61 @@ export function SignupPage() {
     }
   }
 
+  /**
+   * Cross-field, so it cannot go through validateField: the match rule lives on
+   * the object via .refine(), and SignupFormSchema.shape.confirmPassword only
+   * knows "non-empty". Called from BOTH password inputs — confirming and then
+   * editing the password above must not leave the earlier match standing.
+   */
+  const validateMatch = (nextPassword: string, nextConfirm: string) => {
+    setErrors((prev) => {
+      const next = { ...prev }
+      if (nextConfirm.length > 0 && nextPassword !== nextConfirm) {
+        next.confirmPassword = 'Passwords do not match'
+      } else {
+        delete next.confirmPassword
+      }
+      return next
+    })
+  }
+
   const isFormValid =
     username.trim().length > 0 &&
     email.trim().length > 0 &&
     password.trim().length > 0 &&
+    confirmPassword.length > 0 &&
     Object.keys(errors).length === 0
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!isFormValid) return
-    if (DEBUG) console.log('[SIGNUP_PAGE] Form submitted with:', { username, email, password })
-    signup(
-      { username, email, password },
-      {
-        onSuccess: () => {
-          if (DEBUG) console.log('[SIGNUP_PAGE] Signup successful, navigating to /')
-          navigate('/')
-        },
+
+    // Validate BEFORE the request, never after. The legacy app (spec §14)
+    // compared the confirmation once the response was already back, so a
+    // mismatched signup had already been accepted by the time it complained.
+    const result = SignupFormSchema.safeParse({ username, email, password, confirmPassword })
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {}
+      for (const issue of result.error.errors) {
+        const field = issue.path[0]
+        if (typeof field === 'string' && !fieldErrors[field]) fieldErrors[field] = issue.message
+      }
+      setErrors(fieldErrors)
+      return
+    }
+
+    // `password` is deliberately absent: this is a plaintext credential, and the
+    // hardening pass forbids it reaching any log sink, including a dev console.
+    if (DEBUG) console.log('[SIGNUP_PAGE] Form submitted with:', { username, email })
+
+    // Only the shared schema's fields go on the wire — confirmPassword is a
+    // form concern and the API has no field for it.
+    const { confirmPassword: _confirmPassword, ...credentials } = result.data
+    signup(credentials, {
+      onSuccess: () => {
+        if (DEBUG) console.log('[SIGNUP_PAGE] Signup successful, navigating to /')
+        navigate('/')
       },
-    )
+    })
   }
 
   return (
@@ -107,11 +145,31 @@ export function SignupPage() {
               onChange={(e) => {
                 setPassword(e.target.value)
                 validateField('password', e.target.value)
+                validateMatch(e.target.value, confirmPassword)
               }}
               className={errors.password ? 'border-[var(--destructive)]' : ''}
               required
             />
             {errors.password && <p className="text-xs text-[var(--destructive)]">{errors.password}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirm password</Label>
+            <p className="text-xs text-[var(--muted-foreground)]">Re-enter the same password</p>
+            <Input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => {
+                setConfirmPassword(e.target.value)
+                validateMatch(password, e.target.value)
+              }}
+              className={errors.confirmPassword ? 'border-[var(--destructive)]' : ''}
+              required
+            />
+            {errors.confirmPassword && (
+              <p className="text-xs text-[var(--destructive)]">{errors.confirmPassword}</p>
+            )}
           </div>
 
           {error && <p className="text-sm text-[var(--destructive)]">Signup failed. Please try again.</p>}

--- a/e2e/auth-and-posts.spec.ts
+++ b/e2e/auth-and-posts.spec.ts
@@ -13,7 +13,15 @@ test('signup, create a post, like it, then log out', async ({ page }) => {
   await page.goto('/signup')
   await page.getByLabel('Username').fill(username)
   await page.getByLabel('Email').fill(`${username}@example.com`)
-  await page.getByLabel('Password').fill('a-valid-password')
+  // `exact` matters: Playwright's getByLabel matches by SUBSTRING, so a bare
+  // 'Password' also resolves "Confirm password" and strict mode fails on the
+  // two matches. (Testing Library's getByLabelText defaults the opposite way,
+  // which is why the component tests never saw this.) Any future field whose
+  // label contains another's needs the same treatment.
+  await page.getByLabel('Password', { exact: true }).fill('a-valid-password')
+  // Required: the form blocks submission until the confirmation matches, so
+  // without this the button stays disabled and the click times out.
+  await page.getByLabel('Confirm password').fill('a-valid-password')
   await page.getByRole('button', { name: 'Sign Up' }).click()
   await expect(page).toHaveURL('/')
   await expect(page.getByText(`Welcome, ${username}`)).toBeVisible()


### PR DESCRIPTION
Closes the one P2 gap left open in the design spec's §14 regression checklist.

## The regression

The legacy app compared the password confirmation only **after** the request had gone out, so a mismatched signup was already accepted by the time the UI complained. The fix is the ordering: `handleSubmit` parses the full schema and bails **before** calling `signup`.

## `SignupFormSchema` is client-only on purpose

It lives in `apps/client/src/lib/`, deliberately **not** in `packages/zod-shared`. Confirmation is a typo guard for the person typing, not a security control — the server gains nothing from a second copy of a password it already has, and publishing a `confirmPassword` field in the shared schema would imply the API validates something it never sees.

It extends `SignupSchema` rather than redeclaring the fields, so the username/email/password rules cannot drift from the ones the server enforces. Only the shared schema's fields go on the wire.

## Cross-field validation needed its own path

The existing `validateField` helper is a ternary chain that falls through to `SignupSchema.shape.password` for any unrecognised field — so a naive fourth arm would have validated the confirmation against the *password* rules and reported "valid" on a mismatch. The match rule lives on the object via `.refine()`, not on the field, so it gets a dedicated `validateMatch` called from **both** password inputs: confirming and then editing the password above it must not leave the earlier match standing.

## Also removes two plaintext-password log leaks on this path

`SignupPage` logged `{ username, email, password }` on submit, and `authApi.signup` logged its whole input object.

⚠️ These two were **not the whole leak** — see #38, which fixes the generic `request` wrapper that re-leaks the password regardless of what these two do. That PR is the one that actually closes it; this one is complementary, not sufficient.

## Tests

5 new tests, TDD'd — I watched each fail first, including reverting the log fix to confirm that test genuinely catches a regression rather than passing vacuously. The payload assertion uses an exact object, so an extra `confirmPassword` key would fail it.

- typecheck ✅
- lint ✅
- 314/314 tests ✅

**README:** no update needed — a confirmation field is a UX detail inside the already-documented signup capability, not a new one. No new dir, dependency, script, REST resource, or flow change.

## Not in scope

`SignupPage` still shows a generic "Signup failed. Please try again." and discards the server's message. The demo-caps spec §4 requires the 403 cap message to render there — that belongs to the caps work (#40), so I left it alone rather than crossing branches.
