### PR TITLE
feat: realtime chat (P4) — Socket.io inside apps/server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,19 @@ npm run seed         # seed the database
 with TypeScript's project-references build mode. There is no root `tsconfig.json`. Don't reintroduce a root
 `tsc --build` — it's been tried and reverted.
 
+**Don't run `typecheck` or `lint` locally — CI owns them.** Both run on every PR; running them again on
+each edit costs minutes per change and buys nothing the PR won't catch. Write clean code, push, and fix
+whatever CI flags. This applies to agents and subagents too: a dispatch should not instruct one to "run
+the full gate" before reporting.
+
+`npm run test` is **not** covered by that rule — keep running it. Tests are the working feedback loop, not
+a gate: TDD depends on watching a test fail before it passes, and a suite that only runs in CI stops being
+usable for that. The same goes for a single-file run while iterating.
+
+`npm run test:e2e` needs the prod Docker image, which currently won't build on this machine (see the Avast
+note below). Treat E2E as CI-verified until that's fixed, and say so plainly rather than implying a spec
+passed locally when it never ran.
+
 **Docker:** per-app multi-stage Dockerfiles (`base → deps → dev`/`builder → runner`) live inside each app
 (`apps/server/Dockerfile`). Orchestration/deploy config lives in `infra/`: `compose.yaml` is the dev stack
 (`target: dev`, hot reload); `compose.e2e.yaml` builds the `runner` target — the actual production image —
@@ -164,3 +177,4 @@ arguments to `toDto` on purpose; collapsing them reports every feed item as lock
 - Never mention spec section numbers in code. Cite them in docs and plans instead.
 - Add `console.*` tracing to API calls, service methods, and middleware during development — request
   path/method, payload, status, errors. Gate with `if (process.env.DEBUG)` to keep production quiet.
+  - Avoid from long comments in the code, if you feel that a comments is necessarry write 2 lines max.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,19 +61,24 @@ so a broken prod build is caught before Render is; `render.yaml` is the prod inf
 
 ```
 apps/
-  server/      # Express REST API; also serves the built SPA in prod → Render web service
+  server/      # Express REST API + Socket.io (P4); also serves the built SPA in prod → Render web service
   client/      # React + Vite SPA → static bundle, served by apps/server
-  realtime/    # Socket.io service (P4) → separate Render web service
 packages/
   zod-shared/  # Zod schemas only — the cross-app package (server validates and client forms both use it)
 ```
 
-**One origin, one service.** `apps/server` serves both `/api/v1/*` and the built SPA (catch-all →
-`index.html`). In dev, Vite's `server.proxy` forwards `/api` to the API container, reproducing the same
-origin. This is load-bearing: the httpOnly session cookie works identically in dev, CI, and prod, and **CORS
-is never needed anywhere**. `apps/realtime` is the exception — it's a separate origin, which is exactly why
-it needs a signed handshake ticket instead of the cookie (Render subdomains are on the Public Suffix List
-and cannot share cookies).
+**One origin, one service — with no exceptions.** `apps/server` serves `/api/v1/*`, the built SPA
+(catch-all → `index.html`), and the Socket.io server, all from one process. In dev, Vite's `server.proxy`
+forwards `/api` to the API container, reproducing the same origin. This is load-bearing: the httpOnly
+session cookie works identically in dev, CI, and prod, and **CORS is never needed anywhere**.
+
+There is **no `apps/realtime`** (decided 2026-07-29). It was designed as a separate service, which forced a
+signed handshake ticket — a separate origin cannot receive the session cookie, and Render subdomains are on
+the Public Suffix List so widening the cookie's domain is refused by the browser, not merely unwise.
+Running Socket.io in the same process removes the ticket, the shared sign/verify package it needed, and
+CORS. The socket reads the session directly via `io.engine.use(sessionMiddleware)`; identity always comes
+from `socket.data.user`, never from a message payload. Rationale:
+`docs/superpowers/specs/2026-07-29-realtime-chat-design.md`.
 
 **Zod is the single source of truth for validation.** Schemas live in `packages/zod-shared/src/schemas/`;
 types are inferred (`z.infer<...>`), never hand-declared. The same schema validates the request on the

--- a/README.md
+++ b/README.md
@@ -12,32 +12,33 @@ A from-scratch rebuild of a five-year-old MERN blog + chat app, built as a portf
 fullstack/backend roles. It reimplements every real feature of the legacy app — session auth, posts,
 likes, threaded comments, search — while fixing five documented authorization holes the original had,
 and adds genuine upgrades (server-side session auth instead of a client-stored JWT, per-reader content
-gating, MongoDB-backed full-text search) the legacy app never had. Realtime chat and OAuth are designed
-but intentionally not built yet.
+gating, MongoDB-backed full-text search, realtime chat over Socket.io) the legacy app never had. OAuth
+login is designed but intentionally not built yet.
 
 ## Architecture
 
 ```mermaid
 flowchart TB
-    Browser(("Browser")) -->|"HTTPS — SPA + /api/v1/*, one origin"| Server
+    Browser(("Browser")) -->|"HTTPS + WebSocket — SPA + /api/v1/* + chat, one origin"| Server
 
     subgraph Server["apps/server (Express)"]
         API["REST API<br/>/api/v1/*"]
+        Chat["Socket.io<br/>realtime chat"]
         SPA["Built client SPA<br/>catch-all → index.html"]
     end
 
-    Server -->|session store| Redis[("Redis")]
+    Server -->|session store + chat buffer/presence| Redis[("Redis")]
     Server -->|Mongoose| Mongo[("MongoDB")]
     Shared["packages/zod-shared<br/>Zod schemas"] -.validates + types.-> Server
     Shared -.forms + types.-> ClientSrc["apps/client source<br/>(built into the Server's image)"]
 ```
 
-**One origin, one deployed service.** `apps/server` serves both the REST API and the built client SPA —
-no separate frontend service, no CORS anywhere, and the httpOnly session cookie behaves identically in
-dev, CI, and prod. `packages/zod-shared` is the cross-app package: the same Zod schema validates a
-request on the server and drives the matching form on the client. Realtime chat (P4, designed but not
-built) will run in this same process rather than as a separate service, so it inherits the same origin and
-the same session instead of needing an auth handshake of its own. Full rationale:
+**One origin, one deployed service.** `apps/server` serves the REST API, the built client SPA, and the
+Socket.io realtime chat server — no separate frontend or realtime service, no CORS anywhere, and the
+httpOnly session cookie behaves identically in dev, CI, and prod. `packages/zod-shared` is the cross-app
+package: the same Zod schema validates a request on the server and drives the matching form on the
+client. Realtime chat (P4) runs in this same process rather than as a separate service, so it inherits the
+same origin and the same session instead of needing an auth handshake of its own. Full rationale:
 `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` and
 `docs/superpowers/specs/2026-07-29-realtime-chat-design.md`.
 
@@ -86,7 +87,7 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 
 | Layer | What's used |
 |---|---|
-| Server | Express 5 · Mongoose 8 (MongoDB) · `express-session` + `connect-redis` (Redis-backed sessions) · bcryptjs · Helmet · Zod |
+| Server | Express 5 · Socket.io (realtime chat) · Mongoose 8 (MongoDB) · `express-session` + `connect-redis` (Redis-backed sessions) · bcryptjs · Helmet · Zod |
 | Client | React 19 · Vite · TanStack Query · React Router 8 · Tailwind CSS 4 · `react-markdown` + `remark-gfm` |
 | Shared | Zod schemas in `packages/zod-shared`, the single source of truth for both server validation and client forms |
 | Testing | Vitest · Supertest · `mongodb-memory-server` · Testing Library · Playwright (e2e) |
@@ -99,11 +100,11 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 - **Likes** — idempotent (`PUT`/`DELETE`, not a toggle endpoint), optimistic UI with rollback on failure.
 - **Threaded comments** — Markdown editor with a live preview, cascade-delete of reply subtrees.
 - **Search** — full-text search plus tag filtering over the feed, debounced, bookmarkable via the URL.
+- **Realtime chat** — one room, signed-in only, with presence and typing indicators; recent history is
+  loaded from Redis on join, and messages live only in Redis, never in MongoDB.
 
-**Not yet built (by design, not oversight):** realtime chat (P4 — designed, see
-`docs/superpowers/specs/2026-07-29-realtime-chat-design.md`), OAuth login (planned P6), and media/avatar
-uploads. See the phase table in `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13
-for what's next.
+**Not yet built (by design, not oversight):** OAuth login (planned P6) and media/avatar uploads. See the
+phase table in `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,66 @@ npm run seed               # demo data + a demo account
 The client is on http://localhost:5173, proxying `/api` to the API on http://localhost:3000/api/v1 —
 same origin as prod, so the session cookie behaves identically in dev.
 
+### Running the stack with Docker Compose directly
+
+`npm run dev` is a thin wrapper. The underlying command, and the rest of the day-to-day set:
+
+```bash
+# Start everything with hot reload (api, client, mongo, redis). Foreground.
+docker compose -f infra/compose.yaml --project-directory . watch
+
+# Or detached, without file watching
+docker compose -f infra/compose.yaml --project-directory . up -d
+
+docker compose -f infra/compose.yaml --project-directory . ps
+docker compose -f infra/compose.yaml --project-directory . logs -f api
+docker compose -f infra/compose.yaml --project-directory . down        # stop
+docker compose -f infra/compose.yaml --project-directory . down -v     # stop and wipe the volumes
+```
+
+**`--project-directory .` is not optional, and it must be run from the repo root.** The compose file's
+`context`, `develop.watch` and `secrets` paths are written relative to the repo root, but Compose resolves
+them relative to the compose file's own directory — `infra/`. Omit the flag and the build context is wrong.
+
+**Use `watch`, not `up -d`, while developing.** Containers bake their source at build time, so a detached
+stack keeps serving the code from whenever it was built. `restart` does not help — it restarts the same
+stale image. If an edit isn't showing up, that's why:
+
+```bash
+docker compose -f infra/compose.yaml --project-directory . up -d --build   # force a rebuild
+```
+
+A change to `package.json` or `package-lock.json` forces a full rebuild even under `watch`, because
+dependencies are installed into the image rather than synced.
+
+| Service | Port | Notes |
+|---|---|---|
+| `client` | 5173 | Vite dev server; proxies `/api` and the Socket.io upgrade to `api` |
+| `api` | 3000 | Express + Socket.io |
+| `mongo` | 27019 → 27017 | Bound to `127.0.0.1` only |
+| `redis` | 6379 | Bound to `127.0.0.1` only |
+
+**The production image**, which is what CI runs the E2E against and what Render deploys, is a different
+stack — `target: runner` rather than `target: dev`, with the client's built bundle served by the API
+rather than by Vite:
+
+```bash
+docker compose -f infra/compose.e2e.yaml --project-directory . up --build --wait
+npm run test:e2e
+docker compose -f infra/compose.e2e.yaml --project-directory . down -v
+```
+
+**If a build fails** with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` or npm's `Exit handler never called!`, local
+TLS interception is breaking `npm ci` inside the container. `infra/compose.override.yaml` (gitignored)
+feeds the exported root CA in as a build secret, and because this repo always passes `-f` explicitly,
+Compose will **not** auto-merge it — pass it explicitly too:
+
+```bash
+docker compose --project-directory . -f infra/compose.yaml -f infra/compose.override.yaml watch
+```
+
+Never bake a CA certificate into an image, and never commit one.
+
 ### Trying the chat
 
 Chat needs two signed-in users, so open a second **incognito/private** window rather than a second tab —

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ flowchart TB
 **One origin, one deployed service.** `apps/server` serves both the REST API and the built client SPA —
 no separate frontend service, no CORS anywhere, and the httpOnly session cookie behaves identically in
 dev, CI, and prod. `packages/zod-shared` is the cross-app package: the same Zod schema validates a
-request on the server and drives the matching form on the client. Full rationale, including why
-`apps/realtime` (P4, not built yet) will need a different auth handshake:
-`docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md`.
+request on the server and drives the matching form on the client. Realtime chat (P4, designed but not
+built) will run in this same process rather than as a separate service, so it inherits the same origin and
+the same session instead of needing an auth handshake of its own. Full rationale:
+`docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` and
+`docs/superpowers/specs/2026-07-29-realtime-chat-design.md`.
 
 ## Core flows, in a nutshell
 
@@ -98,9 +100,10 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 - **Threaded comments** — Markdown editor with a live preview, cascade-delete of reply subtrees.
 - **Search** — full-text search plus tag filtering over the feed, debounced, bookmarkable via the URL.
 
-**Not yet built (by design, not oversight):** realtime chat (`apps/realtime`, planned P4), OAuth login
-(planned P6), and media/avatar uploads. See the phase table in
-`docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
+**Not yet built (by design, not oversight):** realtime chat (P4 — designed, see
+`docs/superpowers/specs/2026-07-29-realtime-chat-design.md`), OAuth login (planned P6), and media/avatar
+uploads. See the phase table in `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13
+for what's next.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 ## About
 
-A from-scratch rebuild of a five-year-old MERN blog + chat app, built as a portfolio piece targeting
-fullstack/backend roles. It reimplements every real feature of the legacy app — session auth, posts,
+A MERN blog + chat app. It reimplements every real feature of the legacy app — session auth, posts,
 likes, threaded comments, search — while fixing five documented authorization holes the original had,
 and adds genuine upgrades (server-side session auth instead of a client-stored JWT, per-reader content
 gating, MongoDB-backed full-text search, realtime chat over Socket.io) the legacy app never had. OAuth
@@ -118,6 +117,31 @@ npm run seed               # demo data + a demo account
 The client is on http://localhost:5173, proxying `/api` to the API on http://localhost:3000/api/v1 —
 same origin as prod, so the session cookie behaves identically in dev.
 
+### Trying the chat
+
+Chat needs two signed-in users, so open a second **incognito/private** window rather than a second tab —
+two tabs share one session and you would be talking to yourself.
+
+```bash
+npm run dev                # wait for all four containers to report healthy
+npm run seed               # creates demo/reader; prints the shared password
+```
+
+1. Sign in as `demo` at http://localhost:5173/login, open **Chat** in the nav.
+2. In a private window, sign in as `reader` and open Chat too.
+3. Type in one window — the message, the online count and the typing indicator all update in the other.
+4. Reload either window: the last 50 messages come back from Redis. Restart the `redis` container and
+   they do not — the buffer is deliberately ephemeral, and that is the design working, not a bug.
+
+The socket is served by the API process on the same origin, so there is no separate service to start.
+`/chat` redirects to `/login` when signed out; that guard is UX only — the socket handshake rejects a
+sessionless connection server-side regardless.
+
+**If the containers fail to build** with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` or npm's
+`Exit handler never called!`, that is local TLS interception breaking `npm ci` inside the container, not
+a problem with the code. See the `extra-ca` note in `CLAUDE.md`; the certificate has to be re-exported
+whenever the interceptor rotates it.
+
 **Deploying:** `infra/render.yaml` declares this rebuild's target Render service, but it has not been
 promoted to `master`/deployed yet — there is no live URL for it. (`master`'s legacy app is separately
 live on Render today; that deployment predates this rebuild and is unrelated to it.)
@@ -163,8 +187,14 @@ is a query error) and degrades to the unfiltered feed instead.
 |---|---|
 | `npm run dev` | Full stack via `docker compose watch`, hot reload |
 | `npm run seed` | Wipe and reseed the demo dataset |
-| `npm run typecheck` | Per-workspace `tsc --noEmit` |
-| `npm run lint` | ESLint (flat config) |
+| `npm run typecheck` | Per-workspace `tsc --noEmit` — CI runs this on every PR |
+| `npm run lint` | ESLint (flat config) — CI runs this on every PR |
 | `npm run test` | Vitest unit + Supertest integration |
 | `npm run test:e2e` | Playwright, against the production Docker image |
 | `npm run build` | Production build (client Vite bundle + server tsup bundle) |
+
+Two things worth knowing about `docker compose watch`: source edits under `apps/` sync into the running
+containers, but a change to `package.json` or `package-lock.json` triggers a full **rebuild** — so pulling
+a branch that adds a dependency means waiting for `npm ci` to run inside the container again. And the
+containers bake source at build time, so if an edit genuinely is not showing up, rebuild before debugging
+the code.

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -21,6 +21,7 @@
     "react-markdown": "^10.1.0",
     "react-router": "^8.3.0",
     "remark-gfm": "^4.0.1",
+    "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0"
   },

--- a/apps/client/src/api/chat.ts
+++ b/apps/client/src/api/chat.ts
@@ -1,0 +1,7 @@
+import { request } from './client.js'
+import type { ChatMessage } from '@blog/zod-shared'
+
+export const chatApi = {
+  /** The last 50 messages, oldest-first (see apps/server/src/lib/services/chat.ts). */
+  messages: () => request<ChatMessage[]>('/api/v1/chat/messages'),
+}

--- a/apps/client/src/components/layouts/PageShell.tsx
+++ b/apps/client/src/components/layouts/PageShell.tsx
@@ -20,6 +20,9 @@ export function PageShell({ children }: { children: React.ReactNode }) {
                 <Link to="/blog/new" className="text-sm hover:underline">
                   New Post
                 </Link>
+                <Link to="/chat" className="text-sm hover:underline">
+                  Chat
+                </Link>
                 {/* There is no /logout route — logging out is a POST, not a
                     page. Navigating there rendered a dead end. */}
                 <button

--- a/apps/client/src/components/patterns/ChatRoom.test.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.test.tsx
@@ -1,0 +1,164 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/CommentForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import type { ChatMessage } from '@blog/zod-shared'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ChatStatus, ChatUser } from '../../hooks/use-chat.js'
+
+// Mocked so each test can drive ChatRoom through a specific hook state
+// directly, instead of exercising the real socket.
+vi.mock('../../hooks/use-chat.js', () => ({ useChat: vi.fn() }))
+
+const { useChat } = await import('../../hooks/use-chat.js')
+const { ChatRoom } = await import('./ChatRoom.js')
+
+type ChatState = {
+  messages: ChatMessage[]
+  online: ChatUser[]
+  typingUsers: string[]
+  status: ChatStatus
+  send: ReturnType<typeof vi.fn>
+  setTyping: ReturnType<typeof vi.fn>
+}
+
+function mockChat(overrides: Partial<ChatState> = {}): ChatState {
+  const state: ChatState = {
+    messages: [],
+    online: [],
+    typingUsers: [],
+    status: 'connected',
+    send: vi.fn(),
+    setTyping: vi.fn(),
+    ...overrides,
+  }
+  vi.mocked(useChat).mockReturnValue(state)
+  return state
+}
+
+describe('ChatRoom status line', () => {
+  afterEach(() => cleanup())
+
+  // The status line is the entire mitigation for the ~60s cold start — a
+  // silent page during that window is indistinguishable from a broken one.
+  it('tells the reader the socket is connecting', () => {
+    mockChat({ status: 'connecting' })
+    render(<ChatRoom />)
+    expect(screen.getByText('Connecting…')).toBeInTheDocument()
+  })
+
+  it('tells the reader the socket dropped and is retrying', () => {
+    mockChat({ status: 'reconnecting' })
+    render(<ChatRoom />)
+    expect(screen.getByText('Reconnecting…')).toBeInTheDocument()
+  })
+
+  it('tells the reader the connection failed and how to recover', () => {
+    mockChat({ status: 'failed' })
+    render(<ChatRoom />)
+    expect(screen.getByText('Could not connect. Reload to try again.')).toBeInTheDocument()
+  })
+
+  it('shows no status line once connected', () => {
+    mockChat({ status: 'connected' })
+    render(<ChatRoom />)
+    expect(screen.queryByText('Connecting…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reconnecting…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Could not connect. Reload to try again.')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatRoom send flow', () => {
+  afterEach(() => cleanup())
+
+  it('sends the typed body, then clears the draft and stops the typing signal', () => {
+    const state = mockChat({ status: 'connected' })
+    render(<ChatRoom />)
+
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello room' } })
+    fireEvent.click(screen.getByText('Send'))
+
+    expect(state.send).toHaveBeenCalledWith('hello room')
+    expect(screen.getByLabelText('Message')).toHaveValue('')
+    expect(state.setTyping).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('ChatRoom send button gating', () => {
+  afterEach(() => cleanup())
+
+  it('disables Send when the draft is empty', () => {
+    mockChat({ status: 'connected' })
+    render(<ChatRoom />)
+    expect(screen.getByText('Send')).toBeDisabled()
+  })
+
+  it('disables Send when the draft is only whitespace', () => {
+    mockChat({ status: 'connected' })
+    render(<ChatRoom />)
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: '   ' } })
+    expect(screen.getByText('Send')).toBeDisabled()
+  })
+
+  it('disables Send while not connected, even with a non-empty draft', () => {
+    mockChat({ status: 'reconnecting' })
+    render(<ChatRoom />)
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello' } })
+    expect(screen.getByText('Send')).toBeDisabled()
+  })
+
+  it('enables Send once there is a non-empty draft and the socket is connected', () => {
+    mockChat({ status: 'connected' })
+    render(<ChatRoom />)
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello' } })
+    expect(screen.getByText('Send')).not.toBeDisabled()
+  })
+})
+
+describe('ChatRoom message input gating', () => {
+  afterEach(() => cleanup())
+
+  it('disables the input once the connection has failed', () => {
+    mockChat({ status: 'failed' })
+    render(<ChatRoom />)
+    expect(screen.getByLabelText('Message')).toBeDisabled()
+  })
+
+  it('leaves the input enabled while connected', () => {
+    mockChat({ status: 'connected' })
+    render(<ChatRoom />)
+    expect(screen.getByLabelText('Message')).not.toBeDisabled()
+  })
+})
+
+describe('ChatRoom messages and presence', () => {
+  afterEach(() => cleanup())
+
+  it('renders a message with its author and body', () => {
+    mockChat({
+      messages: [
+        {
+          id: 'm1',
+          body: 'hello room',
+          author: { id: 'u2', username: 'abe' },
+          sentAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+    render(<ChatRoom />)
+    expect(screen.getByText('abe')).toBeInTheDocument()
+    expect(screen.getByText(/hello room/)).toBeInTheDocument()
+  })
+
+  it('reflects the online roster size', () => {
+    mockChat({
+      online: [
+        { id: 'u1', username: 'reader' },
+        { id: 'u2', username: 'abe' },
+      ],
+    })
+    render(<ChatRoom />)
+    expect(screen.getByText('2 online')).toBeInTheDocument()
+  })
+})

--- a/apps/client/src/components/patterns/ChatRoom.test.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.test.tsx
@@ -21,6 +21,7 @@ type ChatState = {
   status: ChatStatus
   send: ReturnType<typeof vi.fn>
   setTyping: ReturnType<typeof vi.fn>
+  sendError: string | null
 }
 
 function mockChat(overrides: Partial<ChatState> = {}): ChatState {
@@ -29,8 +30,11 @@ function mockChat(overrides: Partial<ChatState> = {}): ChatState {
     online: [],
     typingUsers: [],
     status: 'connected',
-    send: vi.fn(),
+    // Defaults to a successful send — ChatRoom only clears the draft when
+    // send() reports true, so a test exercising that path must opt in.
+    send: vi.fn(() => true),
     setTyping: vi.fn(),
+    sendError: null,
     ...overrides,
   }
   vi.mocked(useChat).mockReturnValue(state)
@@ -82,6 +86,33 @@ describe('ChatRoom send flow', () => {
     expect(state.send).toHaveBeenCalledWith('hello room')
     expect(screen.getByLabelText('Message')).toHaveValue('')
     expect(state.setTyping).toHaveBeenCalledWith(false)
+  })
+
+  // send() returns false for a locally-rejected message (over the length
+  // limit) — the draft must survive so the reader can fix it, not vanish.
+  it('keeps the draft when send() rejects the message', () => {
+    const state = mockChat({ status: 'connected', send: vi.fn(() => false) })
+    render(<ChatRoom />)
+
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'too long' } })
+    fireEvent.click(screen.getByText('Send'))
+
+    expect(state.send).toHaveBeenCalledWith('too long')
+    expect(screen.getByLabelText('Message')).toHaveValue('too long')
+    expect(state.setTyping).not.toHaveBeenCalledWith(false)
+  })
+
+  // A rejected message must not vanish silently — see design §7.
+  it('renders sendError near the composer', () => {
+    mockChat({ status: 'connected', sendError: 'Message must be at most 1,000 characters' })
+    render(<ChatRoom />)
+    expect(screen.getByText('Message must be at most 1,000 characters')).toBeInTheDocument()
+  })
+
+  it('renders nothing extra when there is no sendError', () => {
+    mockChat({ status: 'connected', sendError: null })
+    render(<ChatRoom />)
+    expect(screen.queryByText(/characters/)).not.toBeInTheDocument()
   })
 })
 
@@ -149,6 +180,23 @@ describe('ChatRoom messages and presence', () => {
     render(<ChatRoom />)
     expect(screen.getByText('abe')).toBeInTheDocument()
     expect(screen.getByText(/hello room/)).toBeInTheDocument()
+  })
+
+  // No fallback name: a username-less author omits the author span and its
+  // separator, rather than an empty span plus a stray leading space.
+  it('renders a message from a username-less author with no leading space', () => {
+    mockChat({
+      messages: [
+        {
+          id: 'm2',
+          body: 'anonymous-ish message',
+          author: { id: 'u3' },
+          sentAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+    render(<ChatRoom />)
+    expect(screen.getByText('anonymous-ish message')).toBeInTheDocument()
   })
 
   it('reflects the online roster size', () => {

--- a/apps/client/src/components/patterns/ChatRoom.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { Button } from '../ui/button.js'
+import { Input } from '../ui/input.js'
+import { useChat } from '../../hooks/use-chat.js'
+
+const STATUS_LABEL = {
+  connecting: 'Connecting…',
+  connected: '',
+  reconnecting: 'Reconnecting…',
+  failed: 'Could not connect. Reload to try again.',
+} as const
+
+// Split out of ChatPage on purpose: useChat() connects a socket on mount, so
+// this component must only ever render inside ChatPage's <RequireAuth> —
+// never beside it. Rendering it for an anonymous visitor would open (and the
+// server would immediately reject) a socket for nothing, waking the realtime
+// service's free-tier instance on every anonymous hit to /chat.
+export function ChatRoom() {
+  const { messages, online, typingUsers, status, send, setTyping } = useChat()
+  const [draft, setDraft] = useState('')
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    send(draft)
+    setDraft('')
+    setTyping(false)
+  }
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-bold">Chat</h1>
+        <p className="text-xs text-[var(--muted-foreground)]">{online.length} online</p>
+      </header>
+
+      {/* The service sleeps when idle and cold-starts in ~60s, so a silent
+          page is indistinguishable from a broken one. Say what is happening. */}
+      {STATUS_LABEL[status] && (
+        <p className="text-xs text-[var(--muted-foreground)]">{STATUS_LABEL[status]}</p>
+      )}
+
+      <ul className="flex flex-col gap-2">
+        {messages.map((m) => (
+          <li key={m.id} className="text-sm">
+            {/* Plain text, not Markdown: a fast room does not need tables, and
+                it removes the question of what a link in chat should do. */}
+            <span className="font-semibold">{m.author.username}</span> {m.body}
+          </li>
+        ))}
+      </ul>
+
+      <p className="h-4 text-xs text-[var(--muted-foreground)]">
+        {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
+      </p>
+
+      <form onSubmit={submit} className="flex gap-2">
+        <Input
+          aria-label="Message"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value)
+            setTyping(e.target.value.length > 0)
+          }}
+          disabled={status === 'failed'}
+        />
+        <Button type="submit" disabled={draft.trim().length === 0 || status !== 'connected'}>
+          Send
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/client/src/components/patterns/ChatRoom.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.tsx
@@ -16,14 +16,18 @@ const STATUS_LABEL = {
 // server would immediately reject) a socket for nothing, waking the realtime
 // service's free-tier instance on every anonymous hit to /chat.
 export function ChatRoom() {
-  const { messages, online, typingUsers, status, send, setTyping } = useChat()
+  const { messages, online, typingUsers, status, send, setTyping, sendError } = useChat()
   const [draft, setDraft] = useState('')
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault()
-    send(draft)
-    setDraft('')
-    setTyping(false)
+    // Only clear the draft once send() has actually accepted it — a locally
+    // rejected message (e.g. over the length limit) leaves the text in place
+    // so the reader can fix it instead of losing it.
+    if (send(draft)) {
+      setDraft('')
+      setTyping(false)
+    }
   }
 
   return (
@@ -42,9 +46,13 @@ export function ChatRoom() {
       <ul className="flex flex-col gap-2">
         {messages.map((m) => (
           <li key={m.id} className="text-sm">
-            {/* Plain text, not Markdown: a fast room does not need tables, and
-                it removes the question of what a link in chat should do. */}
-            <span className="font-semibold">{m.author.username}</span> {m.body}
+            {m.author.username ? (
+              <>
+                <span className="font-semibold">{m.author.username}</span> {m.body}
+              </>
+            ) : (
+              m.body
+            )}
           </li>
         ))}
       </ul>
@@ -52,6 +60,8 @@ export function ChatRoom() {
       <p className="h-4 text-xs text-[var(--muted-foreground)]">
         {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
       </p>
+
+      {sendError && <p className="text-sm text-[var(--destructive)]">{sendError}</p>}
 
       <form onSubmit={submit} className="flex gap-2">
         <Input

--- a/apps/client/src/components/patterns/ChatRoom.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.tsx
@@ -21,9 +21,7 @@ export function ChatRoom() {
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Only clear the draft once send() has actually accepted it — a locally
-    // rejected message (e.g. over the length limit) leaves the text in place
-    // so the reader can fix it instead of losing it.
+    // Only clear the draft once send() actually accepts it, so a rejected message isn't lost.
     if (send(draft)) {
       setDraft('')
       setTyping(false)

--- a/apps/client/src/hooks/use-chat.test.tsx
+++ b/apps/client/src/hooks/use-chat.test.tsx
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (payload: unknown) => void>()
+const socket = {
+  connected: false,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  emit: vi.fn(),
+  on: vi.fn((event: string, fn: (payload: unknown) => void) => {
+    handlers.set(event, fn)
+    return socket
+  }),
+  off: vi.fn((event: string) => {
+    handlers.delete(event)
+    return socket
+  }),
+}
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => socket) }))
+
+const { useChat } = await import('./use-chat.js')
+
+describe('useChat', () => {
+  afterEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+    cleanup()
+  })
+
+  it('appends a broadcast message', async () => {
+    const { result } = renderHook(() => useChat())
+    act(() => {
+      handlers.get('message')?.({
+        id: '1',
+        body: 'hello',
+        author: { id: 'u1', username: 'demo' },
+        sentAt: '2026-07-29T00:00:00.000Z',
+      })
+    })
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+    expect(result.current.messages[0]?.body).toBe('hello')
+  })
+
+  // Legacy chat.jsx:51 registered a listener per message received, so every
+  // message was handled N times and the count grew with the conversation.
+  it('removes every listener it registered on unmount', () => {
+    const { unmount } = renderHook(() => useChat())
+    const registered = socket.on.mock.calls.map(([event]) => event)
+
+    unmount()
+
+    const removed = socket.off.mock.calls.map(([event]) => event)
+    for (const event of registered) expect(removed).toContain(event)
+    expect(handlers.size).toBe(0)
+  })
+
+  // Legacy chat.jsx:57 emitted disconnect on every render.
+  it('does not reconnect or disconnect on re-render', () => {
+    const { rerender } = renderHook(() => useChat())
+    const connectsAfterMount = socket.connect.mock.calls.length
+
+    rerender()
+    rerender()
+
+    expect(socket.connect).toHaveBeenCalledTimes(connectsAfterMount)
+    expect(socket.disconnect).not.toHaveBeenCalled()
+  })
+
+  it('sends the body only — the server stamps the author', () => {
+    const { result } = renderHook(() => useChat())
+    act(() => result.current.send('  hi  '))
+    expect(socket.emit).toHaveBeenCalledWith('message', { body: 'hi' })
+  })
+})

--- a/apps/client/src/hooks/use-chat.test.tsx
+++ b/apps/client/src/hooks/use-chat.test.tsx
@@ -107,6 +107,43 @@ describe('useChat', () => {
     expect(socket.emit).toHaveBeenCalledWith('message', { body: 'hi' })
   })
 
+  // Design §5/§7: the same ChatMessageSchema the server enforces must reject
+  // an over-length message on the client too, rather than letting it round-
+  // trip to the server just to be rejected and silently swallowed.
+  it('rejects an over-length message locally, without emitting, and surfaces the Zod message', () => {
+    stubFetch(() => jsonResponse([]))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
+
+    let accepted = true
+    act(() => {
+      accepted = result.current.send('a'.repeat(1001))
+    })
+
+    expect(accepted).toBe(false)
+    expect(socket.emit).not.toHaveBeenCalled()
+    expect(result.current.sendError).toMatch(/1,000 characters/)
+  })
+
+  // A rejected message used to vanish silently — the composer emptied with no
+  // sign anything went wrong. The server's `error` event (validation failure
+  // or a failed Redis append) must surface through sendError.
+  it('surfaces a server-side rejection via sendError, cleared on the next attempt', async () => {
+    stubFetch(() => jsonResponse([]))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
+
+    act(() => {
+      handlers.get('error')?.({ message: 'Could not send message. Please try again.' })
+    })
+    await waitFor(() =>
+      expect(result.current.sendError).toBe('Could not send message. Please try again.'),
+    )
+
+    act(() => {
+      result.current.send('a fresh attempt')
+    })
+    expect(result.current.sendError).toBeNull()
+  })
+
   // The design's explicit ordering: load the buffer over REST, then subscribe.
   // Buffered history must render oldest-first, ahead of anything arriving live.
   it('loads the buffer on mount, oldest-first, ahead of live messages', async () => {
@@ -233,5 +270,46 @@ describe('useChat', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  // A remount within the default 5-minute gcTime window used to serve the
+  // FROZEN first-visit buffer while liveMessages (component state) had
+  // already reset to [] — a message that only ever arrived live during the
+  // first visit was gone for good on the second. gcTime: 0 forces a refetch
+  // on remount instead, which recovers it because the server persisted it.
+  it('recovers a message that only arrived live, after an unmount/remount inside the cache window', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([message('live-1', 'arrived mid-visit')]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = renderHook(() => useChat(), { wrapper })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      handlers.get('message')?.(message('live-1', 'arrived mid-visit'))
+    })
+    await waitFor(() => expect(first.result.current.messages).toHaveLength(1))
+
+    first.unmount()
+
+    // gcTime: 0 schedules eviction via a real timer rather than evicting
+    // synchronously on unmount — give it a tick to fire before remounting,
+    // or the second mount would still see the (soon-to-be-collected) cached
+    // snapshot and this test would race the very fix it's proving.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const second = renderHook(() => useChat(), { wrapper })
+
+    await waitFor(() =>
+      expect(second.result.current.messages.map((m) => m.id)).toContain('live-1'),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/client/src/hooks/use-chat.test.tsx
+++ b/apps/client/src/hooks/use-chat.test.tsx
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import type { ChatMessage } from '@blog/zod-shared'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const handlers = new Map<string, (payload: unknown) => void>()
@@ -22,15 +24,43 @@ vi.mock('socket.io-client', () => ({ io: vi.fn(() => socket) }))
 
 const { useChat } = await import('./use-chat.js')
 
+const message = (id: string, body: string): ChatMessage => ({
+  id,
+  body,
+  author: { id: 'u1', username: 'demo' },
+  sentAt: '2026-07-29T00:00:00.000Z',
+})
+
+const jsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+
+function stubFetch(response: () => Response) {
+  const fetchMock = vi.fn(() => Promise.resolve(response()))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return wrapper
+}
+
 describe('useChat', () => {
   afterEach(() => {
     handlers.clear()
     vi.clearAllMocks()
+    vi.unstubAllGlobals()
     cleanup()
   })
 
   it('appends a broadcast message', async () => {
-    const { result } = renderHook(() => useChat())
+    stubFetch(() => jsonResponse([]))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
     act(() => {
       handlers.get('message')?.({
         id: '1',
@@ -46,7 +76,8 @@ describe('useChat', () => {
   // Legacy chat.jsx:51 registered a listener per message received, so every
   // message was handled N times and the count grew with the conversation.
   it('removes every listener it registered on unmount', () => {
-    const { unmount } = renderHook(() => useChat())
+    stubFetch(() => jsonResponse([]))
+    const { unmount } = renderHook(() => useChat(), { wrapper: makeWrapper() })
     const registered = socket.on.mock.calls.map(([event]) => event)
 
     unmount()
@@ -58,7 +89,8 @@ describe('useChat', () => {
 
   // Legacy chat.jsx:57 emitted disconnect on every render.
   it('does not reconnect or disconnect on re-render', () => {
-    const { rerender } = renderHook(() => useChat())
+    stubFetch(() => jsonResponse([]))
+    const { rerender } = renderHook(() => useChat(), { wrapper: makeWrapper() })
     const connectsAfterMount = socket.connect.mock.calls.length
 
     rerender()
@@ -69,8 +101,75 @@ describe('useChat', () => {
   })
 
   it('sends the body only — the server stamps the author', () => {
-    const { result } = renderHook(() => useChat())
+    stubFetch(() => jsonResponse([]))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
     act(() => result.current.send('  hi  '))
     expect(socket.emit).toHaveBeenCalledWith('message', { body: 'hi' })
+  })
+
+  // The design's explicit ordering: load the buffer over REST, then subscribe.
+  // Buffered history must render oldest-first, ahead of anything arriving live.
+  it('loads the buffer on mount, oldest-first, ahead of live messages', async () => {
+    stubFetch(() => jsonResponse([message('1', 'first'), message('2', 'second')]))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(2))
+    expect(result.current.messages.map((m) => m.id)).toEqual(['1', '2'])
+
+    act(() => {
+      handlers.get('message')?.(message('3', 'live'))
+    })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(3))
+    expect(result.current.messages.map((m) => m.id)).toEqual(['1', '2', '3'])
+  })
+
+  // The fetch and the socket connect race. A message can plausibly arrive
+  // live while the buffer fetch is still in flight and also be present in
+  // the fetched buffer once it resolves — that message must appear exactly
+  // once, not twice.
+  it('deduplicates a message present in both the buffer and a live event', async () => {
+    let resolveFetch!: (response: Response) => void
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
+
+    // Live message arrives while the buffer fetch is still pending.
+    act(() => {
+      handlers.get('message')?.(message('dup', 'collides'))
+    })
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+
+    // The buffer resolves afterward and also contains that same id, in its
+    // own (server-authoritative) oldest-first order.
+    act(() => {
+      resolveFetch(jsonResponse([message('older', 'before it'), message('dup', 'collides')]))
+    })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(2))
+    const ids = result.current.messages.map((m) => m.id)
+    expect(ids.filter((id) => id === 'dup')).toHaveLength(1)
+    expect(ids).toEqual(['older', 'dup'])
+  })
+
+  // A broken history endpoint must not take the room down with it: the
+  // socket still connects and live messages still arrive.
+  it('stays usable when the buffer fetch fails', async () => {
+    stubFetch(() => jsonResponse({ error: { message: 'boom' } }, 500))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
+
+    act(() => {
+      handlers.get('message')?.(message('1', 'still works'))
+    })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+    expect(result.current.messages[0]?.body).toBe('still works')
+    expect(socket.connect).toHaveBeenCalled()
   })
 })

--- a/apps/client/src/hooks/use-chat.test.tsx
+++ b/apps/client/src/hooks/use-chat.test.tsx
@@ -176,29 +176,62 @@ describe('useChat', () => {
   // The buffer is a one-time, mount-time snapshot: the endpoint always
   // returns only the *current* last 50, and the merge treats the fetched
   // data as the whole buffered portion on every render rather than
-  // accumulating across refetches. A background refetch (window focus,
-  // reconnect, or the app's 5-minute staleTime elapsing) would silently
-  // swap history out from under a user mid-conversation — messages they
-  // already saw would vanish from the transcript with no error. Assert the
-  // observable outcome (fetch called once) rather than the query's
-  // configuration, so a future change to the global defaults can't silently
-  // reintroduce the bug while this test stays green.
-  it('does not refetch the buffer on window focus or reconnect', async () => {
-    const fetchMock = stubFetch(() => jsonResponse([message('1', 'first')]))
-    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
-
-    await waitFor(() => expect(result.current.messages).toHaveLength(1))
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-
-    act(() => {
-      window.dispatchEvent(new Event('visibilitychange'))
-      window.dispatchEvent(new Event('focus'))
-      window.dispatchEvent(new Event('online'))
+  // accumulating across refetches. Left to the app's global defaults
+  // (staleTime 5min, refetchOnWindowFocus true), a tab-away-and-back after
+  // 5+ minutes would silently swap history out from under a user mid-
+  // conversation. This wrapper mirrors those global defaults (see
+  // apps/client/src/lib/query-client.ts) rather than reusing `makeWrapper`'s
+  // bare client (staleTime 0) — the point of the test is to prove the
+  // per-query override in use-chat.ts beats a client that would otherwise
+  // refetch, so the client has to actually behave like the real one.
+  function makeProdDefaultsWrapper() {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 5 * 60 * 1000 } },
     })
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+  }
 
-    // Let any refetch triggered by those events actually run before asserting.
-    await new Promise((resolve) => setTimeout(resolve, 0))
+  // Verified against the installed @tanstack/query-core@5.101.4 source
+  // (node_modules/@tanstack/query-core/build/modern/{focusManager,
+  // onlineManager,queryObserver}.js) before writing this: focusManager's
+  // default setup listens only for `visibilitychange` on `window` — there is
+  // no `focus` listener in this version, so dispatching a `focus` event is
+  // inert. onlineManager gates its listeners on a `true !== newValue`
+  // transition and starts `_online: true`, so dispatching `online` again is
+  // a no-op. And `shouldFetchOn` short-circuits on `isStale(query, options)`
+  // — a `visibilitychange` dispatched immediately after the fetch resolves
+  // hits a fresh query and refetches nothing regardless of any staleTime or
+  // refetch flag. So the only way to exercise the real path is: advance past
+  // the (mirrored) 5-minute staleTime with fake timers, then dispatch
+  // `visibilitychange`.
+  it('does not refetch the buffer once the global staleTime has elapsed and the tab regains focus', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchMock = stubFetch(() => jsonResponse([message('1', 'first')]))
+      const { result } = renderHook(() => useChat(), { wrapper: makeProdDefaultsWrapper() })
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(result.current.messages).toHaveLength(1)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      // Past the global 5-minute staleTime this query would otherwise have
+      // inherited.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6 * 60 * 1000)
+      })
+
+      await act(async () => {
+        window.dispatchEvent(new Event('visibilitychange'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/client/src/hooks/use-chat.test.tsx
+++ b/apps/client/src/hooks/use-chat.test.tsx
@@ -107,9 +107,7 @@ describe('useChat', () => {
     expect(socket.emit).toHaveBeenCalledWith('message', { body: 'hi' })
   })
 
-  // Design §5/§7: the same ChatMessageSchema the server enforces must reject
-  // an over-length message on the client too, rather than letting it round-
-  // trip to the server just to be rejected and silently swallowed.
+  // Same schema the server enforces — an over-length message must fail here first.
   it('rejects an over-length message locally, without emitting, and surfaces the Zod message', () => {
     stubFetch(() => jsonResponse([]))
     const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
@@ -124,9 +122,7 @@ describe('useChat', () => {
     expect(result.current.sendError).toMatch(/1,000 characters/)
   })
 
-  // A rejected message used to vanish silently — the composer emptied with no
-  // sign anything went wrong. The server's `error` event (validation failure
-  // or a failed Redis append) must surface through sendError.
+  // A rejected message must surface via sendError instead of vanishing silently.
   it('surfaces a server-side rejection via sendError, cleared on the next attempt', async () => {
     stubFetch(() => jsonResponse([]))
     const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
@@ -272,11 +268,7 @@ describe('useChat', () => {
     }
   })
 
-  // A remount within the default 5-minute gcTime window used to serve the
-  // FROZEN first-visit buffer while liveMessages (component state) had
-  // already reset to [] — a message that only ever arrived live during the
-  // first visit was gone for good on the second. gcTime: 0 forces a refetch
-  // on remount instead, which recovers it because the server persisted it.
+  // Reproduces the remount bug: gcTime:0 forces a refetch instead of replaying a frozen buffer.
   it('recovers a message that only arrived live, after an unmount/remount inside the cache window', async () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -299,10 +291,7 @@ describe('useChat', () => {
 
     first.unmount()
 
-    // gcTime: 0 schedules eviction via a real timer rather than evicting
-    // synchronously on unmount — give it a tick to fire before remounting,
-    // or the second mount would still see the (soon-to-be-collected) cached
-    // snapshot and this test would race the very fix it's proving.
+    // gcTime's eviction timer needs a tick to fire before remounting.
     await new Promise((resolve) => setTimeout(resolve, 10))
 
     const second = renderHook(() => useChat(), { wrapper })

--- a/apps/client/src/hooks/use-chat.test.tsx
+++ b/apps/client/src/hooks/use-chat.test.tsx
@@ -172,4 +172,33 @@ describe('useChat', () => {
     expect(result.current.messages[0]?.body).toBe('still works')
     expect(socket.connect).toHaveBeenCalled()
   })
+
+  // The buffer is a one-time, mount-time snapshot: the endpoint always
+  // returns only the *current* last 50, and the merge treats the fetched
+  // data as the whole buffered portion on every render rather than
+  // accumulating across refetches. A background refetch (window focus,
+  // reconnect, or the app's 5-minute staleTime elapsing) would silently
+  // swap history out from under a user mid-conversation — messages they
+  // already saw would vanish from the transcript with no error. Assert the
+  // observable outcome (fetch called once) rather than the query's
+  // configuration, so a future change to the global defaults can't silently
+  // reintroduce the bug while this test stays green.
+  it('does not refetch the buffer on window focus or reconnect', async () => {
+    const fetchMock = stubFetch(() => jsonResponse([message('1', 'first')]))
+    const { result } = renderHook(() => useChat(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      window.dispatchEvent(new Event('visibilitychange'))
+      window.dispatchEvent(new Event('focus'))
+      window.dispatchEvent(new Event('online'))
+    })
+
+    // Let any refetch triggered by those events actually run before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/client/src/hooks/use-chat.ts
+++ b/apps/client/src/hooks/use-chat.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from '@blog/zod-shared'
+import { ChatMessageSchema, type ChatMessage } from '@blog/zod-shared'
 import { useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { io, type Socket } from 'socket.io-client'
@@ -6,7 +6,10 @@ import { chatApi } from '../api/chat.js'
 import { DEBUG } from '../lib/constants.js'
 import { queryKeys } from '../lib/query-client.js'
 
-export type ChatUser = { id: string; username: string }
+// Optional, honestly: it reflects whatever the server's session held at
+// handshake time (see ChatMessage.author in zod-shared). Every real login
+// sets it, but the type must not pretend a session can't lack one.
+export type ChatUser = { id: string; username?: string }
 export type ChatStatus = 'connecting' | 'connected' | 'reconnecting' | 'failed'
 
 export function useChat() {
@@ -14,6 +17,11 @@ export function useChat() {
   const [online, setOnline] = useState<ChatUser[]>([])
   const [typingUsers, setTypingUsers] = useState<string[]>([])
   const [status, setStatus] = useState<ChatStatus>('connecting')
+  // Set by the server's `error` event (rejected validation, a failed Redis
+  // append) and by client-side ChatMessageSchema validation in `send` below.
+  // Cleared at the start of every new attempt so a stale error never outlives
+  // the send it was about to result from.
+  const [sendError, setSendError] = useState<string | null>(null)
 
   // Held in a ref, created once. Creating it during render would open a
   // connection per render — the shape of the legacy chat.jsx:57 defect.
@@ -47,6 +55,13 @@ export function useChat() {
     staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
+    // staleTime: Infinity keeps the buffer frozen *during* a visit (see above).
+    // gcTime: 0 stops that same snapshot from surviving *across* a visit — the
+    // default 5min gcTime would replay it on remount while liveMessages
+    // (component state) had already reset to [], losing anything that arrived
+    // live in between. Evicting on unmount forces a refetch instead, which
+    // recovers those messages because the server already persisted them.
+    gcTime: 0,
   })
 
   useEffect(() => {
@@ -79,12 +94,17 @@ export function useChat() {
     const onConnectError = () => setStatus('failed')
     const onMessage = (message: ChatMessage) => setLiveMessages((prev) => [...prev, message])
     const onPresence = ({ users }: { users: ChatUser[] }) => setOnline(users)
-    const onTyping = ({ username, typing }: { username: string; typing: boolean }) =>
+    // No fallback name: a typing signal with no username is omitted from the
+    // indicator entirely rather than rendering a fabricated placeholder.
+    const onTyping = ({ username, typing }: { username?: string; typing: boolean }) => {
+      if (!username) return
       setTypingUsers((prev) =>
         typing ? [...new Set([...prev, username])] : prev.filter((u) => u !== username),
       )
+    }
     const onError = ({ message }: { message: string }) => {
       if (DEBUG) console.warn('[CHAT] rejected', message)
+      setSendError(message)
     }
 
     socket.on('connect', onConnect)
@@ -110,16 +130,21 @@ export function useChat() {
     }
   }, [])
 
-  const send = useCallback((body: string) => {
-    const trimmed = body.trim()
-    if (!trimmed) return
+  const send = useCallback((body: string): boolean => {
+    setSendError(null)
+    const parsed = ChatMessageSchema.safeParse({ body })
+    if (!parsed.success) {
+      setSendError(parsed.error.errors[0]?.message ?? 'Invalid message')
+      return false
+    }
     // Body only. The author is stamped server-side from the session.
-    socketRef.current?.emit('message', { body: trimmed })
+    socketRef.current?.emit('message', { body: parsed.data.body })
+    return true
   }, [])
 
   const setTyping = useCallback((typing: boolean) => {
     socketRef.current?.emit('typing', { typing })
   }, [])
 
-  return { messages, online, typingUsers, status, send, setTyping }
+  return { messages, online, typingUsers, status, send, setTyping, sendError }
 }

--- a/apps/client/src/hooks/use-chat.ts
+++ b/apps/client/src/hooks/use-chat.ts
@@ -6,9 +6,7 @@ import { chatApi } from '../api/chat.js'
 import { DEBUG } from '../lib/constants.js'
 import { queryKeys } from '../lib/query-client.js'
 
-// Optional, honestly: it reflects whatever the server's session held at
-// handshake time (see ChatMessage.author in zod-shared). Every real login
-// sets it, but the type must not pretend a session can't lack one.
+// Optional — mirrors ChatMessage.author in zod-shared; a session need not hold a username.
 export type ChatUser = { id: string; username?: string }
 export type ChatStatus = 'connecting' | 'connected' | 'reconnecting' | 'failed'
 
@@ -17,10 +15,7 @@ export function useChat() {
   const [online, setOnline] = useState<ChatUser[]>([])
   const [typingUsers, setTypingUsers] = useState<string[]>([])
   const [status, setStatus] = useState<ChatStatus>('connecting')
-  // Set by the server's `error` event (rejected validation, a failed Redis
-  // append) and by client-side ChatMessageSchema validation in `send` below.
-  // Cleared at the start of every new attempt so a stale error never outlives
-  // the send it was about to result from.
+  // Set by the server's error event or local schema validation; cleared on each new attempt.
   const [sendError, setSendError] = useState<string | null>(null)
 
   // Held in a ref, created once. Creating it during render would open a
@@ -55,12 +50,7 @@ export function useChat() {
     staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    // staleTime: Infinity keeps the buffer frozen *during* a visit (see above).
-    // gcTime: 0 stops that same snapshot from surviving *across* a visit — the
-    // default 5min gcTime would replay it on remount while liveMessages
-    // (component state) had already reset to [], losing anything that arrived
-    // live in between. Evicting on unmount forces a refetch instead, which
-    // recovers those messages because the server already persisted them.
+    // Must not refetch during a visit (staleTime above) nor be reused across visits (gcTime).
     gcTime: 0,
   })
 
@@ -94,8 +84,7 @@ export function useChat() {
     const onConnectError = () => setStatus('failed')
     const onMessage = (message: ChatMessage) => setLiveMessages((prev) => [...prev, message])
     const onPresence = ({ users }: { users: ChatUser[] }) => setOnline(users)
-    // No fallback name: a typing signal with no username is omitted from the
-    // indicator entirely rather than rendering a fabricated placeholder.
+    // No fallback name — a username-less typer is omitted, not fabricated.
     const onTyping = ({ username, typing }: { username?: string; typing: boolean }) => {
       if (!username) return
       setTypingUsers((prev) =>

--- a/apps/client/src/hooks/use-chat.ts
+++ b/apps/client/src/hooks/use-chat.ts
@@ -1,0 +1,74 @@
+import type { ChatMessage } from '@blog/zod-shared'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { io, type Socket } from 'socket.io-client'
+import { DEBUG } from '../lib/constants.js'
+
+export type ChatUser = { id: string; username: string }
+export type ChatStatus = 'connecting' | 'connected' | 'reconnecting' | 'failed'
+
+export function useChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [online, setOnline] = useState<ChatUser[]>([])
+  const [typingUsers, setTypingUsers] = useState<string[]>([])
+  const [status, setStatus] = useState<ChatStatus>('connecting')
+
+  // Held in a ref, created once. Creating it during render would open a
+  // connection per render — the shape of the legacy chat.jsx:57 defect.
+  const socketRef = useRef<Socket | null>(null)
+  if (socketRef.current === null) {
+    socketRef.current = io({ autoConnect: false, transports: ['websocket'] })
+  }
+
+  useEffect(() => {
+    const socket = socketRef.current
+    if (!socket) return
+
+    const onConnect = () => setStatus('connected')
+    const onDisconnect = () => setStatus('reconnecting')
+    const onConnectError = () => setStatus('failed')
+    const onMessage = (message: ChatMessage) => setMessages((prev) => [...prev, message])
+    const onPresence = ({ users }: { users: ChatUser[] }) => setOnline(users)
+    const onTyping = ({ username, typing }: { username: string; typing: boolean }) =>
+      setTypingUsers((prev) =>
+        typing ? [...new Set([...prev, username])] : prev.filter((u) => u !== username),
+      )
+    const onError = ({ message }: { message: string }) => {
+      if (DEBUG) console.warn('[CHAT] rejected', message)
+    }
+
+    socket.on('connect', onConnect)
+    socket.on('disconnect', onDisconnect)
+    socket.on('connect_error', onConnectError)
+    socket.on('message', onMessage)
+    socket.on('presence', onPresence)
+    socket.on('typing', onTyping)
+    socket.on('error', onError)
+    socket.connect()
+
+    // Every `on` above has an `off` here. The legacy chat.jsx:51 grew its
+    // listener count with the conversation because it had no cleanup.
+    return () => {
+      socket.off('connect', onConnect)
+      socket.off('disconnect', onDisconnect)
+      socket.off('connect_error', onConnectError)
+      socket.off('message', onMessage)
+      socket.off('presence', onPresence)
+      socket.off('typing', onTyping)
+      socket.off('error', onError)
+      socket.disconnect()
+    }
+  }, [])
+
+  const send = useCallback((body: string) => {
+    const trimmed = body.trim()
+    if (!trimmed) return
+    // Body only. The author is stamped server-side from the session.
+    socketRef.current?.emit('message', { body: trimmed })
+  }, [])
+
+  const setTyping = useCallback((typing: boolean) => {
+    socketRef.current?.emit('typing', { typing })
+  }, [])
+
+  return { messages, online, typingUsers, status, send, setTyping }
+}

--- a/apps/client/src/hooks/use-chat.ts
+++ b/apps/client/src/hooks/use-chat.ts
@@ -28,10 +28,25 @@ export function useChat() {
   // oldest-first, then live), not about serializing the fetch before the
   // socket connects. A failed fetch must not break the room: it just leaves
   // `bufferQuery.data` undefined and live messages still work.
+  //
+  // This is a one-time, mount-time snapshot, not a live view of "the last 50"
+  // — the merge below treats `bufferQuery.data` as the whole buffered portion
+  // on every render, it does not accumulate across refetches. The app's global
+  // defaults (`staleTime: 5min`, refetch on focus/reconnect) are right for the
+  // rest of the app but wrong here: the endpoint always returns only the
+  // *current* CHAT_BUFFER_SIZE, so a background refetch after the user has
+  // been in the room a while (tab away 5+ minutes, come back) would swap
+  // messages 1-50 for whatever is now the last 50 and silently drop history
+  // the user is already reading. Disabling refetch here — not globally — keeps
+  // the buffer a snapshot taken once at open; live messages carry the
+  // transcript forward from there.
   const bufferQuery = useQuery({
     queryKey: queryKeys.chat.messages,
     queryFn: () => chatApi.messages(),
     retry: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   })
 
   useEffect(() => {

--- a/apps/client/src/hooks/use-chat.ts
+++ b/apps/client/src/hooks/use-chat.ts
@@ -1,13 +1,16 @@
 import type { ChatMessage } from '@blog/zod-shared'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { io, type Socket } from 'socket.io-client'
+import { chatApi } from '../api/chat.js'
 import { DEBUG } from '../lib/constants.js'
+import { queryKeys } from '../lib/query-client.js'
 
 export type ChatUser = { id: string; username: string }
 export type ChatStatus = 'connecting' | 'connected' | 'reconnecting' | 'failed'
 
 export function useChat() {
-  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [liveMessages, setLiveMessages] = useState<ChatMessage[]>([])
   const [online, setOnline] = useState<ChatUser[]>([])
   const [typingUsers, setTypingUsers] = useState<string[]>([])
   const [status, setStatus] = useState<ChatStatus>('connecting')
@@ -19,6 +22,39 @@ export function useChat() {
     socketRef.current = io({ autoConnect: false, transports: ['websocket'] })
   }
 
+  // Loads the last 50 messages over REST so the room shows recent context
+  // instead of an empty box. Fired independently of the socket connect below
+  // — the ordering guarantee is about how messages are *presented* (buffer
+  // oldest-first, then live), not about serializing the fetch before the
+  // socket connects. A failed fetch must not break the room: it just leaves
+  // `bufferQuery.data` undefined and live messages still work.
+  const bufferQuery = useQuery({
+    queryKey: queryKeys.chat.messages,
+    queryFn: () => chatApi.messages(),
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (DEBUG && bufferQuery.isError) console.warn('[CHAT] failed to load message history')
+  }, [bufferQuery.isError])
+
+  // Buffer first (already oldest-first from the server), then live messages
+  // in arrival order. Deduping by id here — rather than at arrival time —
+  // is what makes a duplicate impossible instead of merely unlikely: a
+  // message that lands in both the fetched buffer and a live 'message'
+  // event (the fetch-in-flight race) is only ever added once, regardless of
+  // which of the two resolves first.
+  const messages = useMemo(() => {
+    const seen = new Set<string>()
+    const merged: ChatMessage[] = []
+    for (const message of [...(bufferQuery.data ?? []), ...liveMessages]) {
+      if (seen.has(message.id)) continue
+      seen.add(message.id)
+      merged.push(message)
+    }
+    return merged
+  }, [bufferQuery.data, liveMessages])
+
   useEffect(() => {
     const socket = socketRef.current
     if (!socket) return
@@ -26,7 +62,7 @@ export function useChat() {
     const onConnect = () => setStatus('connected')
     const onDisconnect = () => setStatus('reconnecting')
     const onConnectError = () => setStatus('failed')
-    const onMessage = (message: ChatMessage) => setMessages((prev) => [...prev, message])
+    const onMessage = (message: ChatMessage) => setLiveMessages((prev) => [...prev, message])
     const onPresence = ({ users }: { users: ChatUser[] }) => setOnline(users)
     const onTyping = ({ username, typing }: { username: string; typing: boolean }) =>
       setTypingUsers((prev) =>

--- a/apps/client/src/lib/query-client.ts
+++ b/apps/client/src/lib/query-client.ts
@@ -39,4 +39,7 @@ export const queryKeys = {
   users: {
     detail: (id: string) => ['users', id] as const,
   },
+  chat: {
+    messages: ['chat', 'messages'] as const,
+  },
 }

--- a/apps/client/src/pages/ChatPage.test.tsx
+++ b/apps/client/src/pages/ChatPage.test.tsx
@@ -45,8 +45,9 @@ describe('ChatPage guard', () => {
       online: [],
       typingUsers: [],
       status: 'connected',
-      send: vi.fn(),
+      send: vi.fn(() => true),
       setTyping: vi.fn(),
+      sendError: null,
     })
     renderChatPage({ id: 'u1', username: 'reader' })
     expect(useChat).toHaveBeenCalled()

--- a/apps/client/src/pages/ChatPage.test.tsx
+++ b/apps/client/src/pages/ChatPage.test.tsx
@@ -1,0 +1,181 @@
+// The root vitest.config.ts declares no setupFiles, so apps/client/src/test/setup.ts
+// never runs — every client test file wires jest-dom and cleanup itself, as
+// apps/client/src/components/patterns/CommentForm.test.tsx does.
+import '@testing-library/jest-dom/vitest'
+import type { ChatMessage } from '@blog/zod-shared'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { queryKeys } from '../lib/query-client.js'
+import type { ChatStatus, ChatUser } from '../hooks/use-chat.js'
+
+// Mocked so each test can drive ChatPage through a specific hook state
+// directly, instead of exercising the real socket.
+vi.mock('../hooks/use-chat.js', () => ({ useChat: vi.fn() }))
+
+const { useChat } = await import('../hooks/use-chat.js')
+const { ChatPage } = await import('./ChatPage.js')
+
+type ChatState = {
+  messages: ChatMessage[]
+  online: ChatUser[]
+  typingUsers: string[]
+  status: ChatStatus
+  send: ReturnType<typeof vi.fn>
+  setTyping: ReturnType<typeof vi.fn>
+}
+
+function mockChat(overrides: Partial<ChatState> = {}): ChatState {
+  const state: ChatState = {
+    messages: [],
+    online: [],
+    typingUsers: [],
+    status: 'connected',
+    send: vi.fn(),
+    setTyping: vi.fn(),
+    ...overrides,
+  }
+  vi.mocked(useChat).mockReturnValue(state)
+  return state
+}
+
+function renderChatPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // RequireAuth is UX only, not under test here — pre-seed a signed-in viewer
+  // so it resolves past the loading/redirect states immediately.
+  client.setQueryData(queryKeys.me, { id: 'u1', username: 'reader' })
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <ChatPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('ChatPage status line', () => {
+  afterEach(() => cleanup())
+
+  // The status line is the entire mitigation for the ~60s cold start — a
+  // silent page during that window is indistinguishable from a broken one.
+  it('tells the reader the socket is connecting', () => {
+    mockChat({ status: 'connecting' })
+    renderChatPage()
+    expect(screen.getByText('Connecting…')).toBeInTheDocument()
+  })
+
+  it('tells the reader the socket dropped and is retrying', () => {
+    mockChat({ status: 'reconnecting' })
+    renderChatPage()
+    expect(screen.getByText('Reconnecting…')).toBeInTheDocument()
+  })
+
+  it('tells the reader the connection failed and how to recover', () => {
+    mockChat({ status: 'failed' })
+    renderChatPage()
+    expect(screen.getByText('Could not connect. Reload to try again.')).toBeInTheDocument()
+  })
+
+  it('shows no status line once connected', () => {
+    mockChat({ status: 'connected' })
+    renderChatPage()
+    expect(screen.queryByText('Connecting…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reconnecting…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Could not connect. Reload to try again.')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPage send flow', () => {
+  afterEach(() => cleanup())
+
+  it('sends the typed body, then clears the draft and stops the typing signal', () => {
+    const state = mockChat({ status: 'connected' })
+    renderChatPage()
+
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello room' } })
+    fireEvent.click(screen.getByText('Send'))
+
+    expect(state.send).toHaveBeenCalledWith('hello room')
+    expect(screen.getByLabelText('Message')).toHaveValue('')
+    expect(state.setTyping).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('ChatPage send button gating', () => {
+  afterEach(() => cleanup())
+
+  it('disables Send when the draft is empty', () => {
+    mockChat({ status: 'connected' })
+    renderChatPage()
+    expect(screen.getByText('Send')).toBeDisabled()
+  })
+
+  it('disables Send when the draft is only whitespace', () => {
+    mockChat({ status: 'connected' })
+    renderChatPage()
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: '   ' } })
+    expect(screen.getByText('Send')).toBeDisabled()
+  })
+
+  it('disables Send while not connected, even with a non-empty draft', () => {
+    mockChat({ status: 'reconnecting' })
+    renderChatPage()
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello' } })
+    expect(screen.getByText('Send')).toBeDisabled()
+  })
+
+  it('enables Send once there is a non-empty draft and the socket is connected', () => {
+    mockChat({ status: 'connected' })
+    renderChatPage()
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello' } })
+    expect(screen.getByText('Send')).not.toBeDisabled()
+  })
+})
+
+describe('ChatPage message input gating', () => {
+  afterEach(() => cleanup())
+
+  it('disables the input once the connection has failed', () => {
+    mockChat({ status: 'failed' })
+    renderChatPage()
+    expect(screen.getByLabelText('Message')).toBeDisabled()
+  })
+
+  it('leaves the input enabled while connected', () => {
+    mockChat({ status: 'connected' })
+    renderChatPage()
+    expect(screen.getByLabelText('Message')).not.toBeDisabled()
+  })
+})
+
+describe('ChatPage messages and presence', () => {
+  afterEach(() => cleanup())
+
+  it('renders a message with its author and body', () => {
+    mockChat({
+      messages: [
+        {
+          id: 'm1',
+          body: 'hello room',
+          author: { id: 'u2', username: 'abe' },
+          sentAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+    renderChatPage()
+    expect(screen.getByText('abe')).toBeInTheDocument()
+    expect(screen.getByText(/hello room/)).toBeInTheDocument()
+  })
+
+  it('reflects the online roster size', () => {
+    mockChat({
+      online: [
+        { id: 'u1', username: 'reader' },
+        { id: 'u2', username: 'abe' },
+      ],
+    })
+    renderChatPage()
+    expect(screen.getByText('2 online')).toBeInTheDocument()
+  })
+})

--- a/apps/client/src/pages/ChatPage.test.tsx
+++ b/apps/client/src/pages/ChatPage.test.tsx
@@ -2,49 +2,26 @@
 // never runs — every client test file wires jest-dom and cleanup itself, as
 // apps/client/src/components/patterns/CommentForm.test.tsx does.
 import '@testing-library/jest-dom/vitest'
-import type { ChatMessage } from '@blog/zod-shared'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { queryKeys } from '../lib/query-client.js'
-import type { ChatStatus, ChatUser } from '../hooks/use-chat.js'
 
-// Mocked so each test can drive ChatPage through a specific hook state
-// directly, instead of exercising the real socket.
+// Mocked as a spy, not stubbed with real state, because the property under
+// test is whether this hook gets CALLED at all — useChat() connects a socket
+// on mount, so calling it for an anonymous visitor opens (and the server
+// immediately rejects) a socket for nothing, waking the realtime service's
+// free-tier instance on every anonymous hit to /chat. This is the regression
+// the ChatPage/ChatRoom split exists to prevent.
 vi.mock('../hooks/use-chat.js', () => ({ useChat: vi.fn() }))
 
 const { useChat } = await import('../hooks/use-chat.js')
 const { ChatPage } = await import('./ChatPage.js')
 
-type ChatState = {
-  messages: ChatMessage[]
-  online: ChatUser[]
-  typingUsers: string[]
-  status: ChatStatus
-  send: ReturnType<typeof vi.fn>
-  setTyping: ReturnType<typeof vi.fn>
-}
-
-function mockChat(overrides: Partial<ChatState> = {}): ChatState {
-  const state: ChatState = {
-    messages: [],
-    online: [],
-    typingUsers: [],
-    status: 'connected',
-    send: vi.fn(),
-    setTyping: vi.fn(),
-    ...overrides,
-  }
-  vi.mocked(useChat).mockReturnValue(state)
-  return state
-}
-
-function renderChatPage() {
+function renderChatPage(me: { id: string; username: string } | null) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  // RequireAuth is UX only, not under test here — pre-seed a signed-in viewer
-  // so it resolves past the loading/redirect states immediately.
-  client.setQueryData(queryKeys.me, { id: 'u1', username: 'reader' })
+  client.setQueryData(queryKeys.me, me)
   return render(
     <MemoryRouter>
       <QueryClientProvider client={client}>
@@ -54,128 +31,24 @@ function renderChatPage() {
   )
 }
 
-describe('ChatPage status line', () => {
+describe('ChatPage guard', () => {
   afterEach(() => cleanup())
 
-  // The status line is the entire mitigation for the ~60s cold start — a
-  // silent page during that window is indistinguishable from a broken one.
-  it('tells the reader the socket is connecting', () => {
-    mockChat({ status: 'connecting' })
-    renderChatPage()
-    expect(screen.getByText('Connecting…')).toBeInTheDocument()
+  it('never calls useChat — and so never opens a socket — for an unauthenticated visitor', () => {
+    renderChatPage(null)
+    expect(useChat).not.toHaveBeenCalled()
   })
 
-  it('tells the reader the socket dropped and is retrying', () => {
-    mockChat({ status: 'reconnecting' })
-    renderChatPage()
-    expect(screen.getByText('Reconnecting…')).toBeInTheDocument()
-  })
-
-  it('tells the reader the connection failed and how to recover', () => {
-    mockChat({ status: 'failed' })
-    renderChatPage()
-    expect(screen.getByText('Could not connect. Reload to try again.')).toBeInTheDocument()
-  })
-
-  it('shows no status line once connected', () => {
-    mockChat({ status: 'connected' })
-    renderChatPage()
-    expect(screen.queryByText('Connecting…')).not.toBeInTheDocument()
-    expect(screen.queryByText('Reconnecting…')).not.toBeInTheDocument()
-    expect(screen.queryByText('Could not connect. Reload to try again.')).not.toBeInTheDocument()
-  })
-})
-
-describe('ChatPage send flow', () => {
-  afterEach(() => cleanup())
-
-  it('sends the typed body, then clears the draft and stops the typing signal', () => {
-    const state = mockChat({ status: 'connected' })
-    renderChatPage()
-
-    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello room' } })
-    fireEvent.click(screen.getByText('Send'))
-
-    expect(state.send).toHaveBeenCalledWith('hello room')
-    expect(screen.getByLabelText('Message')).toHaveValue('')
-    expect(state.setTyping).toHaveBeenCalledWith(false)
-  })
-})
-
-describe('ChatPage send button gating', () => {
-  afterEach(() => cleanup())
-
-  it('disables Send when the draft is empty', () => {
-    mockChat({ status: 'connected' })
-    renderChatPage()
-    expect(screen.getByText('Send')).toBeDisabled()
-  })
-
-  it('disables Send when the draft is only whitespace', () => {
-    mockChat({ status: 'connected' })
-    renderChatPage()
-    fireEvent.change(screen.getByLabelText('Message'), { target: { value: '   ' } })
-    expect(screen.getByText('Send')).toBeDisabled()
-  })
-
-  it('disables Send while not connected, even with a non-empty draft', () => {
-    mockChat({ status: 'reconnecting' })
-    renderChatPage()
-    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello' } })
-    expect(screen.getByText('Send')).toBeDisabled()
-  })
-
-  it('enables Send once there is a non-empty draft and the socket is connected', () => {
-    mockChat({ status: 'connected' })
-    renderChatPage()
-    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'hello' } })
-    expect(screen.getByText('Send')).not.toBeDisabled()
-  })
-})
-
-describe('ChatPage message input gating', () => {
-  afterEach(() => cleanup())
-
-  it('disables the input once the connection has failed', () => {
-    mockChat({ status: 'failed' })
-    renderChatPage()
-    expect(screen.getByLabelText('Message')).toBeDisabled()
-  })
-
-  it('leaves the input enabled while connected', () => {
-    mockChat({ status: 'connected' })
-    renderChatPage()
-    expect(screen.getByLabelText('Message')).not.toBeDisabled()
-  })
-})
-
-describe('ChatPage messages and presence', () => {
-  afterEach(() => cleanup())
-
-  it('renders a message with its author and body', () => {
-    mockChat({
-      messages: [
-        {
-          id: 'm1',
-          body: 'hello room',
-          author: { id: 'u2', username: 'abe' },
-          sentAt: '2026-01-01T00:00:00.000Z',
-        },
-      ],
+  it('calls useChat once RequireAuth has let a signed-in viewer through', () => {
+    vi.mocked(useChat).mockReturnValue({
+      messages: [],
+      online: [],
+      typingUsers: [],
+      status: 'connected',
+      send: vi.fn(),
+      setTyping: vi.fn(),
     })
-    renderChatPage()
-    expect(screen.getByText('abe')).toBeInTheDocument()
-    expect(screen.getByText(/hello room/)).toBeInTheDocument()
-  })
-
-  it('reflects the online roster size', () => {
-    mockChat({
-      online: [
-        { id: 'u1', username: 'reader' },
-        { id: 'u2', username: 'abe' },
-      ],
-    })
-    renderChatPage()
-    expect(screen.getByText('2 online')).toBeInTheDocument()
+    renderChatPage({ id: 'u1', username: 'reader' })
+    expect(useChat).toHaveBeenCalled()
   })
 })

--- a/apps/client/src/pages/ChatPage.tsx
+++ b/apps/client/src/pages/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Button } from '../components/ui/button.js'
 import { Input } from '../components/ui/input.js'
+import { RequireAuth } from '../components/patterns/RequireAuth.js'
 import { useChat } from '../hooks/use-chat.js'
 
 const STATUS_LABEL = {
@@ -21,47 +22,53 @@ export function ChatPage() {
     setTyping(false)
   }
 
+  // `RequireAuth` is UX only here too — it just redirects an anonymous visitor
+  // to /login before they see the room. The actual gate is server-side: the
+  // socket handshake in apps/server/src/realtime/index.ts rejects a connection
+  // that has no session, so there is nothing this component enforces.
   return (
-    <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4">
-      <header className="flex items-baseline justify-between">
-        <h1 className="text-2xl font-bold">Chat</h1>
-        <p className="text-xs text-[var(--muted-foreground)]">{online.length} online</p>
-      </header>
+    <RequireAuth>
+      <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4">
+        <header className="flex items-baseline justify-between">
+          <h1 className="text-2xl font-bold">Chat</h1>
+          <p className="text-xs text-[var(--muted-foreground)]">{online.length} online</p>
+        </header>
 
-      {/* The service sleeps when idle and cold-starts in ~60s, so a silent
-          page is indistinguishable from a broken one. Say what is happening. */}
-      {STATUS_LABEL[status] && (
-        <p className="text-xs text-[var(--muted-foreground)]">{STATUS_LABEL[status]}</p>
-      )}
+        {/* The service sleeps when idle and cold-starts in ~60s, so a silent
+            page is indistinguishable from a broken one. Say what is happening. */}
+        {STATUS_LABEL[status] && (
+          <p className="text-xs text-[var(--muted-foreground)]">{STATUS_LABEL[status]}</p>
+        )}
 
-      <ul className="flex flex-col gap-2">
-        {messages.map((m) => (
-          <li key={m.id} className="text-sm">
-            {/* Plain text, not Markdown: a fast room does not need tables, and
-                it removes the question of what a link in chat should do. */}
-            <span className="font-semibold">{m.author.username}</span> {m.body}
-          </li>
-        ))}
-      </ul>
+        <ul className="flex flex-col gap-2">
+          {messages.map((m) => (
+            <li key={m.id} className="text-sm">
+              {/* Plain text, not Markdown: a fast room does not need tables, and
+                  it removes the question of what a link in chat should do. */}
+              <span className="font-semibold">{m.author.username}</span> {m.body}
+            </li>
+          ))}
+        </ul>
 
-      <p className="h-4 text-xs text-[var(--muted-foreground)]">
-        {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
-      </p>
+        <p className="h-4 text-xs text-[var(--muted-foreground)]">
+          {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
+        </p>
 
-      <form onSubmit={submit} className="flex gap-2">
-        <Input
-          aria-label="Message"
-          value={draft}
-          onChange={(e) => {
-            setDraft(e.target.value)
-            setTyping(e.target.value.length > 0)
-          }}
-          disabled={status === 'failed'}
-        />
-        <Button type="submit" disabled={draft.trim().length === 0 || status !== 'connected'}>
-          Send
-        </Button>
-      </form>
-    </div>
+        <form onSubmit={submit} className="flex gap-2">
+          <Input
+            aria-label="Message"
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value)
+              setTyping(e.target.value.length > 0)
+            }}
+            disabled={status === 'failed'}
+          />
+          <Button type="submit" disabled={draft.trim().length === 0 || status !== 'connected'}>
+            Send
+          </Button>
+        </form>
+      </div>
+    </RequireAuth>
   )
 }

--- a/apps/client/src/pages/ChatPage.tsx
+++ b/apps/client/src/pages/ChatPage.tsx
@@ -1,74 +1,22 @@
-import { useState } from 'react'
-import { Button } from '../components/ui/button.js'
-import { Input } from '../components/ui/input.js'
+import { ChatRoom } from '../components/patterns/ChatRoom.js'
 import { RequireAuth } from '../components/patterns/RequireAuth.js'
-import { useChat } from '../hooks/use-chat.js'
 
-const STATUS_LABEL = {
-  connecting: 'Connecting…',
-  connected: '',
-  reconnecting: 'Reconnecting…',
-  failed: 'Could not connect. Reload to try again.',
-} as const
-
+// `RequireAuth` is UX only — it redirects an anonymous visitor to /login
+// before they see the room; the actual gate is server-side, the socket
+// handshake in apps/server/src/realtime/index.ts, which rejects a connection
+// with no session.
+//
+// This component does nothing else on purpose: `ChatRoom` calls useChat(),
+// which opens a socket the moment it mounts, so `ChatRoom` must sit inside
+// this guard rather than beside it. If ChatPage called useChat() itself (or
+// any other hook), that hook would run before RequireAuth had a chance to
+// redirect, and an anonymous hit to /chat would open — and get rejected by —
+// a socket for nothing. Keep this file a guard shell only; anything that
+// "simplifies" it back into one component reintroduces that regression.
 export function ChatPage() {
-  const { messages, online, typingUsers, status, send, setTyping } = useChat()
-  const [draft, setDraft] = useState('')
-
-  const submit = (e: React.FormEvent) => {
-    e.preventDefault()
-    send(draft)
-    setDraft('')
-    setTyping(false)
-  }
-
-  // `RequireAuth` is UX only here too — it just redirects an anonymous visitor
-  // to /login before they see the room. The actual gate is server-side: the
-  // socket handshake in apps/server/src/realtime/index.ts rejects a connection
-  // that has no session, so there is nothing this component enforces.
   return (
     <RequireAuth>
-      <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4">
-        <header className="flex items-baseline justify-between">
-          <h1 className="text-2xl font-bold">Chat</h1>
-          <p className="text-xs text-[var(--muted-foreground)]">{online.length} online</p>
-        </header>
-
-        {/* The service sleeps when idle and cold-starts in ~60s, so a silent
-            page is indistinguishable from a broken one. Say what is happening. */}
-        {STATUS_LABEL[status] && (
-          <p className="text-xs text-[var(--muted-foreground)]">{STATUS_LABEL[status]}</p>
-        )}
-
-        <ul className="flex flex-col gap-2">
-          {messages.map((m) => (
-            <li key={m.id} className="text-sm">
-              {/* Plain text, not Markdown: a fast room does not need tables, and
-                  it removes the question of what a link in chat should do. */}
-              <span className="font-semibold">{m.author.username}</span> {m.body}
-            </li>
-          ))}
-        </ul>
-
-        <p className="h-4 text-xs text-[var(--muted-foreground)]">
-          {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
-        </p>
-
-        <form onSubmit={submit} className="flex gap-2">
-          <Input
-            aria-label="Message"
-            value={draft}
-            onChange={(e) => {
-              setDraft(e.target.value)
-              setTyping(e.target.value.length > 0)
-            }}
-            disabled={status === 'failed'}
-          />
-          <Button type="submit" disabled={draft.trim().length === 0 || status !== 'connected'}>
-            Send
-          </Button>
-        </form>
-      </div>
+      <ChatRoom />
     </RequireAuth>
   )
 }

--- a/apps/client/src/pages/ChatPage.tsx
+++ b/apps/client/src/pages/ChatPage.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { Button } from '../components/ui/button.js'
+import { Input } from '../components/ui/input.js'
+import { useChat } from '../hooks/use-chat.js'
+
+const STATUS_LABEL = {
+  connecting: 'Connecting…',
+  connected: '',
+  reconnecting: 'Reconnecting…',
+  failed: 'Could not connect. Reload to try again.',
+} as const
+
+export function ChatPage() {
+  const { messages, online, typingUsers, status, send, setTyping } = useChat()
+  const [draft, setDraft] = useState('')
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    send(draft)
+    setDraft('')
+    setTyping(false)
+  }
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-bold">Chat</h1>
+        <p className="text-xs text-[var(--muted-foreground)]">{online.length} online</p>
+      </header>
+
+      {/* The service sleeps when idle and cold-starts in ~60s, so a silent
+          page is indistinguishable from a broken one. Say what is happening. */}
+      {STATUS_LABEL[status] && (
+        <p className="text-xs text-[var(--muted-foreground)]">{STATUS_LABEL[status]}</p>
+      )}
+
+      <ul className="flex flex-col gap-2">
+        {messages.map((m) => (
+          <li key={m.id} className="text-sm">
+            {/* Plain text, not Markdown: a fast room does not need tables, and
+                it removes the question of what a link in chat should do. */}
+            <span className="font-semibold">{m.author.username}</span> {m.body}
+          </li>
+        ))}
+      </ul>
+
+      <p className="h-4 text-xs text-[var(--muted-foreground)]">
+        {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
+      </p>
+
+      <form onSubmit={submit} className="flex gap-2">
+        <Input
+          aria-label="Message"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value)
+            setTyping(e.target.value.length > 0)
+          }}
+          disabled={status === 'failed'}
+        />
+        <Button type="submit" disabled={draft.trim().length === 0 || status !== 'connected'}>
+          Send
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/client/src/routes.tsx
+++ b/apps/client/src/routes.tsx
@@ -1,6 +1,5 @@
 import { createBrowserRouter, Outlet } from 'react-router'
 import { PageShell } from './components/layouts/PageShell.js'
-import { RequireAuth } from './components/patterns/RequireAuth.js'
 import { BlogFeedPage } from './pages/BlogFeedPage.js'
 import { PostPage } from './pages/PostPage.js'
 import { NewPostPage } from './pages/NewPostPage.js'
@@ -23,14 +22,7 @@ export const router = createBrowserRouter([
       { path: '/blog/:slug/edit', element: <EditPostPage /> },
       { path: '/login', element: <LoginPage /> },
       { path: '/signup', element: <SignupPage /> },
-      {
-        path: '/chat',
-        element: (
-          <RequireAuth>
-            <ChatPage />
-          </RequireAuth>
-        ),
-      },
+      { path: '/chat', element: <ChatPage /> },
     ],
   },
 ])

--- a/apps/client/src/routes.tsx
+++ b/apps/client/src/routes.tsx
@@ -1,11 +1,13 @@
 import { createBrowserRouter, Outlet } from 'react-router'
 import { PageShell } from './components/layouts/PageShell.js'
+import { RequireAuth } from './components/patterns/RequireAuth.js'
 import { BlogFeedPage } from './pages/BlogFeedPage.js'
 import { PostPage } from './pages/PostPage.js'
 import { NewPostPage } from './pages/NewPostPage.js'
 import { EditPostPage } from './pages/EditPostPage.js'
 import { LoginPage } from './pages/LoginPage.js'
 import { SignupPage } from './pages/SignupPage.js'
+import { ChatPage } from './pages/ChatPage.js'
 
 export const router = createBrowserRouter([
   {
@@ -21,6 +23,14 @@ export const router = createBrowserRouter([
       { path: '/blog/:slug/edit', element: <EditPostPage /> },
       { path: '/login', element: <LoginPage /> },
       { path: '/signup', element: <SignupPage /> },
+      {
+        path: '/chat',
+        element: (
+          <RequireAuth>
+            <ChatPage />
+          </RequireAuth>
+        ),
+      },
     ],
   },
 ])

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
         target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
         changeOrigin: false,
       },
+      // Socket.io's own endpoint, not under /api. `ws: true` proxies the
+      // upgrade; without it the handshake polls forever and never upgrades.
+      '/socket.io': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
+        changeOrigin: false,
+        ws: true,
+      },
     },
   },
 })

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
     "helmet": "^8.3.0",
     "mongoose": "^8.9.0",
     "redis": "^6.1.0",
+    "socket.io": "^4.8.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@types/express-session": "^1.19.0",
     "@types/supertest": "^7.2.1",
     "mongodb-memory-server": "^10.1.0",
+    "socket.io-client": "^4.8.3",
     "supertest": "^7.2.2",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1"

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -16,6 +16,8 @@ export type BuildAppOptions = {
   clientDist?: string
   /** Absent in tests that do not exercise chat. */
   chatService?: ChatService
+  /** Ends a user's sockets on logout. Absent in tests without realtime. */
+  disconnectUser?: (userId: string) => void
 }
 
 /**
@@ -37,6 +39,8 @@ export function buildApp(opts: BuildAppOptions): express.Express {
   if (opts.sessionMiddleware) {
     app.use(opts.sessionMiddleware)
   }
+
+  if (opts.disconnectUser) app.set('disconnectUser', opts.disconnectUser)
 
   // On the app, not on v1Router: that router is a module singleton, and
   // mounting per-buildApp would leak one test's service into the next.

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,7 +1,9 @@
 import express from 'express'
 import helmet from 'helmet'
+import type { ChatService } from './lib/services/chat.js'
 import { errorHandler } from './middleware/error-handler.js'
 import { notFound } from './middleware/not-found.js'
+import { createChatRouter } from './routes/v1/chat.js'
 import { v1Router } from './routes/v1/index.js'
 import { mountStatic } from './static.js'
 
@@ -12,6 +14,8 @@ export type BuildAppOptions = {
   trustProxy?: boolean
   /** Directory holding the built SPA. Absent in P1 — there is no client yet. */
   clientDist?: string
+  /** Absent in tests that do not exercise chat. */
+  chatService?: ChatService
 }
 
 /**
@@ -34,6 +38,9 @@ export function buildApp(opts: BuildAppOptions): express.Express {
     app.use(opts.sessionMiddleware)
   }
 
+  // On the app, not on v1Router: that router is a module singleton, and
+  // mounting per-buildApp would leak one test's service into the next.
+  if (opts.chatService) app.use('/api/v1/chat', createChatRouter(opts.chatService))
   app.use('/api/v1', v1Router)
   if (opts.clientDist) mountStatic(app, opts.clientDist)
   app.use(notFound)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,13 +1,13 @@
 import express from 'express'
 import helmet from 'helmet'
-import { buildSessionMiddleware, type SessionOptions } from './lib/session.js'
 import { errorHandler } from './middleware/error-handler.js'
 import { notFound } from './middleware/not-found.js'
 import { v1Router } from './routes/v1/index.js'
 import { mountStatic } from './static.js'
 
 export type BuildAppOptions = {
-  session?: SessionOptions
+  /** Prebuilt so the Socket.io server can share this exact instance. */
+  sessionMiddleware?: express.RequestHandler
   /** Behind Render's proxy this must be set, or Secure cookies are dropped. */
   trustProxy?: boolean
   /** Directory holding the built SPA. Absent in P1 — there is no client yet. */
@@ -30,8 +30,8 @@ export function buildApp(opts: BuildAppOptions): express.Express {
   app.use(helmet())
   app.use(express.json({ limit: '100kb' }))
 
-  if (opts.session) {
-    app.use(buildSessionMiddleware(opts.session))
+  if (opts.sessionMiddleware) {
+    app.use(opts.sessionMiddleware)
   }
 
   app.use('/api/v1', v1Router)

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,3 +1,4 @@
+import { createServer } from 'node:http'
 import { connectDb } from './lib/db.js'
 import { RedisStore } from 'connect-redis' // NAMED export in v9 — there is no default
 import { loadEnv } from './lib/env.js'
@@ -5,6 +6,7 @@ import { getRedis } from './lib/redis.js'
 import { createChatService } from './lib/services/chat.js'
 import { buildSessionMiddleware } from './lib/session.js'
 import { buildApp } from './app.js'
+import { createRealtime } from './realtime/index.js'
 
 async function main(): Promise<void> {
   // Validate the environment FIRST: fail before opening any connection.
@@ -29,7 +31,10 @@ async function main(): Promise<void> {
     chatService,
   })
 
-  app.listen(env.PORT, () => {
+  const server = createServer(app)
+  createRealtime({ server, sessionMiddleware, chatService })
+
+  server.listen(env.PORT, () => {
     console.log(`API listening on :${env.PORT} (${env.NODE_ENV})`)
   })
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,6 +2,7 @@ import { connectDb } from './lib/db.js'
 import { RedisStore } from 'connect-redis' // NAMED export in v9 — there is no default
 import { loadEnv } from './lib/env.js'
 import { getRedis } from './lib/redis.js'
+import { buildSessionMiddleware } from './lib/session.js'
 import { buildApp } from './app.js'
 
 async function main(): Promise<void> {
@@ -12,12 +13,14 @@ async function main(): Promise<void> {
   const redis = await getRedis(env.REDIS_URL)
   await connectDb(env.MONGODB_URI)
 
+  const sessionMiddleware = buildSessionMiddleware({
+    store: new RedisStore({ client: redis, prefix: 'sess:' }),
+    secret: env.SESSION_SECRET,
+    secure: isProd, // a Secure cookie over plain http:// is silently dropped
+  })
+
   const app = buildApp({
-    session: {
-      store: new RedisStore({ client: redis, prefix: 'sess:' }),
-      secret: env.SESSION_SECRET,
-      secure: isProd, // a Secure cookie over plain http:// is silently dropped
-    },
+    sessionMiddleware,
     trustProxy: isProd, // Render terminates TLS at a proxy
     clientDist: env.CLIENT_DIST,
   })

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,6 +2,7 @@ import { connectDb } from './lib/db.js'
 import { RedisStore } from 'connect-redis' // NAMED export in v9 — there is no default
 import { loadEnv } from './lib/env.js'
 import { getRedis } from './lib/redis.js'
+import { createChatService } from './lib/services/chat.js'
 import { buildSessionMiddleware } from './lib/session.js'
 import { buildApp } from './app.js'
 
@@ -19,10 +20,13 @@ async function main(): Promise<void> {
     secure: isProd, // a Secure cookie over plain http:// is silently dropped
   })
 
+  const chatService = createChatService(redis)
+
   const app = buildApp({
     sessionMiddleware,
     trustProxy: isProd, // Render terminates TLS at a proxy
     clientDist: env.CLIENT_DIST,
+    chatService,
   })
 
   app.listen(env.PORT, () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -6,7 +6,7 @@ import { getRedis } from './lib/redis.js'
 import { createChatService } from './lib/services/chat.js'
 import { buildSessionMiddleware } from './lib/session.js'
 import { buildApp } from './app.js'
-import { createRealtime } from './realtime/index.js'
+import { createRealtime, type Realtime } from './realtime/index.js'
 
 async function main(): Promise<void> {
   // Validate the environment FIRST: fail before opening any connection.
@@ -24,15 +24,21 @@ async function main(): Promise<void> {
 
   const chatService = createChatService(redis)
 
+  // `createRealtime` needs `server`, which needs `app`, which needs a
+  // reference to `disconnectUser` — resolved via this closure once
+  // `realtime` is assigned below, after `app` is built.
+  // eslint-disable-next-line prefer-const -- reassigned once, after the closure that captures it is created
+  let realtime: Realtime | undefined
   const app = buildApp({
     sessionMiddleware,
     trustProxy: isProd, // Render terminates TLS at a proxy
     clientDist: env.CLIENT_DIST,
     chatService,
+    disconnectUser: (userId) => realtime?.disconnectUser(userId),
   })
 
   const server = createServer(app)
-  createRealtime({ server, sessionMiddleware, chatService })
+  realtime = createRealtime({ server, sessionMiddleware, chatService })
 
   server.listen(env.PORT, () => {
     console.log(`API listening on :${env.PORT} (${env.NODE_ENV})`)

--- a/apps/server/src/lib/services/chat.test.ts
+++ b/apps/server/src/lib/services/chat.test.ts
@@ -62,4 +62,16 @@ describe('chatService', () => {
   it('returns an empty array when the buffer is empty', async () => {
     expect(await createChatService(redis).list()).toEqual([])
   })
+
+  // The key can be shared with another Render project on the free tier, so a
+  // foreign write is a real possibility. It must not 500 the whole feed.
+  it('skips entries that fail to parse rather than failing the whole call', async () => {
+    const service = createChatService(redis)
+    await service.append(message('good one'))
+    redis.store.unshift('not json{{{')
+    await service.append(message('good two'))
+
+    const result = await service.list()
+    expect(result.map((m) => m.body)).toEqual(['good one', 'good two'])
+  })
 })

--- a/apps/server/src/lib/services/chat.test.ts
+++ b/apps/server/src/lib/services/chat.test.ts
@@ -1,0 +1,65 @@
+import type { ChatMessage } from '@blog/zod-shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CHAT_BUFFER_SIZE, CHAT_KEY, CHAT_TTL_SECONDS, createChatService } from './chat.js'
+
+/** A list-shaped fake: LPUSH prepends, LTRIM slices, LRANGE reads. */
+function fakeRedis() {
+  const store: string[] = []
+  return {
+    store,
+    lPush: vi.fn(async (_k: string, v: string) => store.unshift(v)),
+    lTrim: vi.fn(async (_k: string, s: number, e: number) => {
+      store.splice(0, store.length, ...store.slice(s, e + 1))
+    }),
+    lRange: vi.fn(async (_k: string, s: number, e: number) =>
+      e === -1 ? store.slice(s) : store.slice(s, e + 1),
+    ),
+    expire: vi.fn(async () => undefined),
+  }
+}
+
+const message = (body: string): ChatMessage => ({
+  id: `id-${body}`,
+  body,
+  author: { id: 'u1', username: 'demo' },
+  sentAt: '2026-07-29T00:00:00.000Z',
+})
+
+describe('chatService', () => {
+  let redis: ReturnType<typeof fakeRedis>
+
+  beforeEach(() => {
+    redis = fakeRedis()
+  })
+
+  it('writes to the capped key and refreshes its TTL', async () => {
+    await createChatService(redis).append(message('hello'))
+
+    expect(redis.lPush).toHaveBeenCalledWith(CHAT_KEY, expect.stringContaining('hello'))
+    expect(redis.lTrim).toHaveBeenCalledWith(CHAT_KEY, 0, CHAT_BUFFER_SIZE - 1)
+    expect(redis.expire).toHaveBeenCalledWith(CHAT_KEY, CHAT_TTL_SECONDS)
+  })
+
+  it('keeps only the newest CHAT_BUFFER_SIZE messages', async () => {
+    const service = createChatService(redis)
+    for (let i = 0; i < CHAT_BUFFER_SIZE + 10; i++) await service.append(message(`m${i}`))
+
+    expect(redis.store).toHaveLength(CHAT_BUFFER_SIZE)
+    const bodies = (await service.list()).map((m) => m.body)
+    expect(bodies).toContain(`m${CHAT_BUFFER_SIZE + 9}`)
+    expect(bodies).not.toContain('m0')
+  })
+
+  // LPUSH puts newest at the head; a chat reads oldest-first.
+  it('lists oldest first', async () => {
+    const service = createChatService(redis)
+    await service.append(message('first'))
+    await service.append(message('second'))
+
+    expect((await service.list()).map((m) => m.body)).toEqual(['first', 'second'])
+  })
+
+  it('returns an empty array when the buffer is empty', async () => {
+    expect(await createChatService(redis).list()).toEqual([])
+  })
+})

--- a/apps/server/src/lib/services/chat.ts
+++ b/apps/server/src/lib/services/chat.ts
@@ -32,11 +32,7 @@ export function createChatService(redis: ChatRedis): ChatService {
 
     async list() {
       const raw = await redis.lRange(CHAT_KEY, 0, -1)
-      // This key can be shared with another Render project on the free tier,
-      // so a foreign write here is a real possibility, not a hypothetical —
-      // one bad entry must not 500 the feed for every user forever. Skip it
-      // rather than let JSON.parse throw for the whole list; never log the
-      // entry itself, since it may not be chat data at all.
+      // Skip entries that fail to parse instead of 500ing the whole feed; never log the entry itself.
       const messages: ChatMessage[] = []
       for (const entry of raw) {
         try {

--- a/apps/server/src/lib/services/chat.ts
+++ b/apps/server/src/lib/services/chat.ts
@@ -1,0 +1,39 @@
+import type { ChatMessage } from '@blog/zod-shared'
+
+export const CHAT_KEY = 'chat:messages'
+/** Enough for arriving context, small enough to stay trivial in a 25 MB store. */
+export const CHAT_BUFFER_SIZE = 50
+export const CHAT_TTL_SECONDS = 60 * 60 * 24
+
+/** The four commands this service uses — narrow so tests need no live Redis. */
+export type ChatRedis = {
+  lPush(key: string, value: string): Promise<number>
+  lTrim(key: string, start: number, stop: number): Promise<unknown>
+  lRange(key: string, start: number, stop: number): Promise<string[]>
+  expire(key: string, seconds: number): Promise<unknown>
+}
+
+export type ChatService = {
+  append(message: ChatMessage): Promise<void>
+  list(): Promise<ChatMessage[]>
+}
+
+export function createChatService(redis: ChatRedis): ChatService {
+  return {
+    async append(message) {
+      await redis.lPush(CHAT_KEY, JSON.stringify(message))
+      // Trim on every write rather than periodically: the list can never
+      // exceed the cap even briefly, so a burst cannot spike memory.
+      await redis.lTrim(CHAT_KEY, 0, CHAT_BUFFER_SIZE - 1)
+      // Refreshed on each write, so an idle room expires but a busy one never does.
+      await redis.expire(CHAT_KEY, CHAT_TTL_SECONDS)
+      if (process.env.DEBUG) console.log('[CHAT_SERVICE] append', { id: message.id })
+    },
+
+    async list() {
+      const raw = await redis.lRange(CHAT_KEY, 0, -1)
+      // LPUSH writes newest-to-head; a conversation reads oldest-first.
+      return raw.reverse().map((entry) => JSON.parse(entry) as ChatMessage)
+    },
+  }
+}

--- a/apps/server/src/lib/services/chat.ts
+++ b/apps/server/src/lib/services/chat.ts
@@ -32,8 +32,21 @@ export function createChatService(redis: ChatRedis): ChatService {
 
     async list() {
       const raw = await redis.lRange(CHAT_KEY, 0, -1)
+      // This key can be shared with another Render project on the free tier,
+      // so a foreign write here is a real possibility, not a hypothetical —
+      // one bad entry must not 500 the feed for every user forever. Skip it
+      // rather than let JSON.parse throw for the whole list; never log the
+      // entry itself, since it may not be chat data at all.
+      const messages: ChatMessage[] = []
+      for (const entry of raw) {
+        try {
+          messages.push(JSON.parse(entry) as ChatMessage)
+        } catch {
+          if (process.env.DEBUG) console.warn('[CHAT_SERVICE] skipped an unparsable entry')
+        }
+      }
       // LPUSH writes newest-to-head; a conversation reads oldest-first.
-      return raw.reverse().map((entry) => JSON.parse(entry) as ChatMessage)
+      return messages.reverse()
     },
   }
 }

--- a/apps/server/src/lib/session.test.ts
+++ b/apps/server/src/lib/session.test.ts
@@ -2,12 +2,13 @@ import session from 'express-session'
 import request from 'supertest'
 import { describe, expect, it } from 'vitest'
 import { buildApp } from '../app.js'
+import { buildSessionMiddleware } from './session.js'
 
 const SECRET = 'test-secret-at-least-32-characters-long'
 
 function appWith(secure: boolean, trustProxy = false) {
   return buildApp({
-    session: { store: new session.MemoryStore(), secret: SECRET, secure },
+    sessionMiddleware: buildSessionMiddleware({ store: new session.MemoryStore(), secret: SECRET, secure }),
     trustProxy,
   })
 }

--- a/apps/server/src/realtime/index.ts
+++ b/apps/server/src/realtime/index.ts
@@ -2,10 +2,27 @@ import { randomUUID } from 'node:crypto'
 import type { IncomingMessage, Server as HttpServer } from 'node:http'
 import { ChatMessageSchema, type ChatMessage } from '@blog/zod-shared'
 import type { RequestHandler } from 'express'
-import { Server, type Socket } from 'socket.io'
+import { Server, type DefaultEventsMap, type Socket } from 'socket.io'
 import type { ChatService } from '../lib/services/chat.js'
 
-export type RealtimeUser = { userId: string; username: string }
+/**
+ * `username` is optional here, honestly: the handshake guard below only
+ * requires `userId`, and the `session-test` helper route (and, in principle,
+ * any future session path) can produce a session with no username. Typing
+ * this as a required `string` would be a lie the compiler can't catch.
+ */
+export type RealtimeUser = { userId: string; username?: string }
+
+/**
+ * `socket.data`'s shape. Socket.io declares `Socket<..., SocketData = any>` —
+ * a non-generic `interface Socket { data: {...} }` augmentation does NOT
+ * override that generic default (verified: it silently resolves to `any`
+ * and no cast off it is visible to `no-explicit-any`). Parameterising the
+ * `Server`/`Socket` generics is the only way to type `socket.data` for real.
+ */
+type RealtimeSocketData = { user: RealtimeUser }
+type RealtimeServer = Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, RealtimeSocketData>
+type RealtimeSocket = Socket<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, RealtimeSocketData>
 
 /**
  * `socket.request` is the raw Node `IncomingMessage` from the handshake, after
@@ -20,7 +37,7 @@ type SessionRequest = IncomingMessage & {
 }
 
 export type Realtime = {
-  io: Server
+  io: RealtimeServer
   /** Ends every socket held by this user — used on logout. */
   disconnectUser(userId: string): void
   close(): Promise<void>
@@ -43,7 +60,9 @@ export function createRealtime({
   sessionMiddleware,
   chatService,
 }: CreateRealtimeOptions): Realtime {
-  const io = new Server(server)
+  const io = new Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, RealtimeSocketData>(
+    server,
+  )
 
   // Runs the session middleware on the handshake request, so socket.request
   // carries the same session object a REST handler would see.
@@ -62,8 +81,8 @@ export function createRealtime({
     next()
   })
 
-  io.on('connection', (socket: Socket) => {
-    const user = socket.data.user as RealtimeUser
+  io.on('connection', (socket: RealtimeSocket) => {
+    const user = socket.data.user
     if (process.env.DEBUG) console.log('[REALTIME] connected', { userId: user.userId })
 
     socket.on('message', async (payload: unknown) => {
@@ -84,7 +103,19 @@ export function createRealtime({
         sentAt: new Date().toISOString(),
       }
 
-      await chatService.append(message)
+      // Socket.io does not await or catch handler promises — an uncaught
+      // rejection here (e.g. a Redis blip) becomes an unhandled rejection
+      // that, under Node's default flags, kills the whole process. Caught
+      // here and reported to the sender instead; the room never sees a
+      // message that was not actually persisted.
+      try {
+        await chatService.append(message)
+      } catch {
+        if (process.env.DEBUG) console.error('[REALTIME] append failed', { id: message.id })
+        socket.emit('error', { message: 'Could not send message. Please try again.' })
+        return
+      }
+
       io.emit('message', message)
       if (process.env.DEBUG) console.log('[REALTIME] broadcast', { id: message.id })
     })

--- a/apps/server/src/realtime/index.ts
+++ b/apps/server/src/realtime/index.ts
@@ -81,9 +81,40 @@ export function createRealtime({
     next()
   })
 
+  /**
+   * Derived from the live socket set, never stored. One process with no Redis
+   * adapter means io.sockets already is the authoritative answer, and
+   * Socket.io's ping/pong timeout already fires `disconnect` for a dead client —
+   * so a Redis set plus application heartbeats would reimplement, worse, two
+   * things that already work (design §4).
+   *
+   * Deduplicated by userId: two tabs are one person online.
+   */
+  function broadcastPresence(): void {
+    const byId = new Map<string, { id: string; username?: string }>()
+    for (const socket of io.sockets.sockets.values()) {
+      const user = socket.data.user as RealtimeUser | undefined
+      if (user) byId.set(user.userId, { id: user.userId, username: user.username })
+    }
+    io.emit('presence', { users: [...byId.values()] })
+  }
+
   io.on('connection', (socket: RealtimeSocket) => {
     const user = socket.data.user
     if (process.env.DEBUG) console.log('[REALTIME] connected', { userId: user.userId })
+
+    broadcastPresence()
+
+    socket.on('typing', (payload: unknown) => {
+      const typing = Boolean((payload as { typing?: unknown } | null)?.typing)
+      // Broadcast and forget. Writing the highest-frequency, lowest-value event
+      // in the app into a 25 MB store would be a poor trade (design §5).
+      socket.broadcast.emit('typing', {
+        userId: user.userId,
+        username: user.username,
+        typing,
+      })
+    })
 
     socket.on('message', async (payload: unknown) => {
       const parsed = ChatMessageSchema.safeParse(payload)
@@ -122,6 +153,7 @@ export function createRealtime({
 
     socket.on('disconnect', () => {
       if (process.env.DEBUG) console.log('[REALTIME] disconnected', { userId: user.userId })
+      broadcastPresence()
     })
   })
 

--- a/apps/server/src/realtime/index.ts
+++ b/apps/server/src/realtime/index.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from 'node:crypto'
+import type { IncomingMessage, Server as HttpServer } from 'node:http'
+import { ChatMessageSchema, type ChatMessage } from '@blog/zod-shared'
+import type { RequestHandler } from 'express'
+import { Server, type Socket } from 'socket.io'
+import type { ChatService } from '../lib/services/chat.js'
+
+export type RealtimeUser = { userId: string; username: string }
+
+/**
+ * `socket.request` is the raw Node `IncomingMessage` from the handshake, after
+ * `sessionMiddleware` has run over it via `io.engine.use`. Widened locally
+ * rather than through a global `declare module 'http'` augmentation — that
+ * would collide with express-session's own `Express.Request.session` typing
+ * (Express's `Request` extends both `Express.Request` and `IncomingMessage`)
+ * and silently break `req.session` typing everywhere else in the app.
+ */
+type SessionRequest = IncomingMessage & {
+  session?: { userId?: string; username?: string }
+}
+
+export type Realtime = {
+  io: Server
+  /** Ends every socket held by this user — used on logout. */
+  disconnectUser(userId: string): void
+  close(): Promise<void>
+}
+
+type CreateRealtimeOptions = {
+  server: HttpServer
+  /** The SAME instance Express uses, so the socket reads the same session. */
+  sessionMiddleware: RequestHandler
+  chatService: ChatService
+}
+
+/**
+ * Socket.io on the app's own HTTP server. No CORS option: this is same-origin
+ * by construction (design §2), and adding one would silently permit the
+ * cross-origin case the design deliberately removed.
+ */
+export function createRealtime({
+  server,
+  sessionMiddleware,
+  chatService,
+}: CreateRealtimeOptions): Realtime {
+  const io = new Server(server)
+
+  // Runs the session middleware on the handshake request, so socket.request
+  // carries the same session object a REST handler would see.
+  io.engine.use(sessionMiddleware)
+
+  io.use((socket, next) => {
+    const session = (socket.request as SessionRequest).session
+    if (!session?.userId) {
+      next(new Error('unauthorized'))
+      return
+    }
+    socket.data.user = { userId: session.userId, username: session.username }
+    // One room per user, solely so logout can end their sockets without a
+    // hand-maintained registry.
+    socket.join(`user:${session.userId}`)
+    next()
+  })
+
+  io.on('connection', (socket: Socket) => {
+    const user = socket.data.user as RealtimeUser
+    if (process.env.DEBUG) console.log('[REALTIME] connected', { userId: user.userId })
+
+    socket.on('message', async (payload: unknown) => {
+      const parsed = ChatMessageSchema.safeParse(payload)
+      if (!parsed.success) {
+        // Back to the sender only — a malformed message is not the room's business.
+        socket.emit('error', { message: parsed.error.errors[0]?.message ?? 'Invalid message' })
+        return
+      }
+
+      const message: ChatMessage = {
+        id: randomUUID(),
+        body: parsed.data.body,
+        // From the socket's session, NEVER from the payload. Zod already
+        // stripped any author the client sent; this is the second reason it
+        // cannot be spoofed.
+        author: { id: user.userId, username: user.username },
+        sentAt: new Date().toISOString(),
+      }
+
+      await chatService.append(message)
+      io.emit('message', message)
+      if (process.env.DEBUG) console.log('[REALTIME] broadcast', { id: message.id })
+    })
+
+    socket.on('disconnect', () => {
+      if (process.env.DEBUG) console.log('[REALTIME] disconnected', { userId: user.userId })
+    })
+  })
+
+  return {
+    io,
+    disconnectUser(userId) {
+      io.in(`user:${userId}`).disconnectSockets()
+    },
+    close: () => io.close(),
+  }
+}

--- a/apps/server/src/realtime/realtime.test.ts
+++ b/apps/server/src/realtime/realtime.test.ts
@@ -50,9 +50,15 @@ describe('realtime', () => {
     await new Promise<void>((resolve) => httpServer.close(() => resolve()))
   })
 
-  /** Signs in over REST and returns the session cookie for the handshake. */
-  async function signedInCookie(): Promise<string> {
-    const res = await request(app).post('/api/v1/session-test/login').send({})
+  /**
+   * Signs in over REST and returns the session cookie for the handshake.
+   * `userId` defaults to the fixed 'user-123' every other test in this file
+   * uses; pass one explicitly to stand up a second, distinct identity.
+   */
+  async function signedInCookie(userId?: string): Promise<string> {
+    const res = await request(app)
+      .post('/api/v1/session-test/login')
+      .send(userId ? { userId } : {})
     return (res.headers['set-cookie'] as unknown as string[])[0]!.split(';')[0]!
   }
 
@@ -161,6 +167,41 @@ describe('realtime', () => {
     const message = await received
     expect(message.body).toBe('still works')
     expect(chatService.appended).toHaveLength(1)
+  })
+
+  // Design §8: presence must reflect connect AND disconnect. Two distinct
+  // identities on purpose — with one shared identity, dedup would keep the
+  // user listed via a second socket, and the assertion below would pass for
+  // the wrong reason.
+  it('removes a user from presence when their socket disconnects', async () => {
+    const watcher = connect(await signedInCookie('watcher-1'))
+    await new Promise<void>((resolve) => watcher.on('connect', resolve))
+
+    const leaver = connect(await signedInCookie('leaver-1'))
+    await new Promise<void>((resolve) => leaver.on('connect', resolve))
+
+    // The presence broadcast triggered by leaver's own connection is still in
+    // flight to watcher at this point (it's a separate round trip from the
+    // client-side 'connect' event above). Wait for it explicitly so the
+    // listener registered below can only be resolved by the DISCONNECT
+    // broadcast, not race the connect one.
+    await new Promise<void>((resolve) => {
+      watcher.on('presence', function onConnectPresence({ users }: { users: { id: string }[] }) {
+        if (users.some((u) => u.id === 'leaver-1')) {
+          watcher.off('presence', onConnectPresence)
+          resolve()
+        }
+      })
+    })
+
+    const presence = new Promise<{ users: { id: string }[] }>((resolve) =>
+      watcher.on('presence', resolve),
+    )
+    leaver.disconnect()
+
+    const ids = (await presence).users.map((u) => u.id)
+    expect(ids).not.toContain('leaver-1')
+    expect(ids).toContain('watcher-1')
   })
 
   it('lists a user once even when they hold two sockets', async () => {

--- a/apps/server/src/realtime/realtime.test.ts
+++ b/apps/server/src/realtime/realtime.test.ts
@@ -90,6 +90,9 @@ describe('realtime', () => {
     expect(message.author.username).not.toBe('admin')
     expect(message.body).toBe('hello')
     expect(chatService.appended).toHaveLength(1)
+    // The broadcast and the persisted record must carry the same identity —
+    // not just the same length of stored messages.
+    expect(chatService.appended[0]!.author.id).toBe('user-123')
   })
 
   it('rejects an empty message without broadcasting it', async () => {

--- a/apps/server/src/realtime/realtime.test.ts
+++ b/apps/server/src/realtime/realtime.test.ts
@@ -105,4 +105,57 @@ describe('realtime', () => {
     expect((await failure).message).toMatch(/empty/i)
     expect(chatService.appended).toHaveLength(0)
   })
+
+  // Regression guard for the process-killing bug: Socket.io does not await or
+  // catch handler promises, so an uncaught rejection from chatService.append
+  // (e.g. a Redis blip) would become an unhandled rejection and, under
+  // Node's default flags, terminate the process — every other socket and all
+  // REST traffic with it. This asserts the three properties the try/catch
+  // fix guarantees, not just that "something" happened.
+  it('recovers from a failed append: errors the sender, never broadcasts, and stays connected', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    // Same chatService instance the running realtime already closed over —
+    // reassigning append simulates a persistence failure (e.g. Redis down)
+    // for this one message, without touching the stub used by every passing
+    // test above.
+    chatService.append = async () => {
+      throw new Error('redis unavailable')
+    }
+
+    let broadcast = false
+    socket.on('message', () => {
+      broadcast = true
+    })
+
+    const failure = new Promise<{ message: string }>((resolve) => socket.on('error', resolve))
+    socket.emit('message', { body: 'this will fail to persist' })
+
+    // Property 1: the sender gets an error event, not silence.
+    expect((await failure).message).toMatch(/could not send|try again/i)
+
+    // Give a wrongly-scheduled broadcast a chance to arrive before asserting
+    // its absence — the assertion above only proves the catch branch ran,
+    // not that the emit branch was skipped.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Property 2: a message that was never persisted must never reach
+    // anyone's room. This is the property most likely to rot under a future
+    // refactor, so it is asserted directly rather than inferred from the
+    // error event alone.
+    expect(broadcast).toBe(false)
+    expect(chatService.appended).toHaveLength(0)
+
+    // Property 3: the rejection was actually caught, not merely deferred —
+    // the socket is still connected and the server keeps working afterward.
+    expect(socket.connected).toBe(true)
+
+    chatService.append = async (m) => void chatService.appended.push(m)
+    const received = new Promise<ChatMessage>((resolve) => socket.on('message', resolve))
+    socket.emit('message', { body: 'still works' })
+    const message = await received
+    expect(message.body).toBe('still works')
+    expect(chatService.appended).toHaveLength(1)
+  })
 })

--- a/apps/server/src/realtime/realtime.test.ts
+++ b/apps/server/src/realtime/realtime.test.ts
@@ -1,0 +1,105 @@
+import { createServer, type Server as HttpServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { ChatMessage } from '@blog/zod-shared'
+import session from 'express-session'
+import request from 'supertest'
+import { io as ioClient, type Socket } from 'socket.io-client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildApp } from '../app.js'
+import { buildSessionMiddleware } from '../lib/session.js'
+import type { ChatService } from '../lib/services/chat.js'
+import { createRealtime, type Realtime } from './index.js'
+
+const SECRET = 'test-only-secret-never-used-in-production-32c'
+
+function stubChatService(): ChatService & { appended: ChatMessage[] } {
+  const appended: ChatMessage[] = []
+  return { appended, append: async (m) => void appended.push(m), list: async () => appended }
+}
+
+describe('realtime', () => {
+  let httpServer: HttpServer
+  let realtime: Realtime
+  let chatService: ReturnType<typeof stubChatService>
+  let url: string
+  let app: ReturnType<typeof buildApp>
+  const sockets: Socket[] = []
+
+  beforeEach(async () => {
+    chatService = stubChatService()
+    const sessionMiddleware = buildSessionMiddleware({
+      store: new session.MemoryStore(),
+      secret: SECRET,
+      secure: false,
+    })
+    app = buildApp({ sessionMiddleware, chatService })
+    httpServer = createServer(app)
+    realtime = createRealtime({ server: httpServer, sessionMiddleware, chatService })
+    await new Promise<void>((resolve) => httpServer.listen(0, resolve))
+    url = `http://localhost:${(httpServer.address() as AddressInfo).port}`
+  })
+
+  afterEach(async () => {
+    sockets.forEach((s) => s.disconnect())
+    sockets.length = 0
+    await realtime.close()
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+  })
+
+  /** Signs in over REST and returns the session cookie for the handshake. */
+  async function signedInCookie(): Promise<string> {
+    const res = await request(app).post('/api/v1/session-test/login').send({})
+    return (res.headers['set-cookie'] as unknown as string[])[0]!.split(';')[0]!
+  }
+
+  function connect(cookie?: string): Socket {
+    const socket = ioClient(url, {
+      transports: ['websocket'],
+      extraHeaders: cookie ? { Cookie: cookie } : {},
+    })
+    sockets.push(socket)
+    return socket
+  }
+
+  it('rejects an anonymous handshake', async () => {
+    const socket = connect()
+    const error = await new Promise<Error>((resolve) => socket.on('connect_error', resolve))
+    expect(error.message).toBe('unauthorized')
+  })
+
+  it('accepts a handshake carrying a valid session cookie', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+    expect(socket.connected).toBe(true)
+  })
+
+  // THE regression (spec §14, legacy app.js:56). The payload's author must be
+  // ignored entirely; the broadcast identity comes from the session.
+  it('stamps the session identity and ignores an author in the payload', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const received = new Promise<ChatMessage>((resolve) => socket.on('message', resolve))
+    socket.emit('message', { body: 'hello', author: { id: 'evil', username: 'admin' } })
+
+    const message = await received
+    // The session's identity, not the payload's. Asserted as two separate
+    // claims because `toEqual` treats an undefined property as absent, so a
+    // whole-object comparison could pass for the wrong reason.
+    expect(message.author.id).toBe('user-123')
+    expect(message.author.username).not.toBe('admin')
+    expect(message.body).toBe('hello')
+    expect(chatService.appended).toHaveLength(1)
+  })
+
+  it('rejects an empty message without broadcasting it', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const failure = new Promise<{ message: string }>((resolve) => socket.on('error', resolve))
+    socket.emit('message', { body: '   ' })
+
+    expect((await failure).message).toMatch(/empty/i)
+    expect(chatService.appended).toHaveLength(0)
+  })
+})

--- a/apps/server/src/realtime/realtime.test.ts
+++ b/apps/server/src/realtime/realtime.test.ts
@@ -50,11 +50,7 @@ describe('realtime', () => {
     await new Promise<void>((resolve) => httpServer.close(() => resolve()))
   })
 
-  /**
-   * Signs in over REST and returns the session cookie for the handshake.
-   * `userId` defaults to the fixed 'user-123' every other test in this file
-   * uses; pass one explicitly to stand up a second, distinct identity.
-   */
+  /** Signs in over REST; pass userId to stand up a second, distinct identity. */
   async function signedInCookie(userId?: string): Promise<string> {
     const res = await request(app)
       .post('/api/v1/session-test/login')
@@ -169,10 +165,7 @@ describe('realtime', () => {
     expect(chatService.appended).toHaveLength(1)
   })
 
-  // Design §8: presence must reflect connect AND disconnect. Two distinct
-  // identities on purpose — with one shared identity, dedup would keep the
-  // user listed via a second socket, and the assertion below would pass for
-  // the wrong reason.
+  // Design §8: two identities on purpose — one shared identity would let dedup mask the removal.
   it('removes a user from presence when their socket disconnects', async () => {
     const watcher = connect(await signedInCookie('watcher-1'))
     await new Promise<void>((resolve) => watcher.on('connect', resolve))
@@ -180,11 +173,7 @@ describe('realtime', () => {
     const leaver = connect(await signedInCookie('leaver-1'))
     await new Promise<void>((resolve) => leaver.on('connect', resolve))
 
-    // The presence broadcast triggered by leaver's own connection is still in
-    // flight to watcher at this point (it's a separate round trip from the
-    // client-side 'connect' event above). Wait for it explicitly so the
-    // listener registered below can only be resolved by the DISCONNECT
-    // broadcast, not race the connect one.
+    // Drain the connect-triggered presence broadcast first, so the listener below only catches disconnect's.
     await new Promise<void>((resolve) => {
       watcher.on('presence', function onConnectPresence({ users }: { users: { id: string }[] }) {
         if (users.some((u) => u.id === 'leaver-1')) {

--- a/apps/server/src/realtime/realtime.test.ts
+++ b/apps/server/src/realtime/realtime.test.ts
@@ -32,7 +32,11 @@ describe('realtime', () => {
       secret: SECRET,
       secure: false,
     })
-    app = buildApp({ sessionMiddleware, chatService })
+    app = buildApp({
+      sessionMiddleware,
+      chatService,
+      disconnectUser: (id) => realtime.disconnectUser(id),
+    })
     httpServer = createServer(app)
     realtime = createRealtime({ server: httpServer, sessionMiddleware, chatService })
     await new Promise<void>((resolve) => httpServer.listen(0, resolve))
@@ -157,5 +161,54 @@ describe('realtime', () => {
     const message = await received
     expect(message.body).toBe('still works')
     expect(chatService.appended).toHaveLength(1)
+  })
+
+  it('lists a user once even when they hold two sockets', async () => {
+    const cookie = await signedInCookie()
+    const first = connect(cookie)
+    await new Promise<void>((resolve) => first.on('connect', resolve))
+
+    const second = connect(cookie)
+    const presence = await new Promise<{ users: { id: string }[] }>((resolve) =>
+      second.on('presence', resolve),
+    )
+
+    expect(presence.users.filter((u) => u.id === 'user-123')).toHaveLength(1)
+  })
+
+  it('relays a typing signal without persisting it', async () => {
+    const watcher = connect(await signedInCookie())
+    await new Promise<void>((resolve) => watcher.on('connect', resolve))
+    const typer = connect(await signedInCookie())
+    await new Promise<void>((resolve) => typer.on('connect', resolve))
+
+    const signal = new Promise<{ typing: boolean }>((resolve) => watcher.on('typing', resolve))
+    typer.emit('typing', { typing: true })
+
+    expect((await signal).typing).toBe(true)
+    expect(chatService.appended).toHaveLength(0)
+  })
+
+  it('disconnects a user\'s sockets when asked', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const closed = new Promise<void>((resolve) => socket.on('disconnect', () => resolve()))
+    realtime.disconnectUser('user-123')
+
+    await closed
+    expect(socket.connected).toBe(false)
+  })
+
+  it('ends the socket when the user logs out over REST', async () => {
+    const cookie = await signedInCookie()
+    const socket = connect(cookie)
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const closed = new Promise<void>((resolve) => socket.on('disconnect', () => resolve()))
+    await request(app).post('/api/v1/auth/logout').set('Cookie', cookie)
+
+    await closed
+    expect(socket.connected).toBe(false)
   })
 })

--- a/apps/server/src/routes/v1/auth.ts
+++ b/apps/server/src/routes/v1/auth.ts
@@ -45,8 +45,14 @@ authRouter.post('/login', validate(LoginSchema), async (req, res) => {
 // POST, never GET: the legacy GET logout meant any <img src="/logout"> on any
 // page logged the visitor out. requireAuth makes an anonymous logout a 401.
 authRouter.post('/logout', requireAuth, async (req, res) => {
+  const userId = req.session.userId
   await destroySession(req)
   res.clearCookie('sid')
+  // The session is gone, but a socket opened before now still holds its
+  // identity in memory. Without this, logout leaves a live authenticated
+  // socket behind.
+  const disconnectUser = req.app.get('disconnectUser') as ((id: string) => void) | undefined
+  if (userId && disconnectUser) disconnectUser(userId)
   res.status(204).end()
 })
 

--- a/apps/server/src/routes/v1/chat.test.ts
+++ b/apps/server/src/routes/v1/chat.test.ts
@@ -1,0 +1,32 @@
+import type { ChatMessage } from '@blog/zod-shared'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import type { ChatService } from '../../lib/services/chat.js'
+import { buildTestApp } from '../../test/helpers.js'
+
+const stored: ChatMessage[] = [
+  { id: '1', body: 'first', author: { id: 'u1', username: 'demo' }, sentAt: '2026-07-29T00:00:00.000Z' },
+]
+
+const stubService: ChatService = {
+  append: async () => undefined,
+  list: async () => stored,
+}
+
+describe('GET /api/v1/chat/messages', () => {
+  it('401s for an anonymous reader — chat is signed-in only', async () => {
+    const app = buildTestApp({ chatService: stubService })
+    const res = await request(app).get('/api/v1/chat/messages')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the buffer for a signed-in reader', async () => {
+    const app = buildTestApp({ chatService: stubService })
+    const agent = request.agent(app)
+    await agent.post('/api/v1/session-test/login').send({})
+
+    const res = await agent.get('/api/v1/chat/messages')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(stored)
+  })
+})

--- a/apps/server/src/routes/v1/chat.ts
+++ b/apps/server/src/routes/v1/chat.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express'
+import type { ChatService } from '../../lib/services/chat.js'
+import { requireAuth } from '../../middleware/require-auth.js'
+
+/**
+ * Takes the service rather than importing it: the Redis client is created at
+ * the entry point, so the service cannot be a module-level singleton the way
+ * the Mongoose-backed ones are.
+ */
+export function createChatRouter(chatService: ChatService): Router {
+  const chatRouter = Router()
+
+  // requireAuth, not optional: the wall covers the room itself, not just
+  // posting into it (design §5).
+  chatRouter.get('/messages', requireAuth, async (_req, res) => {
+    res.json(await chatService.list())
+  })
+
+  return chatRouter
+}

--- a/apps/server/src/routes/v1/index.ts
+++ b/apps/server/src/routes/v1/index.ts
@@ -35,9 +35,7 @@ if (process.env.NODE_ENV !== 'production') {
     throw new Error('db password rejected')
   })
   v1Router.post('/session-test/login', (req, res) => {
-    // Defaults to the fixed 'user-123' every existing test relies on; an
-    // explicit body.userId lets a test stand up a second, distinct identity
-    // (e.g. to prove presence actually removes ONE user, not the only user).
+    // Defaults to 'user-123'; pass body.userId to stand up a second identity in a test.
     const userId = typeof req.body?.userId === 'string' ? req.body.userId : 'user-123'
     req.session.userId = userId
     res.json({ ok: true })

--- a/apps/server/src/routes/v1/index.ts
+++ b/apps/server/src/routes/v1/index.ts
@@ -35,7 +35,11 @@ if (process.env.NODE_ENV !== 'production') {
     throw new Error('db password rejected')
   })
   v1Router.post('/session-test/login', (req, res) => {
-    req.session.userId = 'user-123'
+    // Defaults to the fixed 'user-123' every existing test relies on; an
+    // explicit body.userId lets a test stand up a second, distinct identity
+    // (e.g. to prove presence actually removes ONE user, not the only user).
+    const userId = typeof req.body?.userId === 'string' ? req.body.userId : 'user-123'
+    req.session.userId = userId
     res.json({ ok: true })
   })
   v1Router.get('/session-test/whoami', (req, res) => {

--- a/apps/server/src/test/helpers.ts
+++ b/apps/server/src/test/helpers.ts
@@ -8,6 +8,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server'
 import mongoose from 'mongoose'
 import { afterAll, beforeAll, beforeEach } from 'vitest'
 import { buildApp, type BuildAppOptions } from '../app.js'
+import { buildSessionMiddleware } from '../lib/session.js'
 
 // Test-only. Never imported by src/index.ts, so it is unreachable from the
 // tsup bundle and the production image. Production secrets always come from
@@ -22,7 +23,11 @@ const TEST_SESSION_SECRET = 'test-only-secret-never-used-in-production-32c'
  */
 export function buildTestApp(overrides: Partial<BuildAppOptions> = {}): express.Express {
   return buildApp({
-    session: { store: new session.MemoryStore(), secret: TEST_SESSION_SECRET, secure: false },
+    sessionMiddleware: buildSessionMiddleware({
+      store: new session.MemoryStore(),
+      secret: TEST_SESSION_SECRET,
+      secure: false,
+    }),
     ...overrides,
   })
 }

--- a/apps/server/src/types/express-session.d.ts
+++ b/apps/server/src/types/express-session.d.ts
@@ -1,9 +1,16 @@
 import 'express-session'
+import 'socket.io'
 
 declare module 'express-session' {
   interface SessionData {
     /** The ONLY source of caller identity. Never read identity from a body field. */
     userId?: string
     username?: string
+  }
+}
+
+declare module 'socket.io' {
+  interface Socket {
+    data: { user: { userId: string; username: string } }
   }
 }

--- a/apps/server/src/types/express-session.d.ts
+++ b/apps/server/src/types/express-session.d.ts
@@ -1,16 +1,9 @@
 import 'express-session'
-import 'socket.io'
 
 declare module 'express-session' {
   interface SessionData {
     /** The ONLY source of caller identity. Never read identity from a body field. */
     userId?: string
     username?: string
-  }
-}
-
-declare module 'socket.io' {
-  interface Socket {
-    data: { user: { userId: string; username: string } }
   }
 }

--- a/docs/architecture/deployment-architecture.md
+++ b/docs/architecture/deployment-architecture.md
@@ -5,7 +5,8 @@ Living reference doc — update as the rebuild progresses. Unlike `docs/superpow
 
 **Status legend:** ✅ live today · 🚧 in progress · 📋 planned, not built yet
 
-**Last verified against reality:** 2026-07-28, P2 (React client) complete on `staging`.
+**Last verified against reality:** 2026-07-29, P2 (React client) complete on `staging`; P4 (realtime chat)
+built on `dev/realtime-chat`, not yet merged or deployed.
 
 ---
 
@@ -73,22 +74,17 @@ reviewer) and to make the pipeline stage explicit.
 
 ```mermaid
 flowchart TB
-    Users(("End Users")) -->|"HTTPS — SPA + /api/v1/*, one origin"| ApiSvc
-    Users -->|WebSocket, signed ticket| RealtimeSvc
+    Users(("End Users")) -->|"HTTPS + WebSocket — SPA + /api/v1/* + chat, one origin"| ApiSvc
 
     Master(["master branch"]) -->|auto-deploy webhook| ApiSvc
-    Master -->|auto-deploy webhook| RealtimeSvc
 
     subgraph RenderCloud["Render (free tier)"]
-        ApiSvc["apps/server<br/>Express REST API<br/>+ serves apps/client build"]
-        RealtimeSvc["apps/realtime<br/>Socket.io service"]
+        ApiSvc["apps/server<br/>Express REST API + Socket.io chat<br/>+ serves apps/client build"]
         Redis[("Render Key Value — Redis<br/>sessions, chat buffer, rate limit")]
         ApiSvc <-->|internal network| Redis
-        RealtimeSvc <-->|internal network| Redis
     end
 
     ApiSvc -->|MONGODB_URI| Atlas[("MongoDB Atlas M0<br/>production cluster")]
-    RealtimeSvc -->|MONGODB_URI| Atlas
 
     ApiSvc -->|signed upload params| Cloudinary[("Cloudinary<br/>free-forever tier")]
     Users -->|"direct upload / image GET"| Cloudinary
@@ -96,18 +92,22 @@ flowchart TB
 
 | Component | Status | Notes |
 |---|---|---|
-| `apps/server` Render service | 🚧 built, not yet deployed | P1. Serves the REST API **and** the built SPA from one origin — no CORS, no cross-origin cookie problem |
+| `apps/server` Render service | 🚧 built, not yet deployed | P1–P4. Serves the REST API, the built SPA, **and** the Socket.io realtime chat server from one origin — no CORS, no cross-origin cookie problem |
 | `apps/client` | 🚧 built, baked into the `apps/server` image | P2, complete on `staging`. Vite build; not a separate Render service — this was always the design, see "Why one service for API + client" below |
-| `apps/realtime` Render service | 📋 planned | P4 — Socket.io, separate service, cold starts accepted |
+| Realtime chat | 🚧 built, not yet deployed | P4 — runs **inside** `apps/server`, not as its own Render service (see below); no separate handshake needed because it shares the session cookie |
 | Render Key Value (Redis) | 🚧 declared in `infra/render.yaml`, not yet provisioned | P1 (sessions) → P4 (chat buffer, presence) → P6 (rate limiting). Ephemeral by design |
 | MongoDB Atlas M0 | ✅ exists, 🚧 being re-secured | Credential was leaked and rotated on 2026-07-16; cluster will be wiped and reseeded before go-live |
 | Cloudinary | 📋 planned | P5 — replaces the S3 + CloudFront plan; free forever, no shared-AWS-account hazard |
-| Socket auth across origins | 📋 planned | P4 — short-lived signed JWT ticket. Render subdomains are on the Public Suffix List, so the two services **cannot** share a session cookie |
 
-**Why one service for API + client:** the session cookie is httpOnly and same-origin. Splitting the SPA
-onto a Render Static Site would put it on a different `*.onrender.com` origin, forcing CORS plus
-`SameSite=None` cookies — and would consume a second slice of the 750-hour free pool. `apps/realtime`
-pays exactly that cost, which is why it needs the signed-ticket handshake instead of the cookie.
+**Why one service for API + client (and chat):** the session cookie is httpOnly and same-origin. Splitting
+the SPA onto a Render Static Site would put it on a different `*.onrender.com` origin, forcing CORS plus
+`SameSite=None` cookies — and would consume a second slice of the 750-hour free pool. A separate
+`apps/realtime` service was designed the same way during P4 planning and would have paid the identical
+cost, needing a short-lived signed JWT ticket to authenticate a socket across origins (Render subdomains
+are on the Public Suffix List, so two services can't share a session cookie). That design was dropped
+before implementation (2026-07-29): Socket.io runs inside `apps/server` instead, reads the session
+directly via `io.engine.use(sessionMiddleware)`, and never had a ticket to build. See
+`docs/superpowers/specs/2026-07-29-realtime-chat-design.md`.
 
 ---
 
@@ -118,24 +118,22 @@ flowchart LR
     Browser(("Browser")) -->|":5173"| Vite
     subgraph Laptop["Developer machine — docker compose watch"]
         Vite["client container<br/>Vite dev server, HMR"]
-        Vite -->|"proxy /api → :3000"| ApiDev
-        ApiDev["api container<br/>dev target, hot reload"]
-        RealtimeDev["realtime container<br/>dev target, hot reload"]
+        Vite -->|"proxy /api + socket.io upgrade → :3000"| ApiDev
+        ApiDev["api container<br/>dev target, hot reload<br/>REST API + Socket.io chat"]
         MongoDev[("mongo container<br/>named volume<br/>127.0.0.1 only")]
         RedisDev[("redis container<br/>127.0.0.1 only")]
         ApiDev <--> MongoDev
         ApiDev <--> RedisDev
-        RealtimeDev <--> MongoDev
-        RealtimeDev <--> RedisDev
     end
 ```
 
 `compose watch` syncs changed source files into the containers (not a bind mount) — avoids the
 Windows `node_modules`/inotify problems a plain bind mount would hit.
 
-**Vite's `server.proxy` forwards `/api` to the api container**, so the browser sees a single origin in
-dev exactly as it will in prod. The auth model is therefore identical across dev, CI, and prod — a cookie
-bug cannot hide until deploy.
+**Vite's `server.proxy` forwards `/api` and the Socket.io upgrade to the api container**, so the browser
+sees a single origin in dev exactly as it will in prod. The auth model is therefore identical across dev,
+CI, and prod — a cookie bug cannot hide until deploy. There is no separate realtime container: chat runs
+in the same api container as the REST API (see "Target production topology" above).
 
 **Mongo and Redis bind to `127.0.0.1`, never `0.0.0.0`** — they run unauthenticated locally, and
 publishing them on all interfaces would expose an unauthenticated database to the LAN.
@@ -145,8 +143,7 @@ publishing them on all interfaces would expose an unauthenticated database to th
 ```mermaid
 flowchart LR
     subgraph Runner["GitHub Actions runner — ephemeral, torn down after"]
-        Compose["docker compose -f infra/compose.e2e.yaml --project-directory . up --wait"] --> ApiE2E["api container<br/>prod/runner target<br/>serves the built SPA"]
-        Compose --> RealtimeE2E["realtime container<br/>prod target"]
+        Compose["docker compose -f infra/compose.e2e.yaml --project-directory . up --wait"] --> ApiE2E["api container<br/>prod/runner target<br/>serves the built SPA + Socket.io chat"]
         ApiE2E <--> MongoE2E[("mongo container")]
         ApiE2E <--> RedisE2E[("redis container")]
         ApiE2E --> PW["Playwright E2E tests"]

--- a/docs/architecture/deployment-architecture.md
+++ b/docs/architecture/deployment-architecture.md
@@ -95,7 +95,7 @@ flowchart TB
 | `apps/server` Render service | 🚧 built, not yet deployed | P1–P4. Serves the REST API, the built SPA, **and** the Socket.io realtime chat server from one origin — no CORS, no cross-origin cookie problem |
 | `apps/client` | 🚧 built, baked into the `apps/server` image | P2, complete on `staging`. Vite build; not a separate Render service — this was always the design, see "Why one service for API + client" below |
 | Realtime chat | 🚧 built, not yet deployed | P4 — runs **inside** `apps/server`, not as its own Render service (see below); no separate handshake needed because it shares the session cookie |
-| Render Key Value (Redis) | 🚧 declared in `infra/render.yaml`, not yet provisioned | P1 (sessions) → P4 (chat buffer, presence) → P6 (rate limiting). Ephemeral by design |
+| Render Key Value (Redis) | 🚧 declared in `infra/render.yaml`, not yet provisioned | P1 (sessions) → P4 (chat buffer) → P6 (rate limiting). Ephemeral by design. Presence is in-memory, not Redis — see the realtime chat design §4 |
 | MongoDB Atlas M0 | ✅ exists, 🚧 being re-secured | Credential was leaked and rotated on 2026-07-16; cluster will be wiped and reseeded before go-live |
 | Cloudinary | 📋 planned | P5 — replaces the S3 + CloudFront plan; free forever, no shared-AWS-account hazard |
 

--- a/docs/superpowers/plans/2026-07-29-realtime-chat.md
+++ b/docs/superpowers/plans/2026-07-29-realtime-chat.md
@@ -1,0 +1,1518 @@
+# Realtime Chat (P4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add authenticated realtime chat — one global room, messages held in Redis, presence and typing indicators — running inside `apps/server` rather than as a separate service.
+
+**Architecture:** Socket.io attaches to the same Node HTTP server as Express and shares the Express session middleware via `io.engine.use(sessionMiddleware)`. The socket therefore reads the same session as every REST request: no handshake ticket, no shared crypto package, no CORS. Messages live in a capped Redis list; presence is derived in-memory from `io.sockets` and stored nowhere.
+
+**Tech Stack:** Socket.io 4 (server + client), Express 5, `express-session` + `connect-redis`, `redis` v6 (node-redis camelCase API), Zod, React 19, Vitest, Playwright.
+
+**Design spec:** `docs/superpowers/specs/2026-07-29-realtime-chat-design.md`. Read it before Task 1 — the "why" for every decision below lives there, and several are deliberate deviations from the main design spec.
+
+## Global Constraints
+
+- **No `any`.** `@typescript-eslint/no-explicit-any` is an error repo-wide.
+- **No new environment variables.** Chat reuses `SESSION_SECRET` and `REDIS_URL`.
+- **No CORS, ever.** Socket.io is same-origin; do not add a `cors` option to the `Server` constructor.
+- **Business logic lives in `lib/services/`.** Socket handlers and routers authenticate, validate, delegate.
+- **Zod is the single source of truth.** Schemas in `packages/zod-shared/src/schemas/`; types inferred with `z.infer`, never hand-declared.
+- **Identity always comes from the session**, never from a request body or socket payload.
+- **Gate `console.*` tracing with `if (process.env.DEBUG)`** on the server, `if (DEBUG)` on the client.
+- **Never pass credentials or message bodies to a log** — use `redactSecrets` if a payload must be traced.
+- **Commits carry no Claude attribution and no `Co-Authored-By` trailer.**
+- **Never merge without a PR**, and never to `master`.
+- Redis calls use node-redis camelCase: `lPush`, `lTrim`, `lRange`, `expire`.
+
+---
+
+## File Structure
+
+**Create:**
+
+| Path | Responsibility |
+|---|---|
+| `packages/zod-shared/src/schemas/chat.ts` | `ChatMessageSchema` (the wire-in payload) and the `ChatMessage` broadcast type |
+| `apps/server/src/lib/services/chat.ts` | Redis buffer: append with trim + TTL, list oldest-first |
+| `apps/server/src/lib/services/chat.test.ts` | Buffer unit tests against a fake Redis client |
+| `apps/server/src/routes/v1/chat.ts` | `GET /api/v1/chat/messages` |
+| `apps/server/src/routes/v1/chat.test.ts` | Route auth + shape |
+| `apps/server/src/realtime/index.ts` | `createRealtime` — Socket.io wiring, auth guard, event handlers |
+| `apps/server/src/realtime/realtime.test.ts` | Socket integration: auth, identity, presence, logout |
+| `apps/client/src/hooks/use-chat.ts` | Socket lifecycle and chat state |
+| `apps/client/src/hooks/use-chat.test.tsx` | Listener cleanup — the `chat.jsx` regressions |
+| `apps/client/src/pages/ChatPage.tsx` | Renders; holds no socket logic |
+| `e2e/chat.spec.ts` | Two browser contexts exchange a message |
+
+**Modify:** `apps/server/src/app.ts`, `index.ts`, `test/helpers.ts`, `lib/session.test.ts`, `routes/v1/index.ts`, `routes/v1/auth.ts`, `packages/zod-shared/src/schemas/index.ts`, `apps/client/src/routes.tsx`, `apps/client/src/components/layouts/PageShell.tsx`, `apps/client/vite.config.ts`, both `package.json` files.
+
+---
+
+### Task 1: Accept a prebuilt session middleware in `buildApp`
+
+Socket.io must share the *same* session middleware instance as Express. `buildApp` currently constructs it internally from `SessionOptions`, so the entry point cannot hand the same object to both.
+
+**Files:**
+- Modify: `apps/server/src/app.ts`
+- Modify: `apps/server/src/index.ts`
+- Modify: `apps/server/src/test/helpers.ts:24-27`
+- Modify: `apps/server/src/lib/session.test.ts:10`
+
+**Interfaces:**
+- Consumes: `buildSessionMiddleware(opts: SessionOptions): RequestHandler` — already exists in `lib/session.ts`.
+- Produces: `BuildAppOptions.sessionMiddleware?: RequestHandler` replacing `session?: SessionOptions`.
+
+- [ ] **Step 1: Change the option in `app.ts`**
+
+Replace the `session` field and its use:
+
+```ts
+export type BuildAppOptions = {
+  /** Prebuilt so the Socket.io server can share this exact instance. */
+  sessionMiddleware?: express.RequestHandler
+  /** Behind Render's proxy this must be set, or Secure cookies are dropped. */
+  trustProxy?: boolean
+  /** Directory holding the built SPA. Absent in P1 — there is no client yet. */
+  clientDist?: string
+}
+```
+
+```ts
+  if (opts.sessionMiddleware) {
+    app.use(opts.sessionMiddleware)
+  }
+```
+
+Delete the now-unused `buildSessionMiddleware` / `SessionOptions` import from `app.ts`.
+
+- [ ] **Step 2: Run the server tests to see exactly what breaks**
+
+Run: `npm run test -- apps/server`
+Expected: FAIL. `test/helpers.ts`, `lib/session.test.ts` and `index.ts` still pass `session: {...}`, which is no longer a valid option.
+
+- [ ] **Step 3: Update `test/helpers.ts`**
+
+```ts
+import { buildSessionMiddleware } from '../lib/session.js'
+
+export function buildTestApp(overrides: Partial<BuildAppOptions> = {}): express.Express {
+  return buildApp({
+    sessionMiddleware: buildSessionMiddleware({
+      store: new session.MemoryStore(),
+      secret: TEST_SESSION_SECRET,
+      secure: false,
+    }),
+    ...overrides,
+  })
+}
+```
+
+- [ ] **Step 4: Update `lib/session.test.ts`**
+
+Replace the `buildApp({ session: {...} })` call at line 10:
+
+```ts
+  buildApp({
+    sessionMiddleware: buildSessionMiddleware({
+      store: new session.MemoryStore(),
+      secret: SECRET,
+      secure,
+    }),
+  })
+```
+
+Add `buildSessionMiddleware` to that file's imports from `./session.js`.
+
+- [ ] **Step 5: Update `index.ts`**
+
+```ts
+import { buildSessionMiddleware } from './lib/session.js'
+
+  const sessionMiddleware = buildSessionMiddleware({
+    store: new RedisStore({ client: redis, prefix: 'sess:' }),
+    secret: env.SESSION_SECRET,
+    secure: isProd, // a Secure cookie over plain http:// is silently dropped
+  })
+
+  const app = buildApp({
+    sessionMiddleware,
+    trustProxy: isProd, // Render terminates TLS at a proxy
+    clientDist: env.CLIENT_DIST,
+  })
+```
+
+- [ ] **Step 6: Run the full gate**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+Expected: all pass. `app.test.ts`'s middleware-order assertion must still pass unchanged — this task moves *where* the middleware is built, not where it runs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/server/src/app.ts apps/server/src/index.ts apps/server/src/test/helpers.ts apps/server/src/lib/session.test.ts
+git commit -m "refactor(server): build the session middleware at the entry point
+
+Socket.io needs the same middleware instance Express uses, and buildApp
+constructed it internally. Moves construction to index.ts and takes a prebuilt
+handler. No behaviour change: the middleware still runs in the same position."
+```
+
+---
+
+### Task 2: `ChatMessageSchema` in `zod-shared`
+
+**Files:**
+- Create: `packages/zod-shared/src/schemas/chat.ts`
+- Modify: `packages/zod-shared/src/schemas/index.ts`
+- Modify: `packages/zod-shared/src/schemas/schemas.test.ts`
+
+**Interfaces:**
+- Produces: `ChatMessageSchema` (validates `{ body: string }`), `type ChatMessageInput = z.infer<typeof ChatMessageSchema>`, and `type ChatMessage = { id, body, author: { id, username }, sentAt }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/zod-shared/src/schemas/schemas.test.ts`:
+
+```ts
+describe('ChatMessageSchema', () => {
+  it('trims and accepts a normal message', () => {
+    const result = ChatMessageSchema.parse({ body: '  hello  ' })
+    expect(result.body).toBe('hello')
+  })
+
+  it('rejects a whitespace-only message', () => {
+    expect(ChatMessageSchema.safeParse({ body: '   ' }).success).toBe(false)
+  })
+
+  it('rejects a message over 1,000 characters', () => {
+    expect(ChatMessageSchema.safeParse({ body: 'a'.repeat(1001) }).success).toBe(false)
+  })
+
+  // The author is server-derived. A payload claiming one must not survive
+  // parsing, or the socket handler could be tempted to trust it.
+  it('strips an author supplied by the client', () => {
+    const result = ChatMessageSchema.parse({ body: 'hi', author: { id: 'x', username: 'admin' } })
+    expect(result).not.toHaveProperty('author')
+  })
+})
+```
+
+Add `ChatMessageSchema` to that file's import from `./index.js`.
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- packages/zod-shared`
+Expected: FAIL — `ChatMessageSchema` is not exported.
+
+- [ ] **Step 3: Write the schema**
+
+```ts
+// packages/zod-shared/src/schemas/chat.ts
+import { z } from 'zod'
+
+/**
+ * The socket payload a client may send. `body` and nothing else: the author and
+ * timestamp are stamped by the server from the session, so there is no author
+ * field here to spoof. Zod objects strip unknown keys, which is the second
+ * reason a client-supplied author cannot reach a handler.
+ */
+export const ChatMessageSchema = z.object({
+  body: z
+    .string()
+    .trim()
+    .min(1, 'Message cannot be empty')
+    .max(1000, 'Message must be at most 1,000 characters'),
+})
+
+export type ChatMessageInput = z.infer<typeof ChatMessageSchema>
+
+/** What the server broadcasts. Every field beyond `body` is server-derived. */
+export type ChatMessage = {
+  id: string
+  body: string
+  author: { id: string; username: string }
+  /** ISO 8601, server clock. */
+  sentAt: string
+}
+```
+
+- [ ] **Step 4: Export it**
+
+Add to `packages/zod-shared/src/schemas/index.ts`:
+
+```ts
+export * from './chat.js'
+```
+
+- [ ] **Step 5: Run it and confirm it passes**
+
+Run: `npm run test -- packages/zod-shared`
+Expected: PASS, 4 new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/zod-shared/src/schemas/chat.ts packages/zod-shared/src/schemas/index.ts packages/zod-shared/src/schemas/schemas.test.ts
+git commit -m "feat(shared): ChatMessageSchema — body only, author is server-derived"
+```
+
+---
+
+### Task 3: `chatService` — the Redis message buffer
+
+**Files:**
+- Create: `apps/server/src/lib/services/chat.ts`
+- Create: `apps/server/src/lib/services/chat.test.ts`
+
+**Interfaces:**
+- Consumes: `ChatMessage` from `@blog/zod-shared`.
+- Produces:
+  - `type ChatRedis = { lPush(k: string, v: string): Promise<number>; lTrim(k: string, s: number, e: number): Promise<unknown>; lRange(k: string, s: number, e: number): Promise<string[]>; expire(k: string, s: number): Promise<unknown> }`
+  - `createChatService(redis: ChatRedis): ChatService`
+  - `type ChatService = { append(message: ChatMessage): Promise<void>; list(): Promise<ChatMessage[]> }`
+  - `CHAT_KEY = 'chat:messages'`, `CHAT_BUFFER_SIZE = 50`, `CHAT_TTL_SECONDS = 86400`
+
+A factory, not a plain object like `postService`. Mongoose models are module-level singletons that a service can import; the Redis client is created at the entry point and passed down, so injecting it is what makes this unit testable without a live Redis.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/server/src/lib/services/chat.test.ts
+import type { ChatMessage } from '@blog/zod-shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CHAT_BUFFER_SIZE, CHAT_KEY, CHAT_TTL_SECONDS, createChatService } from './chat.js'
+
+/** A list-shaped fake: LPUSH prepends, LTRIM slices, LRANGE reads. */
+function fakeRedis() {
+  const store: string[] = []
+  return {
+    store,
+    lPush: vi.fn(async (_k: string, v: string) => store.unshift(v)),
+    lTrim: vi.fn(async (_k: string, s: number, e: number) => {
+      store.splice(0, store.length, ...store.slice(s, e + 1))
+    }),
+    lRange: vi.fn(async (_k: string, s: number, e: number) =>
+      e === -1 ? store.slice(s) : store.slice(s, e + 1),
+    ),
+    expire: vi.fn(async () => undefined),
+  }
+}
+
+const message = (body: string): ChatMessage => ({
+  id: `id-${body}`,
+  body,
+  author: { id: 'u1', username: 'demo' },
+  sentAt: '2026-07-29T00:00:00.000Z',
+})
+
+describe('chatService', () => {
+  let redis: ReturnType<typeof fakeRedis>
+
+  beforeEach(() => {
+    redis = fakeRedis()
+  })
+
+  it('writes to the capped key and refreshes its TTL', async () => {
+    await createChatService(redis).append(message('hello'))
+
+    expect(redis.lPush).toHaveBeenCalledWith(CHAT_KEY, expect.stringContaining('hello'))
+    expect(redis.lTrim).toHaveBeenCalledWith(CHAT_KEY, 0, CHAT_BUFFER_SIZE - 1)
+    expect(redis.expire).toHaveBeenCalledWith(CHAT_KEY, CHAT_TTL_SECONDS)
+  })
+
+  it('keeps only the newest CHAT_BUFFER_SIZE messages', async () => {
+    const service = createChatService(redis)
+    for (let i = 0; i < CHAT_BUFFER_SIZE + 10; i++) await service.append(message(`m${i}`))
+
+    expect(redis.store).toHaveLength(CHAT_BUFFER_SIZE)
+    const bodies = (await service.list()).map((m) => m.body)
+    expect(bodies).toContain(`m${CHAT_BUFFER_SIZE + 9}`)
+    expect(bodies).not.toContain('m0')
+  })
+
+  // LPUSH puts newest at the head; a chat reads oldest-first.
+  it('lists oldest first', async () => {
+    const service = createChatService(redis)
+    await service.append(message('first'))
+    await service.append(message('second'))
+
+    expect((await service.list()).map((m) => m.body)).toEqual(['first', 'second'])
+  })
+
+  it('returns an empty array when the buffer is empty', async () => {
+    expect(await createChatService(redis).list()).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/server/src/lib/services/chat.test.ts`
+Expected: FAIL — `./chat.js` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+```ts
+// apps/server/src/lib/services/chat.ts
+import type { ChatMessage } from '@blog/zod-shared'
+
+export const CHAT_KEY = 'chat:messages'
+/** Enough for arriving context, small enough to stay trivial in a 25 MB store. */
+export const CHAT_BUFFER_SIZE = 50
+export const CHAT_TTL_SECONDS = 60 * 60 * 24
+
+/** The four commands this service uses — narrow so tests need no live Redis. */
+export type ChatRedis = {
+  lPush(key: string, value: string): Promise<number>
+  lTrim(key: string, start: number, stop: number): Promise<unknown>
+  lRange(key: string, start: number, stop: number): Promise<string[]>
+  expire(key: string, seconds: number): Promise<unknown>
+}
+
+export type ChatService = {
+  append(message: ChatMessage): Promise<void>
+  list(): Promise<ChatMessage[]>
+}
+
+export function createChatService(redis: ChatRedis): ChatService {
+  return {
+    async append(message) {
+      await redis.lPush(CHAT_KEY, JSON.stringify(message))
+      // Trim on every write rather than periodically: the list can never
+      // exceed the cap even briefly, so a burst cannot spike memory.
+      await redis.lTrim(CHAT_KEY, 0, CHAT_BUFFER_SIZE - 1)
+      // Refreshed on each write, so an idle room expires but a busy one never does.
+      await redis.expire(CHAT_KEY, CHAT_TTL_SECONDS)
+      if (process.env.DEBUG) console.log('[CHAT_SERVICE] append', { id: message.id })
+    },
+
+    async list() {
+      const raw = await redis.lRange(CHAT_KEY, 0, -1)
+      // LPUSH writes newest-to-head; a conversation reads oldest-first.
+      return raw.reverse().map((entry) => JSON.parse(entry) as ChatMessage)
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `npm run test -- apps/server/src/lib/services/chat.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/lib/services/chat.ts apps/server/src/lib/services/chat.test.ts
+git commit -m "feat(api): chat message buffer on a capped Redis list"
+```
+
+---
+
+### Task 4: `GET /api/v1/chat/messages`
+
+The client loads the buffer over REST and *then* subscribes. Subscribing first and back-filling opens a window where a message arriving mid-fetch is duplicated or lost.
+
+**Files:**
+- Create: `apps/server/src/routes/v1/chat.ts`
+- Create: `apps/server/src/routes/v1/chat.test.ts`
+- Modify: `apps/server/src/routes/v1/index.ts`
+- Modify: `apps/server/src/app.ts`
+- Modify: `apps/server/src/index.ts`
+
+**Interfaces:**
+- Consumes: `ChatService` (Task 3), `requireAuth`.
+- Produces: `createChatRouter(chatService: ChatService): Router`; `BuildAppOptions.chatService?: ChatService`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/server/src/routes/v1/chat.test.ts
+import type { ChatMessage } from '@blog/zod-shared'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import type { ChatService } from '../../lib/services/chat.js'
+import { buildTestApp } from '../../test/helpers.js'
+
+const stored: ChatMessage[] = [
+  { id: '1', body: 'first', author: { id: 'u1', username: 'demo' }, sentAt: '2026-07-29T00:00:00.000Z' },
+]
+
+const stubService: ChatService = {
+  append: async () => undefined,
+  list: async () => stored,
+}
+
+describe('GET /api/v1/chat/messages', () => {
+  it('401s for an anonymous reader — chat is signed-in only', async () => {
+    const app = buildTestApp({ chatService: stubService })
+    const res = await request(app).get('/api/v1/chat/messages')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the buffer for a signed-in reader', async () => {
+    const app = buildTestApp({ chatService: stubService })
+    const agent = request.agent(app)
+    await agent.post('/api/v1/session-test/login').send({})
+
+    const res = await agent.get('/api/v1/chat/messages')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(stored)
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm run test -- apps/server/src/routes/v1/chat.test.ts`
+Expected: FAIL — `chatService` is not a valid `buildTestApp` option and the route 404s.
+
+- [ ] **Step 3: Write the router**
+
+```ts
+// apps/server/src/routes/v1/chat.ts
+import { Router } from 'express'
+import type { ChatService } from '../../lib/services/chat.js'
+import { requireAuth } from '../../middleware/require-auth.js'
+
+/**
+ * Takes the service rather than importing it: the Redis client is created at
+ * the entry point, so the service cannot be a module-level singleton the way
+ * the Mongoose-backed ones are.
+ */
+export function createChatRouter(chatService: ChatService): Router {
+  const chatRouter = Router()
+
+  // requireAuth, not optional: the wall covers the room itself, not just
+  // posting into it (design §5).
+  chatRouter.get('/messages', requireAuth, async (_req, res) => {
+    res.json(await chatService.list())
+  })
+
+  return chatRouter
+}
+```
+
+- [ ] **Step 4: Mount it on the app, not on the shared router**
+
+`routes/v1/index.ts` needs **no change**. `v1Router` is a module-level singleton, so mounting chat onto it would stack a new router on every `buildApp` call — two tests with different stub services would both hit whichever registered first. Mount it on the app instead, where it is scoped to that app instance.
+
+In `apps/server/src/app.ts`, add the import and the option:
+
+```ts
+import { createChatRouter } from './routes/v1/chat.js'
+import type { ChatService } from './lib/services/chat.js'
+```
+
+```ts
+  /** Absent in tests that do not exercise chat. */
+  chatService?: ChatService
+```
+
+Then mount it immediately before `v1Router`:
+
+```ts
+  // On the app, not on v1Router: that router is a module singleton, and
+  // mounting per-buildApp would leak one test's service into the next.
+  if (opts.chatService) app.use('/api/v1/chat', createChatRouter(opts.chatService))
+  app.use('/api/v1', v1Router)
+```
+
+- [ ] **Step 5: Run it and confirm it passes**
+
+Run: `npm run test -- apps/server/src/routes/v1/chat.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Wire the real service in `index.ts`**
+
+```ts
+import { createChatService } from './lib/services/chat.js'
+
+  const chatService = createChatService(redis)
+
+  const app = buildApp({
+    sessionMiddleware,
+    trustProxy: isProd,
+    clientDist: env.CLIENT_DIST,
+    chatService,
+  })
+```
+
+- [ ] **Step 7: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+Expected: all pass.
+
+```bash
+git add apps/server/src/routes/v1/chat.ts apps/server/src/routes/v1/chat.test.ts apps/server/src/routes/v1/index.ts apps/server/src/app.ts apps/server/src/index.ts
+git commit -m "feat(api): GET /chat/messages returns the recent buffer, auth required"
+```
+
+---
+
+### Task 5: Socket.io server, session auth, and message broadcast
+
+The core of the phase. Closes §14's *"chat messages use server-derived identity"*.
+
+**Files:**
+- Create: `apps/server/src/realtime/index.ts`
+- Create: `apps/server/src/realtime/realtime.test.ts`
+- Modify: `apps/server/package.json`
+- Modify: `apps/server/src/index.ts`
+
+**Interfaces:**
+- Consumes: `ChatService`, `ChatMessageSchema`, `ChatMessage`, the session middleware from Task 1.
+- Produces: `createRealtime(opts: { server: http.Server; sessionMiddleware: RequestHandler; chatService: ChatService }): Realtime` where `type Realtime = { io: Server; disconnectUser(userId: string): void; close(): Promise<void> }`.
+
+- [ ] **Step 1: Install the dependencies**
+
+```bash
+npm install socket.io --workspace=@blog/server
+npm install -D socket.io-client --workspace=@blog/server
+```
+
+`socket.io-client` is a devDependency here — the server workspace needs it only to drive integration tests. The client app installs its own copy in Task 7.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// apps/server/src/realtime/realtime.test.ts
+import { createServer, type Server as HttpServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { ChatMessage } from '@blog/zod-shared'
+import session from 'express-session'
+import request from 'supertest'
+import { io as ioClient, type Socket } from 'socket.io-client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildApp } from '../app.js'
+import { buildSessionMiddleware } from '../lib/session.js'
+import type { ChatService } from '../lib/services/chat.js'
+import { createRealtime, type Realtime } from './index.js'
+
+const SECRET = 'test-only-secret-never-used-in-production-32c'
+
+function stubChatService(): ChatService & { appended: ChatMessage[] } {
+  const appended: ChatMessage[] = []
+  return { appended, append: async (m) => void appended.push(m), list: async () => appended }
+}
+
+describe('realtime', () => {
+  let httpServer: HttpServer
+  let realtime: Realtime
+  let chatService: ReturnType<typeof stubChatService>
+  let url: string
+  let app: ReturnType<typeof buildApp>
+  const sockets: Socket[] = []
+
+  beforeEach(async () => {
+    chatService = stubChatService()
+    const sessionMiddleware = buildSessionMiddleware({
+      store: new session.MemoryStore(),
+      secret: SECRET,
+      secure: false,
+    })
+    app = buildApp({ sessionMiddleware, chatService })
+    httpServer = createServer(app)
+    realtime = createRealtime({ server: httpServer, sessionMiddleware, chatService })
+    await new Promise<void>((resolve) => httpServer.listen(0, resolve))
+    url = `http://localhost:${(httpServer.address() as AddressInfo).port}`
+  })
+
+  afterEach(async () => {
+    sockets.forEach((s) => s.disconnect())
+    sockets.length = 0
+    await realtime.close()
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+  })
+
+  /** Signs in over REST and returns the session cookie for the handshake. */
+  async function signedInCookie(): Promise<string> {
+    const res = await request(app).post('/api/v1/session-test/login').send({})
+    return (res.headers['set-cookie'] as unknown as string[])[0]!.split(';')[0]!
+  }
+
+  function connect(cookie?: string): Socket {
+    const socket = ioClient(url, {
+      transports: ['websocket'],
+      extraHeaders: cookie ? { Cookie: cookie } : {},
+    })
+    sockets.push(socket)
+    return socket
+  }
+
+  it('rejects an anonymous handshake', async () => {
+    const socket = connect()
+    const error = await new Promise<Error>((resolve) => socket.on('connect_error', resolve))
+    expect(error.message).toBe('unauthorized')
+  })
+
+  it('accepts a handshake carrying a valid session cookie', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+    expect(socket.connected).toBe(true)
+  })
+
+  // THE regression (spec §14, legacy app.js:56). The payload's author must be
+  // ignored entirely; the broadcast identity comes from the session.
+  it('stamps the session identity and ignores an author in the payload', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const received = new Promise<ChatMessage>((resolve) => socket.on('message', resolve))
+    socket.emit('message', { body: 'hello', author: { id: 'evil', username: 'admin' } })
+
+    const message = await received
+    // The session's identity, not the payload's. Asserted as two separate
+    // claims because `toEqual` treats an undefined property as absent, so a
+    // whole-object comparison could pass for the wrong reason.
+    expect(message.author.id).toBe('user-123')
+    expect(message.author.username).not.toBe('admin')
+    expect(message.body).toBe('hello')
+    expect(chatService.appended).toHaveLength(1)
+  })
+
+  it('rejects an empty message without broadcasting it', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const failure = new Promise<{ message: string }>((resolve) => socket.on('error', resolve))
+    socket.emit('message', { body: '   ' })
+
+    expect((await failure).message).toMatch(/empty/i)
+    expect(chatService.appended).toHaveLength(0)
+  })
+})
+```
+
+> `/api/v1/session-test/login` is the existing non-production helper route in `routes/v1/index.ts`; it sets `userId` to `'user-123'` and no username, which is why the assertion expects `username: undefined`.
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+Run: `npm run test -- apps/server/src/realtime/realtime.test.ts`
+Expected: FAIL — `./index.js` does not exist.
+
+- [ ] **Step 4: Implement `createRealtime`**
+
+```ts
+// apps/server/src/realtime/index.ts
+import { randomUUID } from 'node:crypto'
+import type { Server as HttpServer } from 'node:http'
+import { ChatMessageSchema, type ChatMessage } from '@blog/zod-shared'
+import type { RequestHandler } from 'express'
+import { Server, type Socket } from 'socket.io'
+import type { ChatService } from '../lib/services/chat.js'
+
+export type RealtimeUser = { userId: string; username: string }
+
+export type Realtime = {
+  io: Server
+  /** Ends every socket held by this user — used on logout. */
+  disconnectUser(userId: string): void
+  close(): Promise<void>
+}
+
+type CreateRealtimeOptions = {
+  server: HttpServer
+  /** The SAME instance Express uses, so the socket reads the same session. */
+  sessionMiddleware: RequestHandler
+  chatService: ChatService
+}
+
+/**
+ * Socket.io on the app's own HTTP server. No CORS option: this is same-origin
+ * by construction (design §2), and adding one would silently permit the
+ * cross-origin case the design deliberately removed.
+ */
+export function createRealtime({
+  server,
+  sessionMiddleware,
+  chatService,
+}: CreateRealtimeOptions): Realtime {
+  const io = new Server(server)
+
+  // Runs the session middleware on the handshake request, so socket.request
+  // carries the same session object a REST handler would see.
+  io.engine.use(sessionMiddleware)
+
+  io.use((socket, next) => {
+    const session = socket.request.session
+    if (!session?.userId) {
+      next(new Error('unauthorized'))
+      return
+    }
+    socket.data.user = { userId: session.userId, username: session.username }
+    // One room per user, solely so logout can end their sockets without a
+    // hand-maintained registry.
+    socket.join(`user:${session.userId}`)
+    next()
+  })
+
+  io.on('connection', (socket: Socket) => {
+    const user = socket.data.user as RealtimeUser
+    if (process.env.DEBUG) console.log('[REALTIME] connected', { userId: user.userId })
+
+    socket.on('message', async (payload: unknown) => {
+      const parsed = ChatMessageSchema.safeParse(payload)
+      if (!parsed.success) {
+        // Back to the sender only — a malformed message is not the room's business.
+        socket.emit('error', { message: parsed.error.errors[0]?.message ?? 'Invalid message' })
+        return
+      }
+
+      const message: ChatMessage = {
+        id: randomUUID(),
+        body: parsed.data.body,
+        // From the socket's session, NEVER from the payload. Zod already
+        // stripped any author the client sent; this is the second reason it
+        // cannot be spoofed.
+        author: { id: user.userId, username: user.username },
+        sentAt: new Date().toISOString(),
+      }
+
+      await chatService.append(message)
+      io.emit('message', message)
+    })
+
+    socket.on('disconnect', () => {
+      if (process.env.DEBUG) console.log('[REALTIME] disconnected', { userId: user.userId })
+    })
+  })
+
+  return {
+    io,
+    disconnectUser(userId) {
+      io.in(`user:${userId}`).disconnectSockets()
+    },
+    close: () => io.close(),
+  }
+}
+```
+
+- [ ] **Step 5: Declare the session fields on Socket.io's request type**
+
+`socket.request` is a Node `IncomingMessage`; `express-session` augments Express's `Request`. Add to `apps/server/src/types/express-session.d.ts` (create if absent — check for an existing `SessionData` augmentation first and extend that file instead of duplicating it):
+
+```ts
+import 'socket.io'
+
+declare module 'http' {
+  interface IncomingMessage {
+    session?: { userId?: string; username?: string }
+  }
+}
+
+declare module 'socket.io' {
+  interface Socket {
+    data: { user: { userId: string; username: string } }
+  }
+}
+```
+
+- [ ] **Step 6: Run it and confirm it passes**
+
+Run: `npm run test -- apps/server/src/realtime/realtime.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 7: Wire it into the entry point**
+
+Replace `app.listen(...)` in `index.ts`:
+
+```ts
+import { createServer } from 'node:http'
+import { createRealtime } from './realtime/index.js'
+
+  const server = createServer(app)
+  createRealtime({ server, sessionMiddleware, chatService })
+
+  server.listen(env.PORT, () => {
+    console.log(`API listening on :${env.PORT} (${env.NODE_ENV})`)
+  })
+```
+
+- [ ] **Step 8: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+Expected: all pass.
+
+```bash
+git add apps/server/src/realtime apps/server/src/index.ts apps/server/src/types apps/server/package.json package-lock.json
+git commit -m "feat(api): Socket.io on the app server, authenticated by the session
+
+Identity comes from socket.data.user, set once at the handshake from the
+session. The payload schema has no author field and Zod strips unknown keys, so
+a client cannot speak as another user — the legacy app.js:56 defect."
+```
+
+---
+
+### Task 6: Presence, typing, and disconnect-on-logout
+
+**Files:**
+- Modify: `apps/server/src/realtime/index.ts`
+- Modify: `apps/server/src/realtime/realtime.test.ts`
+- Modify: `apps/server/src/app.ts`
+- Modify: `apps/server/src/routes/v1/auth.ts`
+- Modify: `apps/server/src/index.ts`
+
+**Interfaces:**
+- Produces: server→client events `presence` (`{ users: { id, username }[] }`) and `typing` (`{ userId, username, typing }`); client→server `typing` (`{ typing: boolean }`); `BuildAppOptions.disconnectUser?: (userId: string) => void`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `realtime.test.ts`:
+
+```ts
+  it('lists a user once even when they hold two sockets', async () => {
+    const cookie = await signedInCookie()
+    const first = connect(cookie)
+    await new Promise<void>((resolve) => first.on('connect', resolve))
+
+    const second = connect(cookie)
+    const presence = await new Promise<{ users: { id: string }[] }>((resolve) =>
+      second.on('presence', resolve),
+    )
+
+    expect(presence.users.filter((u) => u.id === 'user-123')).toHaveLength(1)
+  })
+
+  it('relays a typing signal without persisting it', async () => {
+    const watcher = connect(await signedInCookie())
+    await new Promise<void>((resolve) => watcher.on('connect', resolve))
+    const typer = connect(await signedInCookie())
+    await new Promise<void>((resolve) => typer.on('connect', resolve))
+
+    const signal = new Promise<{ typing: boolean }>((resolve) => watcher.on('typing', resolve))
+    typer.emit('typing', { typing: true })
+
+    expect((await signal).typing).toBe(true)
+    expect(chatService.appended).toHaveLength(0)
+  })
+
+  it('disconnects a user\'s sockets when asked', async () => {
+    const socket = connect(await signedInCookie())
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const closed = new Promise<void>((resolve) => socket.on('disconnect', () => resolve()))
+    realtime.disconnectUser('user-123')
+
+    await closed
+    expect(socket.connected).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+Run: `npm run test -- apps/server/src/realtime/realtime.test.ts`
+Expected: FAIL — no `presence` or `typing` event is ever emitted; the disconnect test times out.
+
+- [ ] **Step 3: Add presence and typing to `createRealtime`**
+
+Add above `io.on('connection', ...)`:
+
+```ts
+  /**
+   * Derived from the live socket set, never stored. One process with no Redis
+   * adapter means io.sockets already is the authoritative answer, and
+   * Socket.io's ping/pong timeout already fires `disconnect` for a dead client —
+   * so a Redis set plus application heartbeats would reimplement, worse, two
+   * things that already work (design §4).
+   *
+   * Deduplicated by userId: two tabs are one person online.
+   */
+  function broadcastPresence(): void {
+    const byId = new Map<string, { id: string; username: string }>()
+    for (const socket of io.sockets.sockets.values()) {
+      const user = socket.data.user as RealtimeUser | undefined
+      if (user) byId.set(user.userId, { id: user.userId, username: user.username })
+    }
+    io.emit('presence', { users: [...byId.values()] })
+  }
+```
+
+Inside the `connection` handler, call `broadcastPresence()` immediately, add the typing relay, and call it again on disconnect:
+
+```ts
+    broadcastPresence()
+
+    socket.on('typing', (payload: unknown) => {
+      const typing = Boolean((payload as { typing?: unknown } | null)?.typing)
+      // Broadcast and forget. Writing the highest-frequency, lowest-value event
+      // in the app into a 25 MB store would be a poor trade (design §5).
+      socket.broadcast.emit('typing', {
+        userId: user.userId,
+        username: user.username,
+        typing,
+      })
+    })
+```
+
+```ts
+    socket.on('disconnect', () => {
+      if (process.env.DEBUG) console.log('[REALTIME] disconnected', { userId: user.userId })
+      broadcastPresence()
+    })
+```
+
+- [ ] **Step 4: Run them and confirm they pass**
+
+Run: `npm run test -- apps/server/src/realtime/realtime.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Disconnect sockets on logout**
+
+Reading the session live revokes *new* connections; an open socket keeps its identity in memory. Add the option to `app.ts`:
+
+```ts
+  /** Ends a user's sockets on logout. Absent in tests without realtime. */
+  disconnectUser?: (userId: string) => void
+```
+
+The logout handler reads it off the app rather than importing it, so no module-level state is involved and each app instance carries its own. In `routes/v1/auth.ts`:
+
+```ts
+authRouter.post('/logout', requireAuth, async (req, res) => {
+  const userId = req.session.userId
+  await destroySession(req)
+  res.clearCookie('sid')
+  // The session is gone, but a socket opened before now still holds its
+  // identity in memory. Without this, logout leaves a live authenticated
+  // socket behind.
+  const disconnectUser = req.app.get('disconnectUser') as ((id: string) => void) | undefined
+  if (userId && disconnectUser) disconnectUser(userId)
+  res.status(204).end()
+})
+```
+
+In `app.ts`, register it: `if (opts.disconnectUser) app.set('disconnectUser', opts.disconnectUser)`.
+
+- [ ] **Step 6: Wire the late binding in `index.ts`**
+
+`createRealtime` needs the HTTP server, which needs the app — so the app needs a reference that resolves later:
+
+```ts
+  let realtime: Realtime | undefined
+  const app = buildApp({
+    sessionMiddleware,
+    trustProxy: isProd,
+    clientDist: env.CLIENT_DIST,
+    chatService,
+    disconnectUser: (userId) => realtime?.disconnectUser(userId),
+  })
+  const server = createServer(app)
+  realtime = createRealtime({ server, sessionMiddleware, chatService })
+```
+
+The closure defers resolution past the assignment. The `?.` can never actually be hit, because no request is served before `listen()`.
+
+- [ ] **Step 7: Add the logout integration test**
+
+Append to `realtime.test.ts`:
+
+```ts
+  it('ends the socket when the user logs out over REST', async () => {
+    const cookie = await signedInCookie()
+    const socket = connect(cookie)
+    await new Promise<void>((resolve) => socket.on('connect', resolve))
+
+    const closed = new Promise<void>((resolve) => socket.on('disconnect', () => resolve()))
+    await request(app).post('/api/v1/auth/logout').set('Cookie', cookie)
+
+    await closed
+    expect(socket.connected).toBe(false)
+  })
+```
+
+This requires the test's `buildApp` call to pass `disconnectUser: (id) => realtime.disconnectUser(id)` — add it, using a `let realtime` declared before `beforeEach` as in Step 6.
+
+- [ ] **Step 8: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+Expected: all pass.
+
+```bash
+git add apps/server/src/realtime apps/server/src/app.ts apps/server/src/routes/v1/auth.ts apps/server/src/index.ts
+git commit -m "feat(api): in-memory presence, typing relay, and logout disconnects sockets"
+```
+
+---
+
+### Task 7: The `useChat` hook
+
+Both remaining §14 chat items are React lifecycle defects, which is why the socket is a designed unit rather than inline effect code.
+
+**Files:**
+- Create: `apps/client/src/hooks/use-chat.ts`
+- Create: `apps/client/src/hooks/use-chat.test.tsx`
+- Modify: `apps/client/package.json`
+
+**Interfaces:**
+- Produces: `useChat(): { messages: ChatMessage[]; online: ChatUser[]; typingUsers: string[]; status: ChatStatus; send(body: string): void; setTyping(typing: boolean): void }` where `type ChatStatus = 'connecting' | 'connected' | 'reconnecting' | 'failed'`.
+
+- [ ] **Step 1: Install the client dependency**
+
+```bash
+npm install socket.io-client --workspace=@blog/client
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+// apps/client/src/hooks/use-chat.test.tsx
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (payload: unknown) => void>()
+const socket = {
+  connected: false,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  emit: vi.fn(),
+  on: vi.fn((event: string, fn: (payload: unknown) => void) => {
+    handlers.set(event, fn)
+    return socket
+  }),
+  off: vi.fn((event: string) => {
+    handlers.delete(event)
+    return socket
+  }),
+}
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => socket) }))
+
+const { useChat } = await import('./use-chat.js')
+
+describe('useChat', () => {
+  afterEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+    cleanup()
+  })
+
+  it('appends a broadcast message', async () => {
+    const { result } = renderHook(() => useChat())
+    act(() => {
+      handlers.get('message')?.({
+        id: '1',
+        body: 'hello',
+        author: { id: 'u1', username: 'demo' },
+        sentAt: '2026-07-29T00:00:00.000Z',
+      })
+    })
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+    expect(result.current.messages[0]?.body).toBe('hello')
+  })
+
+  // Legacy chat.jsx:51 registered a listener per message received, so every
+  // message was handled N times and the count grew with the conversation.
+  it('removes every listener it registered on unmount', () => {
+    const { unmount } = renderHook(() => useChat())
+    const registered = socket.on.mock.calls.map(([event]) => event)
+
+    unmount()
+
+    const removed = socket.off.mock.calls.map(([event]) => event)
+    for (const event of registered) expect(removed).toContain(event)
+    expect(handlers.size).toBe(0)
+  })
+
+  // Legacy chat.jsx:57 emitted disconnect on every render.
+  it('does not reconnect or disconnect on re-render', () => {
+    const { rerender } = renderHook(() => useChat())
+    const connectsAfterMount = socket.connect.mock.calls.length
+
+    rerender()
+    rerender()
+
+    expect(socket.connect).toHaveBeenCalledTimes(connectsAfterMount)
+    expect(socket.disconnect).not.toHaveBeenCalled()
+  })
+
+  it('sends the body only — the server stamps the author', () => {
+    const { result } = renderHook(() => useChat())
+    act(() => result.current.send('  hi  '))
+    expect(socket.emit).toHaveBeenCalledWith('message', { body: 'hi' })
+  })
+})
+```
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+Run: `npm run test -- apps/client/src/hooks/use-chat.test.tsx`
+Expected: FAIL — `./use-chat.js` does not exist.
+
+- [ ] **Step 4: Implement the hook**
+
+```ts
+// apps/client/src/hooks/use-chat.ts
+import type { ChatMessage } from '@blog/zod-shared'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { io, type Socket } from 'socket.io-client'
+import { DEBUG } from '../lib/constants.js'
+
+export type ChatUser = { id: string; username: string }
+export type ChatStatus = 'connecting' | 'connected' | 'reconnecting' | 'failed'
+
+export function useChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [online, setOnline] = useState<ChatUser[]>([])
+  const [typingUsers, setTypingUsers] = useState<string[]>([])
+  const [status, setStatus] = useState<ChatStatus>('connecting')
+
+  // Held in a ref, created once. Creating it during render would open a
+  // connection per render — the shape of the legacy chat.jsx:57 defect.
+  const socketRef = useRef<Socket | null>(null)
+  if (socketRef.current === null) {
+    socketRef.current = io({ autoConnect: false, transports: ['websocket'] })
+  }
+
+  useEffect(() => {
+    const socket = socketRef.current
+    if (!socket) return
+
+    const onConnect = () => setStatus('connected')
+    const onDisconnect = () => setStatus('reconnecting')
+    const onConnectError = () => setStatus('failed')
+    const onMessage = (message: ChatMessage) => setMessages((prev) => [...prev, message])
+    const onPresence = ({ users }: { users: ChatUser[] }) => setOnline(users)
+    const onTyping = ({ username, typing }: { username: string; typing: boolean }) =>
+      setTypingUsers((prev) =>
+        typing ? [...new Set([...prev, username])] : prev.filter((u) => u !== username),
+      )
+    const onError = ({ message }: { message: string }) => {
+      if (DEBUG) console.warn('[CHAT] rejected', message)
+    }
+
+    socket.on('connect', onConnect)
+    socket.on('disconnect', onDisconnect)
+    socket.on('connect_error', onConnectError)
+    socket.on('message', onMessage)
+    socket.on('presence', onPresence)
+    socket.on('typing', onTyping)
+    socket.on('error', onError)
+    socket.connect()
+
+    // Every `on` above has an `off` here. The legacy chat.jsx:51 grew its
+    // listener count with the conversation because it had no cleanup.
+    return () => {
+      socket.off('connect', onConnect)
+      socket.off('disconnect', onDisconnect)
+      socket.off('connect_error', onConnectError)
+      socket.off('message', onMessage)
+      socket.off('presence', onPresence)
+      socket.off('typing', onTyping)
+      socket.off('error', onError)
+      socket.disconnect()
+    }
+  }, [])
+
+  const send = useCallback((body: string) => {
+    const trimmed = body.trim()
+    if (!trimmed) return
+    // Body only. The author is stamped server-side from the session.
+    socketRef.current?.emit('message', { body: trimmed })
+  }, [])
+
+  const setTyping = useCallback((typing: boolean) => {
+    socketRef.current?.emit('typing', { typing })
+  }, [])
+
+  return { messages, online, typingUsers, status, send, setTyping }
+}
+```
+
+- [ ] **Step 5: Run it and confirm it passes**
+
+Run: `npm run test -- apps/client/src/hooks/use-chat.test.tsx`
+Expected: PASS, 4 tests. The unmount test also calls `socket.disconnect()` once, which is correct — the "does not disconnect on re-render" test asserts it is not called *while mounted*.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/client/src/hooks/use-chat.ts apps/client/src/hooks/use-chat.test.tsx apps/client/package.json package-lock.json
+git commit -m "feat(client): useChat — socket created once, every listener cleaned up"
+```
+
+---
+
+### Task 8: `ChatPage`, route, and navigation
+
+**Files:**
+- Create: `apps/client/src/pages/ChatPage.tsx`
+- Modify: `apps/client/src/routes.tsx`
+- Modify: `apps/client/src/components/layouts/PageShell.tsx`
+
+**Interfaces:**
+- Consumes: `useChat` (Task 7), `RequireAuth`, `Button`, `Input`.
+
+- [ ] **Step 1: Write `ChatPage`**
+
+```tsx
+// apps/client/src/pages/ChatPage.tsx
+import { useState } from 'react'
+import { Button } from '../components/ui/button.js'
+import { Input } from '../components/ui/input.js'
+import { useChat } from '../hooks/use-chat.js'
+
+const STATUS_LABEL = {
+  connecting: 'Connecting…',
+  connected: '',
+  reconnecting: 'Reconnecting…',
+  failed: 'Could not connect. Reload to try again.',
+} as const
+
+export function ChatPage() {
+  const { messages, online, typingUsers, status, send, setTyping } = useChat()
+  const [draft, setDraft] = useState('')
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    send(draft)
+    setDraft('')
+    setTyping(false)
+  }
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-bold">Chat</h1>
+        <p className="text-xs text-[var(--muted-foreground)]">{online.length} online</p>
+      </header>
+
+      {/* The service sleeps when idle and cold-starts in ~60s, so a silent
+          page is indistinguishable from a broken one. Say what is happening. */}
+      {STATUS_LABEL[status] && (
+        <p className="text-xs text-[var(--muted-foreground)]">{STATUS_LABEL[status]}</p>
+      )}
+
+      <ul className="flex flex-col gap-2">
+        {messages.map((m) => (
+          <li key={m.id} className="text-sm">
+            {/* Plain text, not Markdown: a fast room does not need tables, and
+                it removes the question of what a link in chat should do. */}
+            <span className="font-semibold">{m.author.username}</span> {m.body}
+          </li>
+        ))}
+      </ul>
+
+      <p className="h-4 text-xs text-[var(--muted-foreground)]">
+        {typingUsers.length > 0 && `${typingUsers.join(', ')} typing…`}
+      </p>
+
+      <form onSubmit={submit} className="flex gap-2">
+        <Input
+          aria-label="Message"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value)
+            setTyping(e.target.value.length > 0)
+          }}
+          disabled={status === 'failed'}
+        />
+        <Button type="submit" disabled={draft.trim().length === 0 || status !== 'connected'}>
+          Send
+        </Button>
+      </form>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Add the route**
+
+In `apps/client/src/routes.tsx`, import `ChatPage` and `RequireAuth`, then add to `children`:
+
+```tsx
+      {
+        path: '/chat',
+        element: (
+          <RequireAuth>
+            <ChatPage />
+          </RequireAuth>
+        ),
+      },
+```
+
+`RequireAuth` is a UX redirect only — the socket handshake in Task 5 is what enforces it.
+
+- [ ] **Step 3: Add the nav link**
+
+In `PageShell.tsx`, add a `Chat` link beside the existing `New Post` link, rendered only when `useMe()` resolves a user. Match the surrounding link markup exactly rather than inventing new classes.
+
+- [ ] **Step 4: Gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm run test`
+Expected: all pass.
+
+```bash
+git add apps/client/src/pages/ChatPage.tsx apps/client/src/routes.tsx apps/client/src/components/layouts/PageShell.tsx
+git commit -m "feat(client): chat page, guarded route, and nav link"
+```
+
+---
+
+### Task 9: WebSocket proxying in dev
+
+**Files:**
+- Modify: `apps/client/vite.config.ts`
+
+- [ ] **Step 1: Add the socket.io proxy entry**
+
+The client connects to its own origin (`io()` with no URL), so in dev that is Vite on `:5173`. Vite must forward the Socket.io path to the API container, and `ws: true` is required or the upgrade fails:
+
+```ts
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
+        changeOrigin: false,
+      },
+      // Socket.io's own endpoint, not under /api. `ws: true` proxies the
+      // upgrade; without it the handshake polls forever and never upgrades.
+      '/socket.io': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3000',
+        changeOrigin: false,
+        ws: true,
+      },
+    },
+```
+
+- [ ] **Step 2: Verify against the running stack**
+
+Run: `npm run dev`
+Then open `http://localhost:5173/chat` signed in, and confirm in DevTools → Network → WS that a `101 Switching Protocols` upgrade succeeds and a sent message appears in a second browser window.
+
+If nothing appears, the container is serving stale code before the code is wrong — use the `docker-compose-rebuild` skill first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/client/vite.config.ts
+git commit -m "build(client): proxy the socket.io upgrade to the API in dev"
+```
+
+---
+
+### Task 10: E2E — two browser contexts
+
+**Files:**
+- Create: `e2e/chat.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { expect, test } from '@playwright/test'
+
+/**
+ * Two independent browser contexts, so each has its own cookie jar and its own
+ * session — the only way to prove a message actually crosses the server rather
+ * than being echoed locally.
+ */
+test('two signed-in users exchange a message', async ({ browser }) => {
+  const stamp = Date.now()
+
+  async function signUp(name: string) {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await page.goto('/signup')
+    await page.getByLabel('Username').fill(name)
+    await page.getByLabel('Email').fill(`${name}@example.com`)
+    // exact: true — "Confirm password" also contains "Password".
+    await page.getByLabel('Password', { exact: true }).fill('a-valid-password')
+    await page.getByLabel('Confirm password').fill('a-valid-password')
+    await page.getByRole('button', { name: 'Sign Up' }).click()
+    await expect(page).toHaveURL('/')
+    return page
+  }
+
+  const alice = await signUp(`e2e-a-${stamp}`)
+  const bob = await signUp(`e2e-b-${stamp}`)
+
+  await alice.goto('/chat')
+  await bob.goto('/chat')
+  // The Send button enables only once the socket reports connected.
+  await expect(alice.getByRole('button', { name: 'Send' })).toBeEnabled()
+  await expect(bob.getByRole('button', { name: 'Send' })).toBeEnabled()
+
+  await alice.getByLabel('Message').fill('hello from alice')
+  await alice.getByRole('button', { name: 'Send' }).click()
+
+  await expect(bob.getByText('hello from alice')).toBeVisible()
+  // Stamped with the sender's session identity, not anything the client sent.
+  await expect(bob.getByText(`e2e-a-${stamp}`)).toBeVisible()
+})
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm run test:e2e -- e2e/chat.spec.ts`
+Expected: PASS. This builds the production image, so it exercises the same single-service topology that ships.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/chat.spec.ts
+git commit -m "test(e2e): a message crosses the server between two browser contexts"
+```
+
+---
+
+### Task 11: Final gate and documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/architecture/deployment-architecture.md`
+- Modify: `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` (§14 checklist)
+
+- [ ] **Step 1: Tick the three §14 chat items**
+
+In the main spec's §14, mark each with what closed it:
+
+- Chat messages use server-derived identity → `realtime.test.ts`, "stamps the session identity and ignores an author in the payload"
+- Socket listeners are cleaned up → `use-chat.test.tsx`, "removes every listener it registered on unmount"
+- Chat does not emit `disconnect` on every render → `use-chat.test.tsx`, "does not reconnect or disconnect on re-render"
+
+- [ ] **Step 2: Move chat out of the README's "Not yet built"**
+
+Add to **Core features**: `**Realtime chat** — one room, signed-in only, with presence and typing indicators; messages live in Redis, not MongoDB.`
+
+Remove chat from the "Not yet built" note, leaving OAuth and media uploads. Add the socket to the architecture Mermaid diagram as part of the existing `apps/server` node — not a new service.
+
+- [ ] **Step 3: Update `deployment-architecture.md`**
+
+Flip the realtime row from planned to built, and record that it runs in the API service rather than its own.
+
+- [ ] **Step 4: Full gate**
+
+Run: `npm ci && npm run typecheck && npm run lint && npm run build && npm run test && npm run test:e2e`
+Expected: all pass, no skips.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/
+git commit -m "docs: chat is built — tick the §14 chat items and update the README"
+```
+
+- [ ] **Step 6: STOP — open a PR, do not merge**
+
+Report: P4 complete, all three §14 chat regressions closed and covered. Open a PR to `staging`. **Do not merge to `master` and do not deploy** — that requires explicit per-time approval.
+
+Raise at that point: **risk §12.1 of the design is still open.** Nothing keeps the service warm, so the first chat visitor after 15 idle minutes waits ~60 s. The connecting state from Task 8 is currently the entire mitigation. Decide before promotion whether to add an external pinger.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage.** §2 architecture → Tasks 1, 5, 9; §3 auth and logout revocation → Tasks 5, 6; §4 Redis buffer and in-memory presence → Tasks 3, 6; §5 REST and socket API → Tasks 2, 4, 5, 6; §6 client lifecycle → Tasks 7, 8; §7 errors → Task 5 Step 4 (sender-only `error` event); §8 testing → every task plus Task 10; §9 configuration → Task 9 (no new env vars, so nothing else to do); §10 doc amendments → already landed in commit `10f7e04c`, with the README's remaining move handled in Task 11; §11 sequencing → Task 11 Step 6; §12 risks → surfaced at Task 11 Step 6.
+
+**Type consistency.** `ChatMessage` is defined once in Task 2 and consumed unchanged in Tasks 3, 5, 7, 8. `ChatService` is defined in Task 3 and consumed in Tasks 4, 5. `RealtimeUser` in Task 5 is reused by Task 6's `broadcastPresence`. The presence payload is `{ users: { id, username }[] }` in Tasks 6, 7 and 8 alike — note it is `id`, not `userId`, on the wire, while `socket.data.user` uses `userId` internally.
+
+**Known deviation from the codebase's patterns, deliberate.** `chatService` is a factory while `postService` and friends are plain objects. Mongoose models are module-level singletons a service can import; the Redis client is built at the entry point, so injection is what makes Task 3 testable without a live Redis. Task 3 states this inline so it does not read as inconsistency.
+
+**Three defects found by this review and fixed inline**, recorded because each would have surfaced as a confusing failure mid-implementation rather than an obvious one:
+
+1. **Task 4 mounted the chat router onto the module-level `v1Router`.** Every `buildApp` call would have stacked another router onto the same shared instance, so the first stub service registered would answer for every later test — a cross-test leak that looks like a caching bug. Now mounted on the app.
+2. **Task 6 offered two ways to wire `disconnectUser`** (module state vs reading it off the app) and left the choice to the implementer. A plan states one. The module-state variant also reintroduced defect 1's problem.
+3. **Task 5's identity assertion used `toEqual` against `username: undefined`.** Vitest treats an undefined property as absent, so the assertion would also have passed if the author were dropped entirely — it would not have caught a real regression. Split into two explicit claims.
+
+**Not in this plan, by design.** No message cap and no rate limit — the `LTRIM` buffer is self-limiting for storage, and the design accepts that a flooder can drown the visible conversation (risk §12.2). No Socket.io Redis adapter, no `apps/realtime`, no handshake ticket.

--- a/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
+++ b/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
@@ -60,7 +60,7 @@ preserving the project's identity: a MERN blog with real-time chat.
 | Theme | **Light only. White primary, blue secondary.** | Editorial aesthetic; blue is the accent (actions, links, focus), body text stays near-black. **No dark-mode toggle.** |
 | Images | **Cloudinary** | Free forever tier. Replaces the S3 + CloudFront plan. |
 | Likes | **Toggle (like / unlike)** | Not up/down voting. Count never goes below zero. |
-| Repo | **Monorepo** (npm workspaces) | Services share models, Zod schemas, and ticket verification. |
+| Repo | **Monorepo** (npm workspaces) | Server and client share Zod schemas and inferred types via `packages/zod-shared`. |
 | Testing | **Vitest (unit) + Supertest (API integration) + Playwright (E2E)** | Regression tests for the authorization bugs; E2E on critical paths. |
 
 ### Standing constraints

--- a/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
+++ b/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
@@ -733,15 +733,18 @@ items, a Supertest integration test against the real route.
 - [x] User cannot delete another user's account (`server/routers/user.js:60`) — `users.test.ts`
 - [x] Logout requires authentication **and is POST-only** (`server/routers/user.js:45` — unauthenticated GET) — `auth.test.ts`
 - [x] Like requires authentication and uses session identity, not a body field — `likes.test.ts`
-- [ ] Chat messages use server-derived identity — a client cannot speak as another user
-      (old `app.js:56` echoed `message.user` straight from the client payload) — **P4** (realtime, not built yet)
+- [x] Chat messages use server-derived identity — a client cannot speak as another user
+      (old `app.js:56` echoed `message.user` straight from the client payload) — `realtime.test.ts`'s "stamps
+      the session identity and ignores an author in the payload"
 - [x] Session token is not readable by JavaScript (httpOnly cookie, not `localStorage`) — `session.test.ts`
 - [x] Login does not reveal whether a username exists — `auth.test.ts`
 - [x] A post's full body is absent from the API response for an anonymous reader (§6) — `posts.test.ts`
 
 **Correctness**
-- [ ] Socket listeners are cleaned up (old `chat.jsx:51` added a listener per message received) — **P4**
-- [ ] Chat does not emit `disconnect` on every render (`chat.jsx:57`) — **P4**
+- [x] Socket listeners are cleaned up (old `chat.jsx:51` added a listener per message received) —
+      `use-chat.test.tsx`'s "removes every listener it registered on unmount"
+- [x] Chat does not emit `disconnect` on every render (`chat.jsx:57`) — `use-chat.test.tsx`'s "does not
+      reconnect or disconnect on re-render"
 - [x] A failed delete does not remove the post from the UI (`store/actions/posts.js:44`) — **P2**, `use-posts.ts`'s `useDeletePost` (invalidate-not-optimistic, so a failed mutation never touched the cache); structural guarantee, not yet exercised by a written test
 - [ ] Password confirmation is validated *before* the request, not after (`updateUser.jsx:58`) — **P2, known gap**: no signup confirm-password field was built in this round; not silently dropped, tracked here for a future pass
 - [x] Password is not silently reset on every profile update (`user.js:79` compares plaintext to a hash) — `users.test.ts`

--- a/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
+++ b/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
@@ -51,8 +51,8 @@ preserving the project's identity: a MERN blog with real-time chat.
 | Type safety | **Zod** | Compensates for Mongoose's weak typing. Validates at runtime, infers TS types. One source of truth, shared client↔server. |
 | Auth | **`express-session` + `connect-redis`** | httpOnly cookie holding a session ID; data in Redis. Hand-rolled enough to explain in an interview, standard enough to be correct. |
 | OAuth providers | **Google, Facebook** via Passport (P6) | No GitHub (explicitly not wanted). |
-| Ephemeral store | **Redis** (Render Key Value in prod, container locally) | Session store, chat buffer, rate limiting, presence. See §7. |
-| Realtime | **Standalone Socket.io service** (`apps/realtime`) | Its own long-running Render container. |
+| Ephemeral store | **Redis** (Render Key Value in prod, container locally) | Session store and chat buffer. See §7. *(Rate limiting dropped 2026-07-29; presence is in-memory, not Redis.)* |
+| Realtime | **Socket.io inside `apps/server`** | *Revised 2026-07-29 — was a standalone `apps/realtime` service.* Same process, same origin, so the socket reads the session directly. See §5. |
 | Hosting (prod) | **Render** | Long-lived containers. |
 | Prod topology | **`apps/server` serves the built SPA + the API from one origin** | No CORS, no cross-origin cookie problem, one web service. See §11. |
 | Local / staging / E2E | **Docker Compose + `compose watch`** | Fully containerized, hot reload preserved. Replaces a cloud staging environment. See §11. |
@@ -114,10 +114,10 @@ than ported.
 ```
 blog-chat-app/
 ├── apps/
-│   ├── server/                # Express REST API + serves the built SPA → Render web service
+│   ├── server/                # Express REST API + Socket.io + serves the built SPA → Render web service
 │   │                          # (models, connection caches, errors live here — server-only)
-│   ├── client/                # React (Vite) SPA → static bundle, served by apps/server
-│   └── realtime/              # Socket.io server → separate Render web service
+│   └── client/                # React (Vite) SPA → static bundle, served by apps/server
+│                              # (revised 2026-07-29: no apps/realtime — see §5)
 ├── packages/
 │   └── zod-shared/           # Zod schemas only — the one thing server AND client both need
 ├── infra/
@@ -217,7 +217,7 @@ too, so CORS is never needed anywhere; that is a *consequence* of the topology c
 | `src/store/` (Redux, thunks, reducers) | **Deleted** — TanStack Query owns server state |
 | `src/app.jsx` (`<Route>` config) | `apps/client/src/routes.tsx` |
 | `src/functions/checkLogin.js` | **Deleted** (dead code; never worked) |
-| `server/app.js` Socket.io block | `apps/realtime/` |
+| `server/app.js` Socket.io block | `apps/server/src/realtime/` — same process as the API *(revised 2026-07-29)* |
 | `src/css/*.css` | Tailwind |
 | `Dockerfile` (broken) | Per-app multi-stage Dockerfiles + Compose (§11) |
 
@@ -302,23 +302,55 @@ username existence via `Unable to find user: <name>`. `verifyCredentials` return
 
 **Rate limiting** on login/signup, backed by Redis (§7), from P6.
 
-### Socket authentication across origins
+### Socket authentication
 
-`apps/realtime` is a separate Render service, so it has a different origin (`*.onrender.com`). **Render
-subdomains are on the Public Suffix List, so a cookie cannot be set on the shared parent domain** — the API's
-session cookie will never reach the realtime service. Cookie-based socket auth is therefore not an option.
+> **Revised 2026-07-29.** Socket.io now runs **inside `apps/server`**, not as a separate service. Full
+> rationale in `2026-07-29-realtime-chat-design.md` §2. The superseded cross-origin design is kept below
+> rather than deleted, because it is the record of *why* a ticket was ever needed — and reinstating it is
+> the cost of ever splitting realtime back out.
 
-**Solution — short-lived signed handshake ticket:**
+Same process, same origin, so the socket reads the same session as every REST request. Socket.io shares
+the Express session middleware directly:
+
+```ts
+io.engine.use(sessionMiddleware)         // the same instance passed to buildApp
+io.use((socket, next) => {
+  const { userId, username } = socket.request.session ?? {}
+  if (!userId) return next(new Error('unauthorized'))
+  socket.data.user = { userId, username }
+  next()
+})
+```
+
+Every broadcast is stamped from `socket.data.user`. The client's payload carries a body and nothing else —
+there is no author field to spoof. The old app echoed `message.user` straight from the client payload
+(`app.js:56`), so anyone could speak as anyone; this is the fix.
+
+Reading the session live revokes **new** connections at logout, but an open socket keeps its identity in
+memory, so `POST /auth/logout` also disconnects that user's sockets.
+
+<details>
+<summary><strong>Superseded — the cross-origin handshake ticket (why it existed)</strong></summary>
+
+When `apps/realtime` was a separate Render service it had a different origin (`*.onrender.com`). **Render
+subdomains are on the Public Suffix List, so a cookie cannot be set on the shared parent domain** — the
+API's session cookie would never reach it, making cookie-based socket auth impossible rather than merely
+awkward.
+
+The solution was a short-lived signed handshake ticket:
 
 1. The client calls `POST /api/v1/auth/socket-ticket`; the API verifies the session and mints a
    **~60-second JWT** containing `{ userId, username }`, signed with a secret shared by both services.
-2. The client passes the ticket in the Socket.io handshake (`io(url, { auth: { ticket } })`).
-3. The realtime service verifies the signature and expiry using a shared verifier (P4 — where this lands
-   is still open: `packages/zod-shared` is Zod-only by design as of the P2 restructure, so a JWT verifier may
-   warrant its own package rather than being force-fit in there), then attaches the identity to the socket.
+2. The client passes the ticket in the handshake (`io(url, { auth: { ticket } })`).
+3. The realtime service verifies signature and expiry, then attaches the identity to the socket.
 
-The realtime service **never trusts a username sent from the client**. The old app echoed `message.user`
-straight from the client payload, so anyone could speak as anyone.
+This also left an unresolved question — where a shared sign/verify pair would live, given
+`packages/zod-shared` is Zod-only by design. That question disappears with the ticket.
+
+**The PSL constraint is real and still applies** to any future split. It is only avoidable by moving to a
+custom domain you control, which costs money and breaks the free-tier-only constraint (§12).
+
+</details>
 
 ---
 
@@ -381,8 +413,8 @@ and Render may restart the instance during maintenance at any time.
 |---|---|---|
 | **Sessions** | `connect-redis` keys with TTL | See the persistence note below. |
 | **Recent chat messages** | Capped list: `LPUSH` + `LTRIM` to last ~50, with TTL | Opening the chat shows recent context instead of an empty box. |
-| **Rate limiting** | Counter + TTL per IP/user | Losing counters on restart is harmless. |
-| **Presence** ("who's online") | `SET` with heartbeat TTLs | Inherently ephemeral by nature. |
+| ~~**Rate limiting**~~ | — | *Removed 2026-07-29:* rate limiting was dropped entirely. See the demo-caps design §5. |
+| ~~**Presence**~~ | — | *Removed 2026-07-29:* presence is **in-memory**, derived from `io.sockets`. With one process and no Redis adapter there is no second party to agree with, and Socket.io's own ping/pong already detects dead connections. See the realtime-chat design §4. |
 
 **On "no persistence" now that sessions live here:** a Redis restart logs every user out. For a demo whose
 services already cold-start after 15 minutes idle, this is acceptable and is *not* worth a paid tier or a
@@ -391,9 +423,10 @@ Mongo-backed session store. It is a deliberate trade, recorded so it is not mist
 **Chat messages are NOT stored in MongoDB.** There is no `Message` model. The chat is a live room, not an
 archive, and Redis is the semantically correct tier.
 
-**Socket.io Redis adapter is _not_ used** — each service runs a single instance, so it would be unnecessary
-machinery. It is the correct answer to "how would you scale this?" and is documented as such in the README
-rather than built prematurely.
+**Socket.io Redis adapter is _not_ used** — a single instance runs the whole app, so it would be
+unnecessary machinery. It is the correct answer to "how would you scale this?" and is documented as such in
+the README rather than built prematurely. *(This is also why presence needs no Redis at all — see the row
+above.)*
 
 **Deployment:** Key Value is a **managed addon**, not a container we build. It is declared in
 `infra/render.yaml` as `type: keyvalue`, and Render injects its internal connection string into both
@@ -531,8 +564,10 @@ On the client, **every `alert()` is removed**; field errors render inline from Z
 
 **Vitest (unit)** — `apps/server/src/models/*` and `apps/server/src/lib/services/*` against
 `mongodb-memory-server` (no live database required), plus `packages/zod-shared` for schema-only tests. Covers
-Zod schemas, slug generation, teaser derivation, socket-ticket verification,
-and the service-layer authorization rules.
+Zod schemas, slug generation, teaser derivation, the chat buffer's trim-and-expire,
+and the service-layer authorization rules. *(Socket auth moved to integration coverage 2026-07-29 — with
+no ticket to verify in isolation, the meaningful assertion is that an anonymous handshake is rejected and
+that a broadcast carries the session's identity rather than the payload's.)*
 
 **Supertest (API integration)** — the layer that most directly demonstrates backend competence, and where the
 §14 regression checklist is enforced against **real routes through the real middleware chain**:
@@ -607,20 +642,28 @@ running as root) with per-app multi-stage Dockerfiles that run as a non-root use
 
 | Component | Host | Free tier |
 |---|---|---|
-| `apps/server` (+ the SPA it serves) | Render web service | 750 instance-hours/workspace/month; 100 GB egress |
-| `apps/realtime` | Render web service | (shares the same 750-hour pool) |
+| `apps/server` (+ the SPA and the Socket.io server it hosts) | Render web service | 750 instance-hours/workspace/month; 100 GB egress |
 | Redis | Render Key Value | 25 MB, 50 connections, **no persistence**, **one per workspace** |
 | Database | MongoDB Atlas M0 | 512 MB |
 | Images | Cloudinary | Free-forever tier; ample for a demo's avatars and cover images |
 | CI | GitHub Actions | Free (public repo) |
 
-**Accepted:** free Render services **spin down after 15 minutes idle and cold-start in ~60 s**. Both services
-are permitted to sleep. (750 hours funds only *one* always-on service, so keeping both warm is not possible on
-the free tier — hence cold starts are accepted rather than worked around.)
+**Accepted:** free Render services **spin down after 15 minutes idle and cold-start in ~60 s**.
 
-**`infra/render.yaml`** declares all three prod resources as infrastructure-as-code. Secrets (`MONGODB_URI`,
+*Revised 2026-07-29.* This originally read "both services are permitted to sleep," on the reasoning that
+750 hours funds only *one* always-on service so keeping two warm was impossible. Collapsing realtime into
+`apps/server` (§5) removes the second service, so the allowance now covers the only service there is —
+744 hours in a 31-day month against a 750-hour grant.
+
+That makes staying warm **possible, not automatic**: Render sleeps an idle service after 15 minutes
+regardless of remaining hours, so eliminating cold starts requires a periodic external ping. None is
+configured. Until one is, the first chat visitor after an idle period still waits ~60 s — but once, not
+twice in series as the two-service design would have cost.
+
+**`infra/render.yaml`** declares both prod resources as infrastructure-as-code. Secrets (`MONGODB_URI`,
 `CLOUDINARY_URL`, OAuth credentials) use `sync: false` and are set in the dashboard — never committed, never
-hardcoded as a fallback. `SESSION_SECRET` and the socket-ticket secret use `generateValue: true`.
+hardcoded as a fallback. `SESSION_SECRET` uses `generateValue: true`. *(The socket-ticket secret is gone
+with the ticket, 2026-07-29 — realtime adds no new environment variable at all.)*
 
 **Never write credentials, tokens, or connection strings into source.** `.env` is gitignored; `.env.example`
 documents every variable with no real values. (A 5-year-old MongoDB credential was found leaked in this
@@ -646,7 +689,7 @@ parallel agents.
 | **P1** | `dev/express-api-foundation` | Monorepo re-shape, `apps/server` (Express + TS; originally scaffolded as `apps/api`, renamed during the P2 restructure) session auth on Redis, `requireAuth`/`requireOwner`, posts CRUD with correct authorization, Supertest integration suite, Compose dev + e2e, seed script, CI, deployed to Render. **Demoable via curl/Postman — no UI needed.** |
 | **P2** | `dev/react-client` | Vite + React + React Router + TanStack Query, Tailwind + shadcn (`ui`/`patterns`/`layouts`), auth pages, blog feed/post/editor, likes with optimistic UI, Playwright E2E, served by `apps/server` in prod. |
 | **P3** | `dev/comments-markdown` | Threaded comments, Markdown editor + preview, `AutoForm`. (Gating shipped in P2 and needs no flag — see §6.) |
-| **P4** | `dev/realtime-chat` | `apps/realtime` Socket.io service, signed handshake tickets, Redis message buffer, presence + typing indicators. |
+| **P4** | `dev/realtime-chat` | Socket.io **inside `apps/server`**, authenticated by the existing session, Redis message buffer, in-memory presence + typing indicators. *(Revised 2026-07-29 — was a standalone `apps/realtime` service with signed handshake tickets; see §5 and `2026-07-29-realtime-chat-design.md`.)* |
 | **P5** | `dev/media-and-search` | Signed Cloudinary uploads, avatars + cover images, tags, MongoDB full-text search. |
 | **P6** | `dev/oauth-polish` | Google + Facebook OAuth via Passport, Redis rate limiting, README + architecture diagram, demo account, final visual polish. |
 

--- a/docs/superpowers/specs/2026-07-29-realtime-chat-design.md
+++ b/docs/superpowers/specs/2026-07-29-realtime-chat-design.md
@@ -1,0 +1,362 @@
+# Realtime Chat (P4) — Design
+
+**Date:** 2026-07-29
+**Status:** approved, not implemented
+**Scope:** P4. Authenticated realtime chat, presence, and typing indicators.
+**Supersedes:** the `apps/realtime` / handshake-ticket design in
+`2026-07-16-express-react-rebuild-design.md` §5. See §2 and §10 below.
+
+---
+
+## §1 What this builds
+
+The legacy app's chat, rebuilt: one global room, signed-in readers only, messages held in Redis rather
+than MongoDB. It closes the three chat items still open on the main spec's §14 regression checklist, all
+of which are real defects in the 2021 code:
+
+| Legacy defect | Closed by |
+|---|---|
+| `app.js:56` echoed `message.user` straight from the client payload — anyone could speak as anyone | §3 |
+| `chat.jsx:51` added a listener per message received | §6 |
+| `chat.jsx:57` emitted `disconnect` on every render | §6 |
+
+**Not in scope:** direct messages, multiple rooms, message history beyond the live buffer, moderation,
+file or image attachments, read receipts, message editing or deletion.
+
+---
+
+## §2 Architecture — Socket.io runs inside `apps/server`
+
+**Decision (2026-07-29): there is no `apps/realtime`.** Socket.io attaches to the same HTTP server that
+serves the REST API and the built SPA.
+
+```ts
+const sessionMiddleware = buildSessionMiddleware({ store, secret, secure })
+const app = buildApp({ sessionMiddleware, trustProxy, clientDist })
+const server = http.createServer(app)
+const io = new Server(server)
+io.engine.use(sessionMiddleware)
+server.listen(env.PORT)
+```
+
+### Why this replaces the two-service design
+
+The main spec put realtime in its own Render service. That forced a chain of consequences, each solving a
+problem created by the one before it:
+
+1. A separate service means a **different origin**.
+2. A different origin means the session cookie cannot reach it — and `onrender.com` is on the **Public
+   Suffix List**, so widening the cookie to the parent domain is not merely inadvisable, it is refused by
+   the browser.
+3. No cookie means inventing a **signed handshake ticket**: a new endpoint, a JWT library, a shared
+   signing secret, and a sign/verify pair that must agree across two codebases.
+4. A sign/verify pair split across two apps needs a **shared package**, which the main spec left as an
+   open question because `packages/zod-shared` is schemas-only by design.
+5. A separate origin also means **CORS**, contradicting the project's "CORS is never needed anywhere"
+   property.
+
+Collapsing to one service dissolves all five at once. Nothing in items 1–5 was solving a problem the
+product has; each was solving a problem the topology introduced.
+
+### The free-tier argument, stated accurately
+
+Render grants **750 instance-hours per month per workspace**. A month is roughly 730 hours, so the
+allowance funds **one** service running continuously — never two. Under the two-service design both must
+sleep, and opening the chat costs *two* ~60-second cold starts in series: one to wake the API for the
+handshake, another to wake the realtime service for the socket. A blog post that loads slowly reads as
+slow; a chat that does nothing for two minutes reads as broken.
+
+**What one service actually buys, without overclaiming:** the cold-start cost halves from two to one, and
+staying warm becomes *possible* within the free allowance. It is not automatic — Render spins a free
+service down after 15 minutes without inbound traffic regardless of the hour budget, so genuinely
+eliminating cold starts needs a periodic ping (an external uptime pinger on a 5–10 minute interval is the
+cheapest option and is free). That ping is **not** part of this phase; it is recorded as risk §12.1.
+
+### What is given up, honestly
+
+A standalone realtime service is a legitimate portfolio talking point — it is the one place this project
+would demonstrate service-to-service authentication, and it allows the socket layer to scale
+independently of the API. Both are real. The independent scaling is theoretical at demo traffic, and the
+auth story is traded for a simpler one that is *correct* rather than merely impressive. Recorded here so
+the choice reads as deliberate if a reviewer asks why the chat is not its own service.
+
+### The one refactor this forces
+
+`buildApp` currently constructs the session middleware internally from `SessionOptions`. Socket.io needs
+**that same instance** — a second one built from the same options would work, but two middleware objects
+sharing one store is a coincidence rather than a guarantee. So `BuildAppOptions` takes a prebuilt
+`sessionMiddleware: RequestHandler` and the construction moves to the entry point. Existing tests that
+pass `session: {...}` are updated to build it themselves.
+
+`app.test.ts`'s middleware-order assertion is **unaffected**: Socket.io attaches to the HTTP server, not
+to the Express chain, so `helmet → json → session → routers → 404 → error handler` is unchanged.
+
+---
+
+## §3 Authentication — the session, directly
+
+No ticket. No token. The handshake runs the same session middleware as every REST request, so the socket
+reads the same session from the same Redis store.
+
+```ts
+io.use((socket, next) => {
+  const { userId, username } = socket.request.session ?? {}
+  if (!userId) return next(new Error('unauthorized'))
+  socket.data.user = { userId, username }
+  socket.join(`user:${userId}`)   // see revocation below
+  next()
+})
+```
+
+**Identity is server-derived, always.** Every message the server broadcasts is stamped from
+`socket.data.user`. The client's payload carries a body and nothing else — there is no author field to
+spoof, because the schema in §5 does not have one. This is the fix for `app.js:56`.
+
+`saveUninitialized: false` is already set, so an anonymous handshake does not allocate a Redis key before
+being rejected.
+
+### Revocation on logout
+
+Reading the session live is better than a ticket for revocation — but only for *new* connections. An
+already-open socket holds its identity in `socket.data`, so destroying the session does not by itself
+close it. Leaving a socket authenticated after logout would contradict the project's authorization model,
+so `POST /api/v1/auth/logout` disconnects that user's sockets:
+
+```ts
+io.in(`user:${userId}`).disconnectSockets()
+```
+
+The `user:<id>` room exists solely for this. It costs one `join` per connection and removes the need for a
+hand-maintained socket registry.
+
+---
+
+## §4 Redis structures
+
+Chat data is ephemeral by design (main spec §7): there is no `Message` model and messages never enter
+MongoDB. The chat is a live room, not an archive.
+
+| Key | Structure | Purpose |
+|---|---|---|
+| `chat:messages` | List, `LPUSH` + `LTRIM 0 49`, TTL 24h | Recent context so an arriving reader sees a conversation, not an empty box |
+
+That is the entire Redis footprint. **Presence is deliberately not in Redis.**
+
+### Presence is in-memory, derived from connected sockets
+
+The main spec §7 lists presence as a Redis use — `SET` with heartbeat TTLs. **This design drops that
+entirely**, and the reason is §2: there is one service running one instance, with no Socket.io Redis
+adapter. `io.sockets` is therefore already the complete and authoritative answer to "who is online."
+
+```ts
+// the whole implementation
+const online = new Set(
+  [...io.sockets.sockets.values()].map((s) => s.data.user.userId),
+)
+```
+
+Recomputed on `connection` and `disconnect`, and broadcast. Nothing is stored.
+
+A Redis presence set exists to let *separate processes* agree on who is connected. With a single process
+there is nobody to agree with, so it would add a key, a client event, a TTL and a cutoff constant to a
+25 MB store shared with the session data — and buy nothing until a second instance exists, which §2 rules
+out.
+
+**No heartbeat event either.** Heartbeats exist to notice clients that vanish without a clean disconnect.
+Socket.io already does that: its ping/pong timeout fires `disconnect` for a dead connection. Adding an
+application-level heartbeat on top would be a second, worse implementation of a mechanism the transport
+already provides.
+
+**On restart:** the process loses in-memory presence, and simultaneously drops every socket — so presence
+correctly becomes empty rather than becoming stale. The two cannot desynchronise, which is a property the
+Redis version would have had to work to preserve.
+
+**Redis has no persistence on the free plan** (main spec §7), so a restart also empties the message
+buffer. That is correct behaviour for this data, not a failure: the chat is live, and an empty room after
+a restart is honest.
+
+---
+
+## §5 API surface
+
+### REST — on `apps/server`, same origin as everything else
+
+| Method | Path | Auth | Returns |
+|---|---|---|---|
+| `GET` | `/api/v1/chat/messages` | `requireAuth` | The recent buffer, oldest first |
+
+The client loads the buffer over REST and *then* subscribes, matching the main spec's data-flow table.
+Doing it the other way round — subscribing first and back-filling — opens a window where a message
+arriving mid-fetch is either duplicated or lost.
+
+### Socket events
+
+| Direction | Event | Payload |
+|---|---|---|
+| client → server | `message` | `{ body: string }` — validated by `ChatMessageSchema` |
+| client → server | `typing` | `{ typing: boolean }` |
+| server → client | `message` | `ChatMessage` (see below) |
+| server → client | `presence` | `{ users: { id, username }[] }` |
+| server → client | `typing` | `{ userId, username, typing }` |
+
+`ChatMessageSchema` lives in `packages/zod-shared` with every other schema, so the same rules validate the
+socket payload on the server and the composer on the client:
+
+```ts
+export const ChatMessageSchema = z.object({
+  body: z.string().trim().min(1, 'Message cannot be empty').max(1000, 'Message must be at most 1,000 characters'),
+})
+```
+
+The broadcast shape adds only server-derived fields:
+
+```ts
+type ChatMessage = {
+  id: string          // crypto.randomUUID() — for React keys and client-side dedup
+  body: string
+  author: { id: string; username: string }   // from socket.data.user, never the payload
+  sentAt: string      // ISO, server clock
+}
+```
+
+**`typing` is never persisted** — it is broadcast and forgotten. Writing a keystroke signal to Redis would
+put the highest-frequency, lowest-value event in the app into a 25 MB store.
+
+**Business logic lives in `lib/services/chat.ts`**, per the project's code constraints. The socket handlers
+authenticate, validate, and delegate — the same rule the REST routers follow. Handlers are thin.
+
+---
+
+## §6 Client design
+
+The remaining two §14 regression items are both React lifecycle defects, which is why the socket is a
+designed unit rather than inline `useEffect` code.
+
+**The socket is created once, outside render.** A `socket.io-client` instance is module-level (or held in
+a ref), created with `autoConnect: false` and connected by an effect that runs once. Creating it during
+render produces a new connection per render — the shape of `chat.jsx:57`, which emitted `disconnect` on
+every render.
+
+**Every listener is removed in the effect's cleanup.** `chat.jsx:51` registered a handler per message
+received, so the listener count grew with the conversation and each message was handled N times. The rule
+here: every `socket.on(...)` has a matching `socket.off(...)` in the same effect's return.
+
+```ts
+useEffect(() => {
+  socket.on('message', onMessage)
+  socket.on('presence', onPresence)
+  return () => {
+    socket.off('message', onMessage)
+    socket.off('presence', onPresence)
+  }
+}, [])
+```
+
+**Structure:** `apps/client/src/hooks/use-chat.ts` owns the socket lifecycle and exposes
+`{ messages, online, typingUsers, send, status }`. `apps/client/src/pages/ChatPage.tsx` renders; it holds
+no socket logic. The `/chat` route is wrapped in `RequireAuth` — a UX redirect only, since §3 is what
+actually enforces it.
+
+**Connection status is surfaced, not hidden.** `status` is `connecting | connected | reconnecting |
+failed`, and the page renders it. Given §2's cold start, a chat that looks idle while the service wakes is
+indistinguishable from a broken one; saying "connecting" is the difference.
+
+**Message bodies render as plain text, not Markdown.** `MarkdownPreview` exists and is safe, but chat is a
+different surface from comments: a fast-moving room does not benefit from block quotes and tables, and
+keeping it plain removes the question of what a link in a chat message should do.
+
+---
+
+## §7 Errors
+
+A rejected handshake surfaces as a connection error, not an HTTP status — Socket.io's middleware signals
+failure with `next(new Error(...))`. The client maps it to `status: 'failed'` and a signed-out prompt.
+
+Message validation failures are returned to the sender only, as an `error` event carrying the Zod message,
+rather than broadcast. The REST endpoint uses the project's existing typed errors and error handler; it
+introduces no new error class.
+
+---
+
+## §8 Testing
+
+| Level | Coverage |
+|---|---|
+| Unit | `chatService.append` trims the buffer to 50 and sets the TTL |
+| Unit | `ChatMessageSchema` rejects empty and over-length bodies |
+| Integration | Presence reflects connect and disconnect, and lists a user once when they hold two sockets |
+| Integration | An anonymous socket handshake is rejected |
+| Integration | An authenticated socket receives its own broadcast, stamped with the session's identity — **not** with an author supplied in the payload |
+| Integration | `GET /api/v1/chat/messages` 401s for an anonymous request |
+| Integration | Logout disconnects that user's open sockets |
+| E2E | Two browser contexts exchange a message (main spec §10 already requires this) |
+
+The identity test is the one that matters: it is the §14 regression, and it must assert that a payload
+carrying `author` or `user` cannot influence the broadcast.
+
+---
+
+## §9 Configuration and deployment
+
+**No new environment variables.** The two-service design needed a socket-ticket secret; this one needs
+nothing — it reuses `SESSION_SECRET` and `REDIS_URL`, both already validated at boot by `lib/env.ts`.
+
+**No new Render service.** `infra/render.yaml` is unchanged apart from removing the `apps/realtime`
+comment. WebSocket upgrades work on Render web services with no extra configuration.
+
+**`infra/compose.yaml`** needs no new container. The Vite dev proxy already forwards `/api`; the socket
+connects to the same origin, so it needs a `ws: true` proxy entry for the Socket.io path.
+
+---
+
+## §10 Documentation this decision invalidates
+
+The single-service decision contradicts the main design spec in five places. Leaving them would have the
+repository describing a service that will never exist.
+
+**These are amended on this branch once this design is approved, before implementation starts** — not in
+the same commit as this document, so the design can be reviewed on its own first. Until they land, the
+main spec still describes the two-service plan and this file is the only record that it is superseded,
+which is the one window where the two disagree:
+
+| Document | Change |
+|---|---|
+| Main spec §3 | Remove `apps/realtime` from the layout and the migration map |
+| Main spec §5 | Replace "Socket authentication across origins" with §3 above; the PSL analysis stays as the *reason* the ticket was designed, marked superseded |
+| Main spec §7 | Remove presence from the Redis table entirely — it is in-memory now (§4). The sessions and chat-buffer rows stand; the rate-limiting row already went with the demo-caps amendment |
+| Main spec §12 | Cost table: one web service, not two; correct the cold-start note |
+| Main spec §13 | P4 row: no separate service |
+| `CLAUDE.md` | The `apps/realtime` architecture bullet and the "realtime is the exception" CORS paragraph — CORS is now genuinely never needed anywhere |
+| `README.md` | Move chat out of "Not yet built"; the architecture diagram gains the socket on the existing service |
+
+---
+
+## §11 Sequencing
+
+Implemented on `dev/realtime-chat`, merged to `staging` via PR. It does not block and is not blocked by
+P2 Task 14 (demo caps) — they share no files now that Task 14 no longer touches `app.ts`.
+
+**Chat has no cap and no rate limit.** Task 14 caps users, posts and comments; messages are exempt because
+the buffer is inherently self-limiting — `LTRIM` holds 50 and a TTL discards the rest, so flooding the
+chat cannot grow storage. It can drown the visible conversation, which the weekly reset does not fix and
+nothing else does either. Accepted: see risk §12.2.
+
+---
+
+## §12 Open risks
+
+1. **Staying warm needs a pinger that does not exist yet.** §2 claims the *option* of no cold starts, not
+   the fact. Without a periodic external ping, the service still sleeps after 15 idle minutes and the
+   first chat visitor waits ~60 seconds. Decide before promotion whether to add one; if not, the
+   connecting state in §6 is the entire mitigation.
+2. **A flooder can drown the room.** With no message cap or rate limit (§11), 50 rapid messages evict all
+   real conversation from the buffer. Storage is unaffected and the TTL cleans up, so this is a nuisance
+   rather than a liability — but unlike the §12.4 risk in the demo-caps design, the weekly reseed does not
+   recover it, because there is nothing to reseed. Revisit if it happens.
+3. **Presence is per-user, not per-connection.** Two tabs are one entry in the online list, and closing
+   one leaves the user online via the other socket. That is the desired behaviour — deduplicating by
+   `userId` is why the set is keyed that way — recorded so it is not mistaken for an oversight.
+4. **Reverting to two services later is expensive.** This design deletes the ticket, the shared package,
+   and the CORS configuration. If the project ever wants realtime split out — for scaling or as a
+   portfolio talking point — items 1–5 in §2 all come back. The superseded §5 in the main spec is kept
+   rather than deleted for exactly this reason.

--- a/docs/superpowers/specs/2026-07-29-realtime-chat-design.md
+++ b/docs/superpowers/specs/2026-07-29-realtime-chat-design.md
@@ -327,7 +327,7 @@ which is the one window where the two disagree:
 | Main spec §12 | Cost table: one web service, not two; correct the cold-start note |
 | Main spec §13 | P4 row: no separate service |
 | `CLAUDE.md` | The `apps/realtime` architecture bullet and the "realtime is the exception" CORS paragraph — CORS is now genuinely never needed anywhere |
-| `README.md` | Move chat out of "Not yet built"; the architecture diagram gains the socket on the existing service |
+| `README.md` | Correct the two `apps/realtime` references. Chat **stays** in "Not yet built" — it is designed, not built, and moving it now would be false. It moves out, and the architecture diagram gains the socket, when the implementation lands |
 
 ---
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -11,7 +11,10 @@ test('two signed-in users exchange a message, and a fresh client sees the buffer
   const stamp = Date.now()
 
   async function signUp(name: string) {
-    const context = await browser.newContext()
+    const context = await browser.newContext({
+      baseURL: 'http://localhost:3000',
+      extraHTTPHeaders: { 'X-Forwarded-Proto': 'https' },
+    })
     const page = await context.newPage()
     await page.goto('/signup')
     await page.getByLabel('Username').fill(name)

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -5,7 +5,9 @@ import { expect, test } from '@playwright/test'
  * session — the only way to prove a message actually crosses the server rather
  * than being echoed locally.
  */
-test('two signed-in users exchange a message', async ({ browser }) => {
+test('two signed-in users exchange a message, and a fresh client sees the buffered history', async ({
+  browser,
+}) => {
   const stamp = Date.now()
 
   async function signUp(name: string) {
@@ -27,14 +29,37 @@ test('two signed-in users exchange a message', async ({ browser }) => {
 
   await alice.goto('/chat')
   await bob.goto('/chat')
-  // The Send button enables only once the socket reports connected.
-  await expect(alice.getByRole('button', { name: 'Send' })).toBeEnabled()
-  await expect(bob.getByRole('button', { name: 'Send' })).toBeEnabled()
 
+  // ChatRoom.tsx disables Send while the draft is empty OR while the socket
+  // isn't 'connected'. Filling the draft first removes the first condition,
+  // so waiting for Send to become enabled afterwards genuinely asserts "the
+  // socket is up" rather than an assertion that would time out regardless of
+  // connection state.
   await alice.getByLabel('Message').fill('hello from alice')
+  await expect(alice.getByRole('button', { name: 'Send' })).toBeEnabled()
+
+  // Bob never sends anything, but his socket has to be connected before
+  // alice's message goes out, or the live broadcast has nothing to reach —
+  // there is no replay to a socket that connects after the fact. A throwaway
+  // draft proves his connection the same way, then gets cleared so it doesn't
+  // linger in the composer.
+  await bob.getByLabel('Message').fill('ready-check')
+  await expect(bob.getByRole('button', { name: 'Send' })).toBeEnabled()
+  await bob.getByLabel('Message').fill('')
+
   await alice.getByRole('button', { name: 'Send' }).click()
 
   await expect(bob.getByText('hello from alice')).toBeVisible()
   // Stamped with the sender's session identity, not anything the client sent.
   await expect(bob.getByText(`e2e-a-${stamp}`)).toBeVisible()
+
+  // A third, brand-new context that never had a socket open while alice's
+  // message went out. If it can still see the message, that message came from
+  // GET /api/v1/chat/messages (the Redis-backed buffer), not a live relay —
+  // proving the buffer that use-chat.ts loads on mount actually reaches a
+  // fresh client instead of leaving it an empty box.
+  const carol = await signUp(`e2e-c-${stamp}`)
+  await carol.goto('/chat')
+  await expect(carol.getByText('hello from alice')).toBeVisible()
+  await expect(carol.getByText(`e2e-a-${stamp}`)).toBeVisible()
 })

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Two independent browser contexts, so each has its own cookie jar and its own
+ * session — the only way to prove a message actually crosses the server rather
+ * than being echoed locally.
+ */
+test('two signed-in users exchange a message', async ({ browser }) => {
+  const stamp = Date.now()
+
+  async function signUp(name: string) {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await page.goto('/signup')
+    await page.getByLabel('Username').fill(name)
+    await page.getByLabel('Email').fill(`${name}@example.com`)
+    // exact: true — "Confirm password" also contains "Password".
+    await page.getByLabel('Password', { exact: true }).fill('a-valid-password')
+    await page.getByLabel('Confirm password').fill('a-valid-password')
+    await page.getByRole('button', { name: 'Sign Up' }).click()
+    await expect(page).toHaveURL('/')
+    return page
+  }
+
+  const alice = await signUp(`e2e-a-${stamp}`)
+  const bob = await signUp(`e2e-b-${stamp}`)
+
+  await alice.goto('/chat')
+  await bob.goto('/chat')
+  // The Send button enables only once the socket reports connected.
+  await expect(alice.getByRole('button', { name: 'Send' })).toBeEnabled()
+  await expect(bob.getByRole('button', { name: 'Send' })).toBeEnabled()
+
+  await alice.getByLabel('Message').fill('hello from alice')
+  await alice.getByRole('button', { name: 'Send' }).click()
+
+  await expect(bob.getByText('hello from alice')).toBeVisible()
+  // Stamped with the sender's session identity, not anything the client sent.
+  await expect(bob.getByText(`e2e-a-${stamp}`)).toBeVisible()
+})

--- a/infra/render.yaml
+++ b/infra/render.yaml
@@ -1,5 +1,7 @@
 # Production infrastructure as code (spec §7, §12).
-# apps/realtime is NOT here — it lands in P4.
+# No apps/realtime service: Socket.io runs inside blogchat-api, sharing its process and
+# origin, so realtime chat needs no service of its own, no env var, and no CORS. See
+# docs/superpowers/specs/2026-07-29-realtime-chat-design.md.
 services:
   - type: web
     name: blogchat-api

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,6 +166,7 @@
         "helmet": "^8.3.0",
         "mongoose": "^8.9.0",
         "redis": "^6.1.0",
+        "socket.io": "^4.8.3",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -174,6 +175,7 @@
         "@types/express-session": "^1.19.0",
         "@types/supertest": "^7.2.1",
         "mongodb-memory-server": "^10.1.0",
+        "socket.io-client": "^4.8.3",
         "supertest": "^7.2.2",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1"
@@ -2013,6 +2015,12 @@
         "win32"
       ]
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
@@ -2729,6 +2737,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2837,7 +2854,6 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2940,6 +2956,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3608,6 +3633,15 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
@@ -4068,6 +4102,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4275,6 +4326,93 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -7635,7 +7773,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8737,6 +8874,106 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/sonner": {
       "version": "2.0.7",
@@ -9942,7 +10179,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -10334,6 +10570,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -10350,6 +10607,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yauzl": {
       "version": "3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-markdown": "^10.1.0",
         "react-router": "^8.3.0",
         "remark-gfm": "^4.0.1",
+        "socket.io-client": "^4.8.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0"
       },
@@ -4353,7 +4354,6 @@
       "version": "6.6.6",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
       "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -8907,7 +8907,6 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -10612,7 +10611,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }

--- a/packages/zod-shared/src/index.ts
+++ b/packages/zod-shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './schemas/user.js'
 export * from './schemas/post.js'
 export * from './schemas/comment.js'
+export * from './schemas/chat.js'

--- a/packages/zod-shared/src/schemas/chat.ts
+++ b/packages/zod-shared/src/schemas/chat.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+/**
+ * The socket payload a client may send. `body` and nothing else: the author and
+ * timestamp are stamped by the server from the session, so there is no author
+ * field here to spoof. Zod objects strip unknown keys, which is the second
+ * reason a client-supplied author cannot reach a handler.
+ */
+export const ChatMessageSchema = z.object({
+  body: z
+    .string()
+    .trim()
+    .min(1, 'Message cannot be empty')
+    .max(1000, 'Message must be at most 1,000 characters'),
+})
+
+export type ChatMessageInput = z.infer<typeof ChatMessageSchema>
+
+/** What the server broadcasts. Every field beyond `body` is server-derived. */
+export type ChatMessage = {
+  id: string
+  body: string
+  author: { id: string; username: string }
+  /** ISO 8601, server clock. */
+  sentAt: string
+}

--- a/packages/zod-shared/src/schemas/chat.ts
+++ b/packages/zod-shared/src/schemas/chat.ts
@@ -20,7 +20,13 @@ export type ChatMessageInput = z.infer<typeof ChatMessageSchema>
 export type ChatMessage = {
   id: string
   body: string
-  author: { id: string; username: string }
+  /**
+   * `username` is optional, honestly: it reflects whatever the session held
+   * at handshake time. Every real login sets it, but nothing in the type
+   * system should pretend a session can't lack one — inventing a placeholder
+   * here would hide that case instead of representing it.
+   */
+  author: { id: string; username?: string }
   /** ISO 8601, server clock. */
   sentAt: string
 }

--- a/packages/zod-shared/src/schemas/index.ts
+++ b/packages/zod-shared/src/schemas/index.ts
@@ -1,3 +1,4 @@
 export * from './user.js'
 export * from './post.js'
 export * from './comment.js'
+export * from './chat.js'

--- a/packages/zod-shared/src/schemas/schemas.test.ts
+++ b/packages/zod-shared/src/schemas/schemas.test.ts
@@ -5,6 +5,7 @@ import {
   UpdatePostSchema,
   CreateCommentSchema,
   UpdateCommentSchema,
+  ChatMessageSchema,
   slugify,
   deriveTeaser,
 } from './index.js'
@@ -197,5 +198,27 @@ describe('deriveTeaser', () => {
 
   it('returns the whole body when it is shorter than the limit', () => {
     expect(deriveTeaser('Only one.')).toBe('Only one.')
+  })
+})
+
+describe('ChatMessageSchema', () => {
+  it('trims and accepts a normal message', () => {
+    const result = ChatMessageSchema.parse({ body: '  hello  ' })
+    expect(result.body).toBe('hello')
+  })
+
+  it('rejects a whitespace-only message', () => {
+    expect(ChatMessageSchema.safeParse({ body: '   ' }).success).toBe(false)
+  })
+
+  it('rejects a message over 1,000 characters', () => {
+    expect(ChatMessageSchema.safeParse({ body: 'a'.repeat(1001) }).success).toBe(false)
+  })
+
+  // The author is server-derived. A payload claiming one must not survive
+  // parsing, or the socket handler could be tempted to trust it.
+  it('strips an author supplied by the client', () => {
+    const result = ChatMessageSchema.parse({ body: 'hi', author: { id: 'x', username: 'admin' } })
+    expect(result).not.toHaveProperty('author')
   })
 })


### PR DESCRIPTION
Closes P4. One global chat room, signed-in only, with presence and typing indicators.

## The architecture decision

**Socket.io runs inside `apps/server`, not as a separate service.** This supersedes the main spec's `apps/realtime` design, and the reasoning is in `docs/superpowers/specs/2026-07-29-realtime-chat-design.md` §2.

The two-service design forced a chain where each link only existed to solve a problem the previous one created: a separate service means a separate origin → the session cookie can't reach it (and `onrender.com` is on the Public Suffix List, so widening the cookie domain is *refused by the browser*, not merely unwise) → so a signed handshake ticket → so a shared sign/verify package, which the spec left as an open question → plus CORS.

Running in one process dissolves all five. The socket reads the session directly via `io.engine.use(sessionMiddleware)`.

The free-tier maths also favours it: Render grants 750 instance-hours/month and a month is ~730 hours, so the allowance funds **one** always-on service and never two. Under the old design both had to sleep, and opening the chat cost *two* ~60s cold starts in series.

The superseded ticket design is kept in a collapsed `<details>` block in the main spec rather than deleted — it records why the ticket existed and what reverting would cost.

## Closes three §14 regression items

All three are real defects in the 2021 app, and each guard was verified by **reintroducing the defect and watching the test fail**:

| Legacy defect | Guard |
|---|---|
| `app.js:56` echoed `message.user` from the client payload — anyone could post as anyone | `realtime.test.ts` — identity is stamped from `socket.data.user`, asserted on both the broadcast and the stored record |
| `chat.jsx:51` registered a listener per message received | `use-chat.test.tsx` — asserts registered ⊆ removed generically, so a future listener can't skip cleanup |
| `chat.jsx:57` emitted `disconnect` on every render | `use-chat.test.tsx` — socket in a ref outside render, single effect, `[]` deps |

## What's here

- Socket.io on the app's HTTP server, session-authenticated at the handshake; logout disconnects that user's open sockets (reading the session live only revokes *new* connections).
- Messages in a capped Redis list (50, 24h TTL). No `Message` model — chat is a live room, not an archive.
- Presence **in-memory**, derived from `io.sockets`. Deliberately not Redis: one process with no Socket.io adapter means `io.sockets` is already authoritative, and Socket.io's ping/pong already detects dead clients, so a Redis set plus heartbeats would reimplement two things that already work.
- `GET /api/v1/chat/messages` loads the buffer before subscribing, deduped by id so a message arriving mid-fetch can't double up.
- README: how to try the chat, and the raw `docker compose` commands with the three traps this repo actually has (`--project-directory .`, `watch` vs `up -d`, and the override file needing its own `-f`).

**373 tests passing**, 43 files.

## Reviewed

Every task got a spec-compliance and quality review; the branch then got a whole-branch review that found 1 Critical + 4 Important, all fixed in one wave and re-reviewed.

The Critical is worth naming: `e2e/chat.spec.ts` used `browser.newContext()`, which does **not** inherit `use` from `playwright.config.ts` — no `baseURL`, no `X-Forwarded-Proto`, so the prod image's `secure` cookie would have been dropped. It would have failed on its first CI run.

The whole-branch review also caught two "built but never consumed" defects that per-task reviews structurally could not see, because each diff looked complete alone: `GET /chat/messages` had no client caller, and `ChatMessageSchema` was never imported by the client despite existing so the composer could share the server's rules.

## Known, and deliberate

- **The E2E has run in CI only.** The production image wouldn't build locally for most of this work (local TLS interception breaking `npm ci`), so this PR's check is its first real execution.
- **The Vite `ws: true` dev proxy is covered by no automated test** — the E2E runs against the production image, where no Vite proxy exists in the path. Verified by hand instead.
- **`ChatRoom.test.tsx:110-124` is tautological** — testing-library normalises whitespace, so it also passes against the pre-fix markup. The source fix is correct; only the guard is weak. One-line fix, tracked.
- **No message cap and no rate limit.** The `LTRIM` buffer is self-limiting for storage, but a flooder can drown the visible conversation and the weekly reseed doesn't recover it (there's nothing to reseed). Accepted; see the design's §12.2.
- **Staying warm needs a pinger that doesn't exist yet.** One service *can* run 24/7 inside the allowance, but Render still sleeps it after 15 idle minutes, so the first chat visitor after a lull waits ~60s. The connecting state in the UI is currently the whole mitigation.