### PR TITLE
feat(client): editorial feed redesign with generated cover art

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 - **Search** — full-text search plus tag filtering over the feed, debounced, bookmarkable via the URL.
 - **Realtime chat** — one room, signed-in only, with presence and typing indicators; recent history is
   loaded from Redis on join, and messages live only in Redis, never in MongoDB.
+- **Generated cover art** — every post gets a deterministic canvas drawing keyed to its slug, so the feed
+  is image-led with no upload pipeline and no stored assets.
 
-**Not yet built (by design, not oversight):** OAuth login (planned P6) and media/avatar uploads. See the
-phase table in `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
+**Not yet built (by design, not oversight):** OAuth login (planned P6) and media/avatar uploads — post
+covers are generated placeholders until those land. See the phase table in
+`docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
 
 ## Quick start
 

--- a/apps/client/src/components/layouts/PageShell.tsx
+++ b/apps/client/src/components/layouts/PageShell.tsx
@@ -1,5 +1,8 @@
-import { Link, useNavigate } from 'react-router'
+import { Link, NavLink, useNavigate } from 'react-router'
 import { useLogout, useMe } from '../../hooks/use-auth.js'
+
+const navLink =
+  'border-b-[1.5px] border-transparent pb-1 hover:text-[var(--foreground)] aria-[current=page]:border-[var(--primary)] aria-[current=page]:text-[var(--primary)]'
 
 export function PageShell({ children }: { children: React.ReactNode }) {
   const { data: me } = useMe()
@@ -7,48 +10,61 @@ export function PageShell({ children }: { children: React.ReactNode }) {
   const logout = useLogout()
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--background)] text-[var(--foreground)]">
-      <header className="border-b border-[var(--border)] py-4">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-4">
-          <Link to="/" className="text-lg font-semibold">
-            Blog
+    <div className="min-h-screen bg-[var(--background)] px-3 py-4 text-[var(--foreground)] sm:px-6 sm:py-10">
+      {/* The content sits on a raised sheet, so the tinted paper reads as a
+          surround rather than as the page's own background. */}
+      <div className="mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-6xl flex-col gap-10 bg-[var(--sheet)] px-5 py-6 shadow-[0_1px_2px_#14161d0a,0_18px_50px_-24px_#14161d3d] sm:gap-14 sm:px-12 sm:py-10">
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <Link
+            to="/"
+            aria-label="Home"
+            className="grid size-8 place-items-center border-[1.5px] border-[var(--foreground)] font-display text-sm tracking-[-0.02em]"
+          >
+            B
           </Link>
-          <nav className="flex gap-4">
+
+          <nav
+            aria-label="Primary"
+            className="flex flex-wrap items-center gap-4 font-mono text-xs tracking-[0.11em] text-[var(--muted-foreground)] uppercase sm:gap-7"
+          >
+            <NavLink to="/" end className={navLink}>
+              Blog
+            </NavLink>
             {me ? (
               <>
-                <span className="text-sm">Welcome, {me.username}</span>
-                <Link to="/blog/new" className="text-sm hover:underline">
-                  New Post
-                </Link>
-                <Link to="/chat" className="text-sm hover:underline">
+                <NavLink to="/chat" className={navLink}>
                   Chat
-                </Link>
+                </NavLink>
+                <NavLink to="/blog/new" className={navLink}>
+                  New post
+                </NavLink>
+                <span aria-hidden="true" className="h-4 w-px bg-[var(--border)]" />
+                <span className="text-[var(--ink-faint)]">{me.username}</span>
                 {/* There is no /logout route — logging out is a POST, not a
                     page. Navigating there rendered a dead end. */}
                 <button
                   onClick={() => logout.mutate(undefined, { onSuccess: () => navigate('/') })}
                   disabled={logout.isPending}
-                  className="text-sm hover:underline"
+                  className="border-b-[1.5px] border-transparent pb-1 uppercase hover:text-[var(--foreground)]"
                 >
-                  Logout
+                  Log out
                 </button>
               </>
             ) : (
               <>
-                <Link to="/login" className="text-sm hover:underline">
-                  Login
-                </Link>
-                <Link to="/signup" className="text-sm hover:underline">
+                <NavLink to="/login" className={navLink}>
+                  Log in
+                </NavLink>
+                <NavLink to="/signup" className={navLink}>
                   Sign up
-                </Link>
+                </NavLink>
               </>
             )}
           </nav>
-        </div>
-      </header>
-      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-8">
-        {children}
-      </main>
+        </header>
+
+        <main className="flex-1">{children}</main>
+      </div>
     </div>
   )
 }

--- a/apps/client/src/components/patterns/CommentForm.tsx
+++ b/apps/client/src/components/patterns/CommentForm.tsx
@@ -93,7 +93,7 @@ export function CommentForm({
       ) : (
         <div
           role="tabpanel"
-          className="min-h-32 rounded-md border border-[var(--border)] p-3 text-sm"
+          className="min-h-32 border border-[var(--border)] p-3 text-sm"
         >
           {body.trim() ? (
             <MarkdownPreview source={body} />

--- a/apps/client/src/components/patterns/CommentThread.tsx
+++ b/apps/client/src/components/patterns/CommentThread.tsx
@@ -52,7 +52,7 @@ function CommentItem({ slug, node, depth }: { slug: string; node: CommentNode; d
 
   return (
     <li className="flex flex-col gap-2">
-      <article className="flex flex-col gap-1 rounded-md border border-[var(--border)] p-3">
+      <article className="flex flex-col gap-1 border border-[var(--border)] p-3">
         <header className="text-xs text-[var(--muted-foreground)]">
           {node.author.username} · {new Date(node.createdAt).toLocaleDateString()}
         </header>

--- a/apps/client/src/components/patterns/PostCard.tsx
+++ b/apps/client/src/components/patterns/PostCard.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router'
 import type { Post } from '../../api/posts.js'
-import { Card } from '../ui/card.js'
+import { formatDate } from '../../lib/format-date.js'
+import { cn } from '../../lib/cn.js'
+import { PostTile } from './PostTile.js'
 
 /**
  * A feed entry. `post.body` is always a teaser here — the list endpoint never
@@ -8,40 +10,99 @@ import { Card } from '../ui/card.js'
  * `post.gated` is the server's verdict on whether this reader may open the post;
  * the card only relays it (spec §6), it does not decide it.
  */
-export function PostCard({ post }: { post: Post }) {
-  return (
-    <Card className="flex flex-col gap-2">
-      <Link to={`/blog/${post.slug}`} className="text-lg font-semibold hover:underline">
-        {post.title}
+export function PostCard({ post, featured = false }: { post: Post; featured?: boolean }) {
+  const meta = (
+    <p className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase tabular-nums">
+      <time dateTime={post.createdAt}>{formatDate(post.createdAt)}</time>
+      <span aria-hidden="true">·</span>
+      <span>{post.author.username}</span>
+      <span aria-hidden="true">·</span>
+      <span>
+        {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
+      </span>
+    </p>
+  )
+
+  // The tile is decorative and duplicates the headline's destination, so it is
+  // kept out of the a11y tree — the headline link is the one real way in.
+  const tile = (
+    <div className="relative">
+      <Link to={`/blog/${post.slug}`} aria-hidden="true" tabIndex={-1} className="group block">
+        <PostTile
+          slug={post.slug}
+          className="transition-opacity duration-200 group-hover:opacity-85"
+        />
       </Link>
-
-      <p className="text-sm whitespace-pre-wrap text-[var(--muted-foreground)]">{post.body}</p>
-
       {post.gated && (
-        <p className="text-sm">
-          <Link to="/login" className="text-[var(--primary)] hover:underline">
-            Sign in to read
-          </Link>{' '}
-          the full post.
-        </p>
+        <Link
+          to="/login"
+          className="absolute bottom-2 left-2 inline-flex items-center gap-1.5 bg-[var(--sheet)] px-2 py-1 font-mono text-[0.66rem] tracking-[0.11em] text-[var(--muted-foreground)] uppercase hover:text-[var(--primary)]"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            aria-hidden="true"
+            className="size-3"
+          >
+            <rect x="4" y="10" width="16" height="11" rx="1" />
+            <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+          </svg>
+          Sign in to read
+        </Link>
       )}
+    </div>
+  )
+
+  const body = (
+    <div className="flex flex-col gap-2.5">
+      {meta}
+      <h3
+        className={cn(
+          'font-display leading-none tracking-[-0.035em] text-balance',
+          featured ? 'text-3xl md:text-4xl' : 'text-xl',
+        )}
+      >
+        <Link to={`/blog/${post.slug}`} className="hover:text-[var(--primary)]">
+          {post.title}
+        </Link>
+      </h3>
+
+      <p className="line-clamp-3 max-w-[58ch] whitespace-pre-wrap text-[var(--muted-foreground)]">
+        {post.body}
+      </p>
 
       {post.tags.length > 0 && (
-        <ul className="flex flex-wrap gap-2">
+        <ul className="flex flex-wrap gap-1.5 font-mono text-[0.68rem] tracking-[0.09em] uppercase">
           {post.tags.map((tag) => (
-            <li
-              key={tag}
-              className="rounded bg-[var(--muted)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
-            >
+            <li key={tag} className="bg-[var(--primary-wash)] px-1.5 py-0.5 text-[var(--primary)]">
               {tag}
             </li>
           ))}
         </ul>
       )}
 
-      <p className="text-xs text-[var(--muted-foreground)]">
-        by {post.author.username} · {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
-      </p>
-    </Card>
+      {featured && (
+        <Link
+          to={`/blog/${post.slug}`}
+          className="mt-1 inline-flex items-center gap-2 self-start border-b-[1.5px] border-[var(--primary)] pb-0.5 font-mono text-xs tracking-[0.11em] text-[var(--primary)] uppercase"
+        >
+          Read the post <span aria-hidden="true">→</span>
+        </Link>
+      )}
+    </div>
+  )
+
+  return featured ? (
+    <article className="grid items-center gap-6 md:grid-cols-[1.35fr_1fr] md:gap-10">
+      {tile}
+      {body}
+    </article>
+  ) : (
+    <article className="flex flex-col gap-3">
+      {tile}
+      {body}
+    </article>
   )
 }

--- a/apps/client/src/components/patterns/PostTile.tsx
+++ b/apps/client/src/components/patterns/PostTile.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useRef } from 'react'
+import { cn } from '../../lib/cn.js'
+
+/**
+ * Generated cover art for a post, drawn from a hash of its slug — same slug,
+ * same drawing, forever. Stands in the exact slot a real cover image will
+ * occupy once uploads land (P5), so the layout does not move when it does.
+ */
+
+const PENS = ['--pen-0', '--pen-1', '--pen-2', '--pen-3', '--pen-4'] as const
+
+function hash(str: string): number {
+  let h = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
+    return s / 4294967296
+  }
+}
+
+// #RRGGBB -> rgba(), so one pen token can serve both the wash and the linework.
+function rgba(hex: string, alpha: number): string {
+  let v = hex.trim().replace('#', '')
+  if (v.length === 3) v = v[0] + v[0] + v[1] + v[1] + v[2] + v[2]
+  const n = Number.parseInt(v, 16)
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${alpha})`
+}
+
+type Motif = (ctx: CanvasRenderingContext2D, w: number, h: number, rnd: () => number) => void
+
+// Line counts are tuned for a wide featured tile; at grid width the same count
+// collapses into moiré, so every motif scales its density by this.
+function density(w: number): number {
+  return Math.min(1, Math.max(0.55, w / 620))
+}
+
+const arcs: Motif = (ctx, w, h, rnd) => {
+  const ox = rnd() < 0.5 ? w * 0.08 : w * 0.92
+  const oy = h * (0.15 + rnd() * 0.7)
+  const count = Math.round((26 + rnd() * 14) * density(w))
+  const step = (Math.max(w, h) * 1.25) / count
+  for (let i = 1; i <= count; i++) {
+    ctx.beginPath()
+    ctx.lineWidth = i % 5 === 0 ? 2 : 0.9
+    ctx.arc(ox, oy, step * i * (0.85 + rnd() * 0.3), 0, Math.PI * 2)
+    ctx.stroke()
+  }
+}
+
+const isogrid: Motif = (ctx, w, h, rnd) => {
+  const cell = w / Math.round((10 + rnd() * 5) * density(w))
+  const skew = 0.45 + rnd() * 0.25
+  for (let x = -h; x < w + h; x += cell) {
+    ctx.lineWidth = 0.9
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x + h * skew, h)
+    ctx.stroke()
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x - h * skew, h)
+    ctx.stroke()
+  }
+  for (let k = 0; k < 3; k++) {
+    const cx = w * (0.2 + rnd() * 0.6)
+    const cy = h * (0.2 + rnd() * 0.6)
+    const r = cell * (0.8 + rnd())
+    ctx.beginPath()
+    ctx.moveTo(cx, cy - r)
+    ctx.lineTo(cx + r * skew * 2, cy)
+    ctx.lineTo(cx, cy + r)
+    ctx.lineTo(cx - r * skew * 2, cy)
+    ctx.closePath()
+    ctx.fill()
+  }
+}
+
+const strata: Motif = (ctx, w, h, rnd) => {
+  const bands = Math.round((28 + rnd() * 14) * density(w))
+  for (let i = 0; i < bands; i++) {
+    const y = (h / bands) * i + h / bands / 2
+    const amp = h * 0.03 * (0.3 + rnd() * 2.2)
+    const freq = (1.2 + rnd() * 2.4) * Math.PI * 2
+    const phase = rnd() * Math.PI * 2
+    ctx.beginPath()
+    ctx.lineWidth = i % 6 === 0 ? 2 : 0.9
+    for (let x = 0; x <= w; x += 3) {
+      const yy = y + Math.sin((x / w) * freq + phase) * amp
+      if (x === 0) ctx.moveTo(x, yy)
+      else ctx.lineTo(x, yy)
+    }
+    ctx.stroke()
+  }
+}
+
+const spokes: Motif = (ctx, w, h, rnd) => {
+  const cx = w * (0.25 + rnd() * 0.5)
+  const cy = h * (0.25 + rnd() * 0.5)
+  const count = Math.round((56 + rnd() * 34) * density(w))
+  const reach = Math.hypot(w, h)
+  for (let i = 0; i < count; i++) {
+    const a = (i / count) * Math.PI * 2
+    ctx.beginPath()
+    ctx.lineWidth = i % 8 === 0 ? 1.8 : 0.8
+    ctx.moveTo(cx + Math.cos(a) * reach * 0.06, cy + Math.sin(a) * reach * 0.06)
+    ctx.lineTo(cx + Math.cos(a) * reach, cy + Math.sin(a) * reach)
+    ctx.stroke()
+  }
+  // Concentric rings across the spokes — a solid wedge here read as a pie
+  // chart and swallowed the tile.
+  for (let r = 1; r <= 5; r++) {
+    ctx.beginPath()
+    ctx.lineWidth = r === 3 ? 2 : 0.9
+    ctx.arc(cx, cy, reach * 0.09 * r * (0.9 + rnd() * 0.35), 0, Math.PI * 2)
+    ctx.stroke()
+  }
+}
+
+const nest: Motif = (ctx, w, h, rnd) => {
+  const count = Math.round((30 + rnd() * 16) * density(w))
+  const turn = (rnd() - 0.5) * 0.06
+  ctx.save()
+  ctx.translate(w / 2, h / 2)
+  for (let i = count; i > 0; i--) {
+    const sw = (w * 1.15 * i) / count
+    const sh = (h * 1.15 * i) / count
+    ctx.rotate(turn)
+    ctx.beginPath()
+    ctx.lineWidth = i % 5 === 0 ? 2 : 0.9
+    ctx.rect(-sw / 2, -sh / 2, sw, sh)
+    ctx.stroke()
+  }
+  ctx.restore()
+}
+
+const MOTIFS: Motif[] = [arcs, isogrid, strata, spokes, nest]
+
+export function PostTile({ slug, className }: { slug: string; className?: string }) {
+  const ref = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return
+
+    const draw = () => {
+      // Nothing laid out yet (or jsdom, which reports 0×0) — no context needed.
+      const rect = canvas.getBoundingClientRect()
+      if (!rect.width || !rect.height) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
+      const w = Math.round(rect.width)
+      const h = Math.round(rect.height)
+      canvas.width = w * dpr
+      canvas.height = h * dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      ctx.clearRect(0, 0, w, h)
+
+      const css = getComputedStyle(document.documentElement)
+      // Three independent hashes: sharing one made motif and pen move together,
+      // so neighbouring posts kept drawing the same figure in the same colour.
+      const seed = hash(slug)
+      const motif = MOTIFS[hash(`${slug}#motif`) % MOTIFS.length]
+      const pen = css.getPropertyValue(PENS[hash(`${slug}#pen`) % PENS.length]) || '#0f5d57'
+      const wash = Number.parseFloat(css.getPropertyValue('--tile-wash')) || 0.07
+      const line = Number.parseFloat(css.getPropertyValue('--tile-line')) || 0.72
+
+      ctx.fillStyle = css.getPropertyValue('--sheet') || '#fff'
+      ctx.fillRect(0, 0, w, h)
+      ctx.fillStyle = rgba(pen, wash)
+      ctx.fillRect(0, 0, w, h)
+
+      ctx.save()
+      ctx.beginPath()
+      ctx.rect(0, 0, w, h)
+      ctx.clip()
+      ctx.strokeStyle = rgba(pen, line)
+      ctx.fillStyle = rgba(pen, line)
+      ctx.lineJoin = 'round'
+      motif(ctx, w, h, makeRng(seed))
+      ctx.restore()
+    }
+
+    draw()
+
+    if (typeof ResizeObserver === 'undefined') return
+    let pending = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(pending)
+      pending = requestAnimationFrame(draw)
+    })
+    observer.observe(canvas)
+    return () => {
+      cancelAnimationFrame(pending)
+      observer.disconnect()
+    }
+  }, [slug])
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden="true"
+      className={cn('block aspect-[16/10] w-full bg-[var(--muted)]', className)}
+    />
+  )
+}

--- a/apps/client/src/components/patterns/PostTile.tsx
+++ b/apps/client/src/components/patterns/PostTile.tsx
@@ -29,7 +29,9 @@ function makeRng(seed: number): () => number {
 // #RRGGBB -> rgba(), so one pen token can serve both the wash and the linework.
 function rgba(hex: string, alpha: number): string {
   let v = hex.trim().replace('#', '')
-  if (v.length === 3) v = v[0] + v[0] + v[1] + v[1] + v[2] + v[2]
+  // Doubling each char rather than indexing: under noUncheckedIndexedAccess
+  // every v[n] is string | undefined, which this expression cannot use.
+  if (v.length === 3) v = v.replace(/./g, (c) => c + c)
   const n = Number.parseInt(v, 16)
   return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${alpha})`
 }
@@ -169,8 +171,12 @@ export function PostTile({ slug, className }: { slug: string; className?: string
       // Three independent hashes: sharing one made motif and pen move together,
       // so neighbouring posts kept drawing the same figure in the same colour.
       const seed = hash(slug)
-      const motif = MOTIFS[hash(`${slug}#motif`) % MOTIFS.length]
-      const pen = css.getPropertyValue(PENS[hash(`${slug}#pen`) % PENS.length]) || '#0f5d57'
+      // The `??` fallbacks are unreachable — a positive modulo is always in
+      // range — but noUncheckedIndexedAccess cannot know that, and asserting
+      // non-null would hide a real out-of-range bug if these lists ever change.
+      const motif = MOTIFS[hash(`${slug}#motif`) % MOTIFS.length] ?? arcs
+      const penToken = PENS[hash(`${slug}#pen`) % PENS.length] ?? PENS[0]
+      const pen = css.getPropertyValue(penToken) || '#0f5d57'
       const wash = Number.parseFloat(css.getPropertyValue('--tile-wash')) || 0.07
       const line = Number.parseFloat(css.getPropertyValue('--tile-line')) || 0.72
 

--- a/apps/client/src/components/ui/button.tsx
+++ b/apps/client/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type ButtonHTMLAttributes } from 'react'
 import { cn } from '../../lib/cn.js'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center rounded-none text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/apps/client/src/components/ui/card.tsx
+++ b/apps/client/src/components/ui/card.tsx
@@ -2,5 +2,7 @@ import type { HTMLAttributes } from 'react'
 import { cn } from '../../lib/cn.js'
 
 export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('rounded-lg border border-[var(--border)] p-4', className)} {...props} />
+  return (
+    <div className={cn('rounded-none border border-[var(--border)] p-4', className)} {...props} />
+  )
 }

--- a/apps/client/src/components/ui/input.tsx
+++ b/apps/client/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputE
     <input
       ref={ref}
       className={cn(
-        'h-10 w-full rounded-md border border-[var(--border)] bg-transparent px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
+        'h-10 w-full rounded-none border border-[var(--border)] bg-transparent px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
         className,
       )}
       {...props}

--- a/apps/client/src/components/ui/skeleton.tsx
+++ b/apps/client/src/components/ui/skeleton.tsx
@@ -2,5 +2,5 @@ import type { HTMLAttributes } from 'react'
 import { cn } from '../../lib/cn.js'
 
 export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-[var(--muted)]', className)} {...props} />
+  return <div className={cn('animate-pulse rounded-none bg-[var(--muted)]', className)} {...props} />
 }

--- a/apps/client/src/components/ui/textarea.tsx
+++ b/apps/client/src/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<H
     <textarea
       ref={ref}
       className={cn(
-        'min-h-32 w-full rounded-md border border-[var(--border)] bg-transparent p-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
+        'min-h-32 w-full rounded-none border border-[var(--border)] bg-transparent p-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
         className,
       )}
       {...props}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -2,18 +2,46 @@
    no postcss.config.js. Light theme only (spec §2) — no .dark block. */
 @import 'tailwindcss';
 
+/* Font roles as Tailwind utilities: font-display, font-body, font-mono.
+   No webfont is loaded, so nothing can silently fall back to a wrong face. */
+@theme {
+  --font-display: 'Arial Black', 'Archivo Black', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-body: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif;
+  --font-mono: ui-monospace, 'Cascadia Mono', 'Cascadia Code', Consolas, 'SF Mono', Menlo, monospace;
+}
+
 :root {
-  --background: oklch(0.98 0.051 105);       /* #FDFBD4 cream */
-  --foreground: oklch(0.28 0.047 67.5);      /* #38240D espresso */
-  --primary: oklch(0.581 0.155 49.5);        /* #C05800 burnt orange */
-  --primary-foreground: oklch(0.98 0.051 105); /* cream, for text on the orange primary */
-  --border: oklch(0.87 0.035 55);            /* light tan, same hue family as rust/orange */
-  --muted: oklch(0.94 0.025 60);             /* pale tan panel background */
-  --muted-foreground: oklch(0.403 0.101 53.8); /* #713600 rust */
-  --destructive: oklch(0.58 0.24 27);        /* red-orange, kept — already warm, harmonizes */
+  --background: #e7eaf1; /* paper — blue-shifted, so the neutral reads as chosen */
+  --sheet: #fafbfd; /* the contained page the content sits on */
+  --foreground: #14161d; /* ink — blue-black, not pure black */
+  --primary: #0f5d57; /* signal pine — links, active nav, focus */
+  --primary-foreground: #fafbfd;
+  --primary-wash: #0f5d5714; /* the same pine at 8% — tag chips, quiet fills */
+  --border: #d8dce4; /* hairline rule */
+  --muted: #eef0f5; /* pale panel */
+  --muted-foreground: #59606e; /* body grey, blue-biased to match the ink */
+  --ink-faint: #8a91a0; /* metadata, third-level text */
+  --destructive: #a82d42; /* oxblood — warm enough to read as danger, cool enough to belong */
+
+  /* Plotter pens for the generated post tiles. One is picked per post from a
+     hash of its slug, so a post's cover art never changes. */
+  --pen-0: #0f5d57;
+  --pen-1: #28356b;
+  --pen-2: #8a6a16;
+  --pen-3: #7a2e3b;
+  --pen-4: #3a414e;
+  --tile-wash: 0.1; /* alpha of the flat pen tint behind the linework */
+  --tile-line: 0.9; /* alpha of the linework itself */
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
 }

--- a/apps/client/src/lib/format-date.ts
+++ b/apps/client/src/lib/format-date.ts
@@ -1,0 +1,12 @@
+// Fixed en-GB so the feed's date column stays one width regardless of locale —
+// the metadata is set in a monospace face and lines up between cards.
+const formatter = new Intl.DateTimeFormat('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+})
+
+export function formatDate(iso: string): string {
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime()) ? '' : formatter.format(date)
+}

--- a/apps/client/src/pages/BlogFeedPage.tsx
+++ b/apps/client/src/pages/BlogFeedPage.tsx
@@ -45,13 +45,18 @@ export function BlogFeedPage() {
 
   const handleSearch = (next: string) => setTerm(next)
 
+  // Only the unfiltered feed has a lead story. Among search results the first
+  // hit is just the first hit, so promoting it would be a false claim.
+  const lead = !debouncedTerm && posts?.length ? posts[0] : undefined
+  const rest = lead ? posts!.slice(1) : (posts ?? [])
+
   let content: ReactNode
   if (isPending) {
     content = (
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-32" />
-        <Skeleton className="h-32" />
-        <Skeleton className="h-32" />
+      <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="aspect-[16/10]" />
+        <Skeleton className="aspect-[16/10]" />
+        <Skeleton className="aspect-[16/10]" />
       </div>
     )
   } else if (isError) {
@@ -62,21 +67,48 @@ export function BlogFeedPage() {
     )
   } else {
     content = (
-      <div className="flex flex-col gap-4">
-        {posts.map((post) => (
+      <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+        {rest.map((post) => (
           <PostCard key={post.id} post={post} />
         ))}
       </div>
     )
   }
 
-  // The search box is outside every branch on purpose: it must stay on screen
-  // while results load and, above all, when a search returns nothing — hiding
-  // it there would leave the reader stranded with no way to change the term.
+  // The band header carries the search box, and both sit outside every branch
+  // on purpose: the box must stay on screen while results load and, above all,
+  // when a search returns nothing — hiding it there would leave the reader
+  // stranded with no way to change the term.
   return (
-    <div className="flex flex-col gap-6">
-      <SearchBar value={term} onChange={handleSearch} />
-      {content}
+    <div className="flex flex-col gap-12">
+      <div className="flex flex-col gap-5">
+        <h1 className="font-display text-[clamp(3rem,8vw,6rem)] leading-[0.86] tracking-[-0.045em] text-balance">
+          The Blog
+        </h1>
+        <p className="max-w-[46ch] text-lg text-[var(--muted-foreground)]">
+          Notes from rebuilding a five-year-old MERN app as an Express and React monorepo — one
+          decision at a time.
+        </p>
+      </div>
+
+      {lead && <PostCard post={lead} featured />}
+
+      <section className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-b border-[var(--border)] pb-3">
+          <h2 className="flex items-baseline gap-3 font-mono text-xs tracking-[0.11em] text-[var(--ink-faint)] uppercase">
+            {debouncedTerm ? 'Results' : 'Recent writing'}
+            {!isPending && !isError && (
+              <span className="tabular-nums">
+                {rest.length} {rest.length === 1 ? 'post' : 'posts'}
+              </span>
+            )}
+          </h2>
+          <div className="w-full sm:w-64">
+            <SearchBar value={term} onChange={handleSearch} />
+          </div>
+        </div>
+        {content}
+      </section>
     </div>
   )
 }

--- a/apps/client/src/pages/LoginPage.tsx
+++ b/apps/client/src/pages/LoginPage.tsx
@@ -23,7 +23,7 @@ export function LoginPage() {
 
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="w-full max-w-md p-8 space-y-6 border border-[var(--border)] rounded-lg">
+      <div className="w-full max-w-md space-y-6 border border-[var(--border)] p-8">
         <h1 className="text-2xl font-bold">Login</h1>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -6,8 +6,10 @@ import { useMe } from '../hooks/use-auth.js'
 import { CommentSection } from '../components/patterns/CommentSection.js'
 import { EmptyState } from '../components/patterns/EmptyState.js'
 import { LikeButton } from '../components/patterns/LikeButton.js'
+import { PostTile } from '../components/patterns/PostTile.js'
 import { Button } from '../components/ui/button.js'
 import { Skeleton } from '../components/ui/skeleton.js'
+import { formatDate } from '../lib/format-date.js'
 
 /**
  * The post detail page. `post.gated` is the server's verdict that this reader is
@@ -29,13 +31,21 @@ export function PostPage() {
   const isOwner = me?.id === post.author.id
 
   return (
-    <article className="flex flex-col gap-4">
-      <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold">{post.title}</h1>
-        <p className="text-sm text-[var(--muted-foreground)]">by {post.author.username}</p>
+    <article className="flex max-w-3xl flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <p className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase tabular-nums">
+          <time dateTime={post.createdAt}>{formatDate(post.createdAt)}</time>
+          <span aria-hidden="true">·</span>
+          <span>{post.author.username}</span>
+        </p>
+        <h1 className="font-display text-[clamp(2rem,5vw,3.25rem)] leading-[0.95] tracking-[-0.04em] text-balance">
+          {post.title}
+        </h1>
       </header>
 
-      <div className="whitespace-pre-wrap">{post.body}</div>
+      <PostTile slug={post.slug} className="aspect-[21/9]" />
+
+      <div className="max-w-[68ch] text-lg leading-relaxed whitespace-pre-wrap">{post.body}</div>
 
       {post.gated && (
         <p className="rounded bg-[var(--muted)] p-4 text-sm">
@@ -47,19 +57,16 @@ export function PostPage() {
       )}
 
       {post.tags.length > 0 && (
-        <ul className="flex flex-wrap gap-2">
+        <ul className="flex flex-wrap gap-1.5 font-mono text-[0.68rem] tracking-[0.09em] uppercase">
           {post.tags.map((tag) => (
-            <li
-              key={tag}
-              className="rounded bg-[var(--muted)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
-            >
+            <li key={tag} className="bg-[var(--primary-wash)] px-1.5 py-0.5 text-[var(--primary)]">
               {tag}
             </li>
           ))}
         </ul>
       )}
 
-      <div className="flex items-center gap-4 text-sm text-[var(--muted-foreground)]">
+      <div className="flex items-center gap-4 border-t border-[var(--border)] pt-5 text-sm text-[var(--muted-foreground)]">
         <LikeButton slug={post.slug} likeCount={post.likeCount} />
         {isOwner && (
           <>

--- a/apps/client/src/pages/SignupPage.tsx
+++ b/apps/client/src/pages/SignupPage.tsx
@@ -97,7 +97,7 @@ export function SignupPage() {
 
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="w-full max-w-md p-8 space-y-6 border border-[var(--border)] rounded-lg">
+      <div className="w-full max-w-md space-y-6 border border-[var(--border)] p-8">
         <h1 className="text-2xl font-bold">Sign Up</h1>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/e2e/auth-and-posts.spec.ts
+++ b/e2e/auth-and-posts.spec.ts
@@ -4,8 +4,9 @@ import { expect, test } from '@playwright/test'
  * The whole authenticated round trip through the real prod image: an account
  * that did not exist, a post it owns, a like on it, and a session that ends.
  *
- * Selectors are the accessible name the app actually renders — "Sign Up",
- * "New Post", "Publish", "Logout" — not the ones the plan guessed at.
+ * Selectors are the accessible name the app actually renders, not the ones the
+ * plan guessed at. The nav rail's labels are matched case-insensitively because
+ * it is uppercased in CSS, and text-transform can reach the accessible name.
  */
 test('signup, create a post, like it, then log out', async ({ page }) => {
   const username = `e2e-${Date.now()}`
@@ -24,9 +25,12 @@ test('signup, create a post, like it, then log out', async ({ page }) => {
   await page.getByLabel('Confirm password').fill('a-valid-password')
   await page.getByRole('button', { name: 'Sign Up' }).click()
   await expect(page).toHaveURL('/')
-  await expect(page.getByText(`Welcome, ${username}`)).toBeVisible()
+  // The nav rail shows the bare username; there is no "Welcome," prefix any
+  // more. Case-insensitive throughout this file because the rail is uppercased
+  // in CSS, and text-transform can reach the accessible name.
+  await expect(page.getByText(username, { exact: false })).toBeVisible()
 
-  await page.getByRole('link', { name: 'New Post' }).click()
+  await page.getByRole('link', { name: /new post/i }).click()
   // AutoForm labels every field with its raw schema key.
   await page.getByLabel('title').fill('An E2E post')
   await page.getByLabel('body').fill('Written by Playwright.')
@@ -38,6 +42,6 @@ test('signup, create a post, like it, then log out', async ({ page }) => {
   await page.getByRole('button', { name: '0' }).click()
   await expect(page.getByRole('button', { name: '1' })).toBeVisible()
 
-  await page.getByRole('button', { name: 'Logout' }).click()
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible()
+  await page.getByRole('button', { name: /log ?out/i }).click()
+  await expect(page.getByRole('link', { name: /log ?in/i })).toBeVisible()
 })


### PR DESCRIPTION
Reworks the blog's visual identity around a supplied reference layout, and gives the feed real cover images without an upload pipeline.

## Why

The previous palette (cream `#FDFBD4` + burnt orange `#C05800`, light-only) was the look most tools default to, and the feed was a flat stack of bordered cards. The reference direction called for an image-led editorial layout: contained sheet, oversized masthead, one lead story, then a card grid.

That layout depends on cover images — and there are none. `Post.coverImage` and `User.image` exist on the models but `CreatePostSchema` has no `coverImage` field, so nothing can set them; signed Cloudinary uploads are P5 (`dev/media-and-search`).

## What

**Palette and type.** Cool paper `#E7EAF1`, blue-black ink `#14161D`, one pine accent `#0F5D57`. Font roles are exposed as Tailwind v4 `@theme` utilities (`font-display` / `font-body` / `font-mono`). No webfont is loaded, so there is no silent fallback. Every component already consumed tokens by name, so the repaint was mostly a token change.

**Generated cover art** (`components/patterns/PostTile.tsx`). Each post's cover is drawn on a canvas from a hash of its slug — same slug, same drawing, forever. Five plotter motifs × five pens, with line density scaled to tile width so grid tiles don't collapse into moiré. It occupies the exact slot a real Cloudinary cover will, so **the layout does not move when uploads land** — the `<canvas>` is swapped for an `<img>`.

**Layout.** Masthead → lead story (7/5 split) → band header → 3-across grid. `PageShell` becomes a hairline rail on a raised sheet with the active tab underlined. `PostPage` gets a display headline, mono metadata and a 21:9 cover, flush-left to align with the feed.

**Primitives** are squared (`rounded-none`) to match the new hairline language.

## Notes for review

- **The lead story is suppressed during a search.** Among search results the first hit is just the first hit; promoting it would be a false claim.
- **The search box moved into the band header**, which is rendered outside every load/error/empty branch — it must stay on screen when a search returns nothing, or the reader is stranded with no way to change the term. This preserves the invariant the previous comment in `BlogFeedPage` was guarding.
- **The tile is `aria-hidden` and `tabIndex={-1}`**; it duplicates the headline's destination, so the headline link is the single real way in. The gated "Sign in to read" chip is a sibling link to `/login`, not nested inside it.
- **Still light-only** (spec §2). No dark block was added — the app has no theme toggle, and adding one was out of scope.
- `PostTile` bails before acquiring a 2D context when the canvas has no layout, which also keeps jsdom quiet in tests.

## Verification

- `npm run test` — **373/373 pass**, 43 files.
- `vite build` — clean.
- Checked against the live Compose stack: anonymous feed, signed-in feed, post detail, 390px mobile. Console clean apart from the pre-existing `favicon.ico` 404.
- Not run locally: `typecheck` / `lint` (CI owns them) and E2E.

## README

`## Core features` gains a "Generated cover art" bullet, and the "Not yet built" note now says post covers are generated placeholders until media uploads land — so a reader seeing cover images doesn't conclude uploads shipped.