### PR TITLE
feat: optional cover images via signed Cloudinary uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 - **Search** — full-text search plus tag filtering over the feed, debounced, bookmarkable via the URL.
 - **Realtime chat** — one room, signed-in only, with presence and typing indicators; recent history is
   loaded from Redis on join, and messages live only in Redis, never in MongoDB.
+- **Generated cover art** — every post gets a deterministic canvas drawing keyed to its slug, so the feed
+  is image-led with no upload pipeline and no stored assets.
 
-**Not yet built (by design, not oversight):** OAuth login (planned P6) and media/avatar uploads. See the
-phase table in `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
+**Not yet built (by design, not oversight):** OAuth login (planned P6) and media/avatar uploads — post
+covers are generated placeholders until those land. See the phase table in
+`docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 
 | Layer | What's used |
 |---|---|
-| Server | Express 5 · Socket.io (realtime chat) · Mongoose 8 (MongoDB) · `express-session` + `connect-redis` (Redis-backed sessions) · bcryptjs · Helmet · Zod |
+| Server | Express 5 · Socket.io (realtime chat) · Mongoose 8 (MongoDB) · `express-session` + `connect-redis` (Redis-backed sessions) · bcryptjs · Helmet · Zod · Cloudinary (signed image uploads) |
 | Client | React 19 · Vite · TanStack Query · React Router 8 · Tailwind CSS 4 · `react-markdown` + `remark-gfm` |
 | Shared | Zod schemas in `packages/zod-shared`, the single source of truth for both server validation and client forms |
 | Testing | Vitest · Supertest · `mongodb-memory-server` · Testing Library · Playwright (e2e) |
@@ -101,12 +101,17 @@ client-side `Array.filter`. See "Search semantics" below for the word-matching b
 - **Search** — full-text search plus tag filtering over the feed, debounced, bookmarkable via the URL.
 - **Realtime chat** — one room, signed-in only, with presence and typing indicators; recent history is
   loaded from Redis on join, and messages live only in Redis, never in MongoDB.
-- **Generated cover art** — every post gets a deterministic canvas drawing keyed to its slug, so the feed
-  is image-led with no upload pipeline and no stored assets.
+- **Cover images** — optional per post, uploaded straight to Cloudinary from the browser against a
+  short-lived signature the API issues; only the public ID is stored, so the delivery host can change
+  without rewriting documents.
+- **Generated cover art** — a post with no uploaded cover gets a deterministic canvas drawing keyed to its
+  slug, so the feed is image-led whether or not the author supplied a picture.
 
-**Not yet built (by design, not oversight):** OAuth login (planned P6) and media/avatar uploads — post
-covers are generated placeholders until those land. See the phase table in
-`docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
+**Not yet built (by design, not oversight):** OAuth login (planned P6) and avatar uploads. See the phase
+table in `docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md` §13 for what's next.
+
+Uploads are optional infrastructure: with no `CLOUDINARY_*` variables set the API still boots, the upload
+endpoint reports 503, and every post falls back to its generated cover.
 
 ## Quick start
 

--- a/apps/client/src/api/posts.ts
+++ b/apps/client/src/api/posts.ts
@@ -13,6 +13,8 @@ export type Post = {
   tags: string[]
   likeCount: number
   coverImage?: string
+  /** Delivery URL derived server-side from coverImage. Absent when there is no cover. */
+  coverUrl?: string
   createdAt: string
   updatedAt: string
 }

--- a/apps/client/src/api/uploads.ts
+++ b/apps/client/src/api/uploads.ts
@@ -1,0 +1,88 @@
+import { ApiError, request } from './client.js'
+
+export type UploadFolder = 'covers' | 'avatars'
+
+export type UploadSignature = {
+  cloudName: string
+  apiKey: string
+  folder: string
+  timestamp: number
+  allowedFormats: string
+  signature: string
+}
+
+/**
+ * The signature only constrains folder and format — Cloudinary has no signable
+ * size parameter — so the byte limit is enforced here, before we ask for one.
+ */
+export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024
+
+export class UploadsUnavailableError extends Error {
+  constructor() {
+    super('Image uploads are not set up on this server.')
+    this.name = 'UploadsUnavailableError'
+  }
+}
+
+export const uploadsApi = {
+  signature: (folder: UploadFolder) =>
+    request<UploadSignature>(`/api/v1/uploads/signature?folder=${folder}`, { method: 'POST' }),
+}
+
+/**
+ * Signature from our API, bytes straight to Cloudinary. Resolves to the public
+ * ID, which is what gets persisted — never the delivery URL, so the host can
+ * change without rewriting documents.
+ *
+ * This is the one place the client talks to a third-party origin, which is why
+ * it uses `fetch` directly instead of the same-origin `request` wrapper.
+ */
+export async function uploadImage(file: File, folder: UploadFolder): Promise<string> {
+  if (file.size > MAX_UPLOAD_BYTES) {
+    throw new Error(`That image is ${(file.size / 1024 / 1024).toFixed(1)} MB. The limit is 5 MB.`)
+  }
+
+  let signed: UploadSignature
+  try {
+    // `request` resolves undefined on a 204; a signature route never sends one.
+    const issued = await uploadsApi.signature(folder)
+    if (!issued) throw new Error('The server issued no upload signature.')
+    signed = issued
+  } catch (err) {
+    // 503 is the deployment saying it has no Cloudinary account, not a failure
+    // the reader can retry — the caller shows a different message for it.
+    if (err instanceof ApiError && err.status === 503) throw new UploadsUnavailableError()
+    throw err
+  }
+
+  const form = new FormData()
+  form.append('file', file)
+  form.append('api_key', signed.apiKey)
+  form.append('timestamp', String(signed.timestamp))
+  form.append('folder', signed.folder)
+  form.append('allowed_formats', signed.allowedFormats)
+  form.append('signature', signed.signature)
+
+  // No credentials: this is a third-party origin and our session cookie has no
+  // business being sent to it.
+  const res = await fetch(`https://api.cloudinary.com/v1_1/${signed.cloudName}/image/upload`, {
+    method: 'POST',
+    body: form,
+  })
+
+  const payload: unknown = await res.json().catch(() => null)
+  if (!res.ok) {
+    const message =
+      typeof payload === 'object' && payload !== null && 'error' in payload
+        ? String((payload as { error: { message?: string } }).error?.message ?? '')
+        : ''
+    throw new Error(message || 'Cloudinary rejected the upload.')
+  }
+
+  const publicId =
+    typeof payload === 'object' && payload !== null && 'public_id' in payload
+      ? (payload as { public_id?: unknown }).public_id
+      : undefined
+  if (typeof publicId !== 'string') throw new Error('Cloudinary returned no public ID.')
+  return publicId
+}

--- a/apps/client/src/components/layouts/PageShell.tsx
+++ b/apps/client/src/components/layouts/PageShell.tsx
@@ -1,5 +1,8 @@
-import { Link, useNavigate } from 'react-router'
+import { Link, NavLink, useNavigate } from 'react-router'
 import { useLogout, useMe } from '../../hooks/use-auth.js'
+
+const navLink =
+  'border-b-[1.5px] border-transparent pb-1 hover:text-[var(--foreground)] aria-[current=page]:border-[var(--primary)] aria-[current=page]:text-[var(--primary)]'
 
 export function PageShell({ children }: { children: React.ReactNode }) {
   const { data: me } = useMe()
@@ -7,48 +10,61 @@ export function PageShell({ children }: { children: React.ReactNode }) {
   const logout = useLogout()
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--background)] text-[var(--foreground)]">
-      <header className="border-b border-[var(--border)] py-4">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-4">
-          <Link to="/" className="text-lg font-semibold">
-            Blog
+    <div className="min-h-screen bg-[var(--background)] px-3 py-4 text-[var(--foreground)] sm:px-6 sm:py-10">
+      {/* The content sits on a raised sheet, so the tinted paper reads as a
+          surround rather than as the page's own background. */}
+      <div className="mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-6xl flex-col gap-10 bg-[var(--sheet)] px-5 py-6 shadow-[0_1px_2px_#14161d0a,0_18px_50px_-24px_#14161d3d] sm:gap-14 sm:px-12 sm:py-10">
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <Link
+            to="/"
+            aria-label="Home"
+            className="grid size-8 place-items-center border-[1.5px] border-[var(--foreground)] font-display text-sm tracking-[-0.02em]"
+          >
+            B
           </Link>
-          <nav className="flex gap-4">
+
+          <nav
+            aria-label="Primary"
+            className="flex flex-wrap items-center gap-4 font-mono text-xs tracking-[0.11em] text-[var(--muted-foreground)] uppercase sm:gap-7"
+          >
+            <NavLink to="/" end className={navLink}>
+              Blog
+            </NavLink>
             {me ? (
               <>
-                <span className="text-sm">Welcome, {me.username}</span>
-                <Link to="/blog/new" className="text-sm hover:underline">
-                  New Post
-                </Link>
-                <Link to="/chat" className="text-sm hover:underline">
+                <NavLink to="/chat" className={navLink}>
                   Chat
-                </Link>
+                </NavLink>
+                <NavLink to="/blog/new" className={navLink}>
+                  New post
+                </NavLink>
+                <span aria-hidden="true" className="h-4 w-px bg-[var(--border)]" />
+                <span className="text-[var(--ink-faint)]">{me.username}</span>
                 {/* There is no /logout route — logging out is a POST, not a
                     page. Navigating there rendered a dead end. */}
                 <button
                   onClick={() => logout.mutate(undefined, { onSuccess: () => navigate('/') })}
                   disabled={logout.isPending}
-                  className="text-sm hover:underline"
+                  className="border-b-[1.5px] border-transparent pb-1 uppercase hover:text-[var(--foreground)]"
                 >
-                  Logout
+                  Log out
                 </button>
               </>
             ) : (
               <>
-                <Link to="/login" className="text-sm hover:underline">
-                  Login
-                </Link>
-                <Link to="/signup" className="text-sm hover:underline">
+                <NavLink to="/login" className={navLink}>
+                  Log in
+                </NavLink>
+                <NavLink to="/signup" className={navLink}>
                   Sign up
-                </Link>
+                </NavLink>
               </>
             )}
           </nav>
-        </div>
-      </header>
-      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-8">
-        {children}
-      </main>
+        </header>
+
+        <main className="flex-1">{children}</main>
+      </div>
     </div>
   )
 }

--- a/apps/client/src/components/patterns/AutoForm.tsx
+++ b/apps/client/src/components/patterns/AutoForm.tsx
@@ -4,9 +4,10 @@ import { Button } from '../ui/button.js'
 import { Input } from '../ui/input.js'
 import { Label } from '../ui/label.js'
 import { Textarea } from '../ui/textarea.js'
+import { ImageUpload } from './ImageUpload.js'
 import { TagsInput } from './TagsInput.js'
 
-type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'text'
+type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'image' | 'text'
 
 /**
  * `ZodTypeDef` is the public (near-empty) shape of `_def`; the discriminant and
@@ -49,6 +50,9 @@ function fieldKind(key: string, schema: ZodTypeAny): FieldKind {
   if (typeName === ZodFirstPartyTypeKind.ZodBoolean) return 'checkbox'
   if (typeName === ZodFirstPartyTypeKind.ZodArray) return 'tags'
   if (key === 'body') return 'textarea'
+  // Keyed by name, not by type: a public ID is a plain string to zod, and a raw
+  // text box for one would be unusable — nobody types a Cloudinary ID by hand.
+  if (key === 'coverImage' || key === 'avatar') return 'image'
   return 'text'
 }
 
@@ -62,11 +66,14 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
   initialValues,
   onSubmit,
   submitLabel = 'Save',
+  imagePreviewUrl,
 }: {
   schema: S
   initialValues?: Partial<z.infer<S>>
   onSubmit: (values: z.infer<S>) => void
   submitLabel?: string
+  /** Delivery URL for an already-saved image — the form holds only its ID. */
+  imagePreviewUrl?: string
 }) {
   // Derived once, up front: `schema.shape` is indexed by an open `string` key,
   // so re-reading it per render would fight `noUncheckedIndexedAccess`.
@@ -74,7 +81,7 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
     ([key, fieldSchema]) => ({ key, kind: fieldKind(key, fieldSchema) }),
   )
 
-  const [values, setValues] = useState<Record<string, string | boolean | string[]>>(() => {
+  const [values, setValues] = useState<Record<string, string | boolean | string[] | null>>(() => {
     const initial = (initialValues ?? {}) as Record<string, unknown>
     return Object.fromEntries(
       fields.map(({ key, kind }) => {
@@ -84,6 +91,10 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
             return [key, Boolean(seed ?? false)]
           case 'tags':
             return [key, Array.isArray(seed) ? seed.map(String) : []]
+          // null, never '': an empty string is not a valid public ID and would
+          // fail the schema on every submit that leaves the image blank.
+          case 'image':
+            return [key, typeof seed === 'string' ? seed : null]
           default:
             return [key, typeof seed === 'string' ? seed : '']
         }
@@ -117,8 +128,17 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
       {fields.map(({ key, kind }) => {
         return (
           <div key={key} className="flex flex-col gap-1">
-            <Label htmlFor={key}>{key}</Label>
-            {kind === 'checkbox' ? (
+            {/* ImageUpload renders its own label and controls. */}
+            {kind !== 'image' && <Label htmlFor={key}>{key}</Label>}
+            {kind === 'image' ? (
+              <ImageUpload
+                value={typeof values[key] === 'string' ? (values[key] as string) : null}
+                previewUrl={imagePreviewUrl}
+                folder={key === 'avatar' ? 'avatars' : 'covers'}
+                label={key === 'avatar' ? 'Avatar' : 'Cover image'}
+                onChange={(publicId) => setValues((v) => ({ ...v, [key]: publicId }))}
+              />
+            ) : kind === 'checkbox' ? (
               <input
                 id={key}
                 type="checkbox"

--- a/apps/client/src/components/patterns/CommentForm.tsx
+++ b/apps/client/src/components/patterns/CommentForm.tsx
@@ -93,7 +93,7 @@ export function CommentForm({
       ) : (
         <div
           role="tabpanel"
-          className="min-h-32 rounded-md border border-[var(--border)] p-3 text-sm"
+          className="min-h-32 border border-[var(--border)] p-3 text-sm"
         >
           {body.trim() ? (
             <MarkdownPreview source={body} />

--- a/apps/client/src/components/patterns/CommentThread.tsx
+++ b/apps/client/src/components/patterns/CommentThread.tsx
@@ -52,7 +52,7 @@ function CommentItem({ slug, node, depth }: { slug: string; node: CommentNode; d
 
   return (
     <li className="flex flex-col gap-2">
-      <article className="flex flex-col gap-1 rounded-md border border-[var(--border)] p-3">
+      <article className="flex flex-col gap-1 border border-[var(--border)] p-3">
         <header className="text-xs text-[var(--muted-foreground)]">
           {node.author.username} · {new Date(node.createdAt).toLocaleDateString()}
         </header>

--- a/apps/client/src/components/patterns/ImageUpload.tsx
+++ b/apps/client/src/components/patterns/ImageUpload.tsx
@@ -1,0 +1,110 @@
+import { useId, useRef, useState } from 'react'
+import { uploadImage, UploadsUnavailableError, type UploadFolder } from '../../api/uploads.js'
+import { Button } from '../ui/button.js'
+
+/**
+ * Optional image picker. Uploads straight to Cloudinary and reports the public
+ * ID; `null` means the author cleared it. A post with no image is not an error
+ * state — it falls back to art generated from its slug.
+ */
+export function ImageUpload({
+  value,
+  previewUrl,
+  onChange,
+  folder = 'covers',
+  label = 'Cover image',
+}: {
+  value?: string | null
+  previewUrl?: string
+  onChange: (publicId: string | null) => void
+  folder?: UploadFolder
+  label?: string
+}) {
+  const inputId = useId()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string>()
+  // A local object URL shows the picked file immediately; the server's delivery
+  // URL only exists after the post is saved.
+  const [localPreview, setLocalPreview] = useState<string>()
+
+  const shown = localPreview ?? previewUrl
+
+  async function handleFile(file: File) {
+    setBusy(true)
+    setError(undefined)
+    try {
+      const publicId = await uploadImage(file, folder)
+      setLocalPreview(URL.createObjectURL(file))
+      onChange(publicId)
+    } catch (err) {
+      setError(
+        err instanceof UploadsUnavailableError
+          ? 'Image uploads are not set up on this server. Your post will use its generated cover.'
+          : err instanceof Error
+            ? err.message
+            : 'That image could not be uploaded.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function clear() {
+    setLocalPreview(undefined)
+    setError(undefined)
+    onChange(null)
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="font-mono text-xs tracking-[0.09em] text-[var(--muted-foreground)] uppercase">
+        {label} <span className="text-[var(--ink-faint)]">— optional</span>
+      </span>
+
+      {shown && (
+        <img
+          src={shown}
+          alt=""
+          className="aspect-[16/10] w-full max-w-md border border-[var(--border)] object-cover"
+        />
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/avif"
+          className="sr-only"
+          onChange={(e) => {
+            const file = e.target.files?.[0]
+            if (file) void handleFile(file)
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          onClick={() => inputRef.current?.click()}
+        >
+          {busy ? 'Uploading…' : shown ? 'Replace image' : 'Choose image'}
+        </Button>
+        {(shown || value) && (
+          <Button type="button" variant="ghost" size="sm" onClick={clear} disabled={busy}>
+            Remove
+          </Button>
+        )}
+      </div>
+
+      <p className="text-xs text-[var(--muted-foreground)]">
+        JPG, PNG, WebP or AVIF, up to 5 MB. Leave this empty to use the cover generated from the
+        post&rsquo;s title.
+      </p>
+
+      {error && <p className="text-xs text-[var(--destructive)]">{error}</p>}
+    </div>
+  )
+}

--- a/apps/client/src/components/patterns/PostCard.tsx
+++ b/apps/client/src/components/patterns/PostCard.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router'
 import type { Post } from '../../api/posts.js'
-import { Card } from '../ui/card.js'
+import { formatDate } from '../../lib/format-date.js'
+import { cn } from '../../lib/cn.js'
+import { PostTile } from './PostTile.js'
 
 /**
  * A feed entry. `post.body` is always a teaser here — the list endpoint never
@@ -8,40 +10,99 @@ import { Card } from '../ui/card.js'
  * `post.gated` is the server's verdict on whether this reader may open the post;
  * the card only relays it (spec §6), it does not decide it.
  */
-export function PostCard({ post }: { post: Post }) {
-  return (
-    <Card className="flex flex-col gap-2">
-      <Link to={`/blog/${post.slug}`} className="text-lg font-semibold hover:underline">
-        {post.title}
+export function PostCard({ post, featured = false }: { post: Post; featured?: boolean }) {
+  const meta = (
+    <p className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase tabular-nums">
+      <time dateTime={post.createdAt}>{formatDate(post.createdAt)}</time>
+      <span aria-hidden="true">·</span>
+      <span>{post.author.username}</span>
+      <span aria-hidden="true">·</span>
+      <span>
+        {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
+      </span>
+    </p>
+  )
+
+  // The tile is decorative and duplicates the headline's destination, so it is
+  // kept out of the a11y tree — the headline link is the one real way in.
+  const tile = (
+    <div className="relative">
+      <Link to={`/blog/${post.slug}`} aria-hidden="true" tabIndex={-1} className="group block">
+        <PostTile
+          slug={post.slug}
+          className="transition-opacity duration-200 group-hover:opacity-85"
+        />
       </Link>
-
-      <p className="text-sm whitespace-pre-wrap text-[var(--muted-foreground)]">{post.body}</p>
-
       {post.gated && (
-        <p className="text-sm">
-          <Link to="/login" className="text-[var(--primary)] hover:underline">
-            Sign in to read
-          </Link>{' '}
-          the full post.
-        </p>
+        <Link
+          to="/login"
+          className="absolute bottom-2 left-2 inline-flex items-center gap-1.5 bg-[var(--sheet)] px-2 py-1 font-mono text-[0.66rem] tracking-[0.11em] text-[var(--muted-foreground)] uppercase hover:text-[var(--primary)]"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            aria-hidden="true"
+            className="size-3"
+          >
+            <rect x="4" y="10" width="16" height="11" rx="1" />
+            <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+          </svg>
+          Sign in to read
+        </Link>
       )}
+    </div>
+  )
+
+  const body = (
+    <div className="flex flex-col gap-2.5">
+      {meta}
+      <h3
+        className={cn(
+          'font-display leading-none tracking-[-0.035em] text-balance',
+          featured ? 'text-3xl md:text-4xl' : 'text-xl',
+        )}
+      >
+        <Link to={`/blog/${post.slug}`} className="hover:text-[var(--primary)]">
+          {post.title}
+        </Link>
+      </h3>
+
+      <p className="line-clamp-3 max-w-[58ch] whitespace-pre-wrap text-[var(--muted-foreground)]">
+        {post.body}
+      </p>
 
       {post.tags.length > 0 && (
-        <ul className="flex flex-wrap gap-2">
+        <ul className="flex flex-wrap gap-1.5 font-mono text-[0.68rem] tracking-[0.09em] uppercase">
           {post.tags.map((tag) => (
-            <li
-              key={tag}
-              className="rounded bg-[var(--muted)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
-            >
+            <li key={tag} className="bg-[var(--primary-wash)] px-1.5 py-0.5 text-[var(--primary)]">
               {tag}
             </li>
           ))}
         </ul>
       )}
 
-      <p className="text-xs text-[var(--muted-foreground)]">
-        by {post.author.username} · {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}
-      </p>
-    </Card>
+      {featured && (
+        <Link
+          to={`/blog/${post.slug}`}
+          className="mt-1 inline-flex items-center gap-2 self-start border-b-[1.5px] border-[var(--primary)] pb-0.5 font-mono text-xs tracking-[0.11em] text-[var(--primary)] uppercase"
+        >
+          Read the post <span aria-hidden="true">→</span>
+        </Link>
+      )}
+    </div>
+  )
+
+  return featured ? (
+    <article className="grid items-center gap-6 md:grid-cols-[1.35fr_1fr] md:gap-10">
+      {tile}
+      {body}
+    </article>
+  ) : (
+    <article className="flex flex-col gap-3">
+      {tile}
+      {body}
+    </article>
   )
 }

--- a/apps/client/src/components/patterns/PostCard.tsx
+++ b/apps/client/src/components/patterns/PostCard.tsx
@@ -30,6 +30,7 @@ export function PostCard({ post, featured = false }: { post: Post; featured?: bo
       <Link to={`/blog/${post.slug}`} aria-hidden="true" tabIndex={-1} className="group block">
         <PostTile
           slug={post.slug}
+          coverUrl={post.coverUrl}
           className="transition-opacity duration-200 group-hover:opacity-85"
         />
       </Link>

--- a/apps/client/src/components/patterns/PostTile.tsx
+++ b/apps/client/src/components/patterns/PostTile.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useRef } from 'react'
+import { cn } from '../../lib/cn.js'
+
+/**
+ * Generated cover art for a post, drawn from a hash of its slug — same slug,
+ * same drawing, forever. Stands in the exact slot a real cover image will
+ * occupy once uploads land (P5), so the layout does not move when it does.
+ */
+
+const PENS = ['--pen-0', '--pen-1', '--pen-2', '--pen-3', '--pen-4'] as const
+
+function hash(str: string): number {
+  let h = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
+    return s / 4294967296
+  }
+}
+
+// #RRGGBB -> rgba(), so one pen token can serve both the wash and the linework.
+function rgba(hex: string, alpha: number): string {
+  let v = hex.trim().replace('#', '')
+  if (v.length === 3) v = v[0] + v[0] + v[1] + v[1] + v[2] + v[2]
+  const n = Number.parseInt(v, 16)
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${alpha})`
+}
+
+type Motif = (ctx: CanvasRenderingContext2D, w: number, h: number, rnd: () => number) => void
+
+// Line counts are tuned for a wide featured tile; at grid width the same count
+// collapses into moiré, so every motif scales its density by this.
+function density(w: number): number {
+  return Math.min(1, Math.max(0.55, w / 620))
+}
+
+const arcs: Motif = (ctx, w, h, rnd) => {
+  const ox = rnd() < 0.5 ? w * 0.08 : w * 0.92
+  const oy = h * (0.15 + rnd() * 0.7)
+  const count = Math.round((26 + rnd() * 14) * density(w))
+  const step = (Math.max(w, h) * 1.25) / count
+  for (let i = 1; i <= count; i++) {
+    ctx.beginPath()
+    ctx.lineWidth = i % 5 === 0 ? 2 : 0.9
+    ctx.arc(ox, oy, step * i * (0.85 + rnd() * 0.3), 0, Math.PI * 2)
+    ctx.stroke()
+  }
+}
+
+const isogrid: Motif = (ctx, w, h, rnd) => {
+  const cell = w / Math.round((10 + rnd() * 5) * density(w))
+  const skew = 0.45 + rnd() * 0.25
+  for (let x = -h; x < w + h; x += cell) {
+    ctx.lineWidth = 0.9
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x + h * skew, h)
+    ctx.stroke()
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x - h * skew, h)
+    ctx.stroke()
+  }
+  for (let k = 0; k < 3; k++) {
+    const cx = w * (0.2 + rnd() * 0.6)
+    const cy = h * (0.2 + rnd() * 0.6)
+    const r = cell * (0.8 + rnd())
+    ctx.beginPath()
+    ctx.moveTo(cx, cy - r)
+    ctx.lineTo(cx + r * skew * 2, cy)
+    ctx.lineTo(cx, cy + r)
+    ctx.lineTo(cx - r * skew * 2, cy)
+    ctx.closePath()
+    ctx.fill()
+  }
+}
+
+const strata: Motif = (ctx, w, h, rnd) => {
+  const bands = Math.round((28 + rnd() * 14) * density(w))
+  for (let i = 0; i < bands; i++) {
+    const y = (h / bands) * i + h / bands / 2
+    const amp = h * 0.03 * (0.3 + rnd() * 2.2)
+    const freq = (1.2 + rnd() * 2.4) * Math.PI * 2
+    const phase = rnd() * Math.PI * 2
+    ctx.beginPath()
+    ctx.lineWidth = i % 6 === 0 ? 2 : 0.9
+    for (let x = 0; x <= w; x += 3) {
+      const yy = y + Math.sin((x / w) * freq + phase) * amp
+      if (x === 0) ctx.moveTo(x, yy)
+      else ctx.lineTo(x, yy)
+    }
+    ctx.stroke()
+  }
+}
+
+const spokes: Motif = (ctx, w, h, rnd) => {
+  const cx = w * (0.25 + rnd() * 0.5)
+  const cy = h * (0.25 + rnd() * 0.5)
+  const count = Math.round((56 + rnd() * 34) * density(w))
+  const reach = Math.hypot(w, h)
+  for (let i = 0; i < count; i++) {
+    const a = (i / count) * Math.PI * 2
+    ctx.beginPath()
+    ctx.lineWidth = i % 8 === 0 ? 1.8 : 0.8
+    ctx.moveTo(cx + Math.cos(a) * reach * 0.06, cy + Math.sin(a) * reach * 0.06)
+    ctx.lineTo(cx + Math.cos(a) * reach, cy + Math.sin(a) * reach)
+    ctx.stroke()
+  }
+  // Concentric rings across the spokes — a solid wedge here read as a pie
+  // chart and swallowed the tile.
+  for (let r = 1; r <= 5; r++) {
+    ctx.beginPath()
+    ctx.lineWidth = r === 3 ? 2 : 0.9
+    ctx.arc(cx, cy, reach * 0.09 * r * (0.9 + rnd() * 0.35), 0, Math.PI * 2)
+    ctx.stroke()
+  }
+}
+
+const nest: Motif = (ctx, w, h, rnd) => {
+  const count = Math.round((30 + rnd() * 16) * density(w))
+  const turn = (rnd() - 0.5) * 0.06
+  ctx.save()
+  ctx.translate(w / 2, h / 2)
+  for (let i = count; i > 0; i--) {
+    const sw = (w * 1.15 * i) / count
+    const sh = (h * 1.15 * i) / count
+    ctx.rotate(turn)
+    ctx.beginPath()
+    ctx.lineWidth = i % 5 === 0 ? 2 : 0.9
+    ctx.rect(-sw / 2, -sh / 2, sw, sh)
+    ctx.stroke()
+  }
+  ctx.restore()
+}
+
+const MOTIFS: Motif[] = [arcs, isogrid, strata, spokes, nest]
+
+export function PostTile({ slug, className }: { slug: string; className?: string }) {
+  const ref = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return
+
+    const draw = () => {
+      // Nothing laid out yet (or jsdom, which reports 0×0) — no context needed.
+      const rect = canvas.getBoundingClientRect()
+      if (!rect.width || !rect.height) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
+      const w = Math.round(rect.width)
+      const h = Math.round(rect.height)
+      canvas.width = w * dpr
+      canvas.height = h * dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      ctx.clearRect(0, 0, w, h)
+
+      const css = getComputedStyle(document.documentElement)
+      // Three independent hashes: sharing one made motif and pen move together,
+      // so neighbouring posts kept drawing the same figure in the same colour.
+      const seed = hash(slug)
+      const motif = MOTIFS[hash(`${slug}#motif`) % MOTIFS.length]
+      const pen = css.getPropertyValue(PENS[hash(`${slug}#pen`) % PENS.length]) || '#0f5d57'
+      const wash = Number.parseFloat(css.getPropertyValue('--tile-wash')) || 0.07
+      const line = Number.parseFloat(css.getPropertyValue('--tile-line')) || 0.72
+
+      ctx.fillStyle = css.getPropertyValue('--sheet') || '#fff'
+      ctx.fillRect(0, 0, w, h)
+      ctx.fillStyle = rgba(pen, wash)
+      ctx.fillRect(0, 0, w, h)
+
+      ctx.save()
+      ctx.beginPath()
+      ctx.rect(0, 0, w, h)
+      ctx.clip()
+      ctx.strokeStyle = rgba(pen, line)
+      ctx.fillStyle = rgba(pen, line)
+      ctx.lineJoin = 'round'
+      motif(ctx, w, h, makeRng(seed))
+      ctx.restore()
+    }
+
+    draw()
+
+    if (typeof ResizeObserver === 'undefined') return
+    let pending = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(pending)
+      pending = requestAnimationFrame(draw)
+    })
+    observer.observe(canvas)
+    return () => {
+      cancelAnimationFrame(pending)
+      observer.disconnect()
+    }
+  }, [slug])
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden="true"
+      className={cn('block aspect-[16/10] w-full bg-[var(--muted)]', className)}
+    />
+  )
+}

--- a/apps/client/src/components/patterns/PostTile.tsx
+++ b/apps/client/src/components/patterns/PostTile.tsx
@@ -143,11 +143,23 @@ const nest: Motif = (ctx, w, h, rnd) => {
 
 const MOTIFS: Motif[] = [arcs, isogrid, strata, spokes, nest]
 
-export function PostTile({ slug, className }: { slug: string; className?: string }) {
+export function PostTile({
+  slug,
+  coverUrl,
+  alt = '',
+  className,
+}: {
+  slug: string
+  /** An uploaded cover, if the author added one. Optional by design. */
+  coverUrl?: string
+  alt?: string
+  className?: string
+}) {
   const ref = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     const canvas = ref.current
+    // Nothing to draw when a real cover is showing — the canvas is not mounted.
     if (!canvas) return
 
     const draw = () => {
@@ -204,6 +216,17 @@ export function PostTile({ slug, className }: { slug: string; className?: string
       observer.disconnect()
     }
   }, [slug])
+
+  if (coverUrl) {
+    return (
+      <img
+        src={coverUrl}
+        alt={alt}
+        loading="lazy"
+        className={cn('block aspect-[16/10] w-full bg-[var(--muted)] object-cover', className)}
+      />
+    )
+  }
 
   return (
     <canvas

--- a/apps/client/src/components/patterns/PostTile.tsx
+++ b/apps/client/src/components/patterns/PostTile.tsx
@@ -29,7 +29,9 @@ function makeRng(seed: number): () => number {
 // #RRGGBB -> rgba(), so one pen token can serve both the wash and the linework.
 function rgba(hex: string, alpha: number): string {
   let v = hex.trim().replace('#', '')
-  if (v.length === 3) v = v[0] + v[0] + v[1] + v[1] + v[2] + v[2]
+  // Doubling each char rather than indexing: under noUncheckedIndexedAccess
+  // every v[n] is string | undefined, which this expression cannot use.
+  if (v.length === 3) v = v.replace(/./g, (c) => c + c)
   const n = Number.parseInt(v, 16)
   return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${alpha})`
 }
@@ -169,8 +171,12 @@ export function PostTile({ slug, className }: { slug: string; className?: string
       // Three independent hashes: sharing one made motif and pen move together,
       // so neighbouring posts kept drawing the same figure in the same colour.
       const seed = hash(slug)
-      const motif = MOTIFS[hash(`${slug}#motif`) % MOTIFS.length]
-      const pen = css.getPropertyValue(PENS[hash(`${slug}#pen`) % PENS.length]) || '#0f5d57'
+      // The `??` fallbacks are unreachable — a positive modulo is always in
+      // range — but noUncheckedIndexedAccess cannot know that, and asserting
+      // non-null would hide a real out-of-range bug if these lists ever change.
+      const motif = MOTIFS[hash(`${slug}#motif`) % MOTIFS.length] ?? arcs
+      const penToken = PENS[hash(`${slug}#pen`) % PENS.length] ?? PENS[0]
+      const pen = css.getPropertyValue(penToken) || '#0f5d57'
       const wash = Number.parseFloat(css.getPropertyValue('--tile-wash')) || 0.07
       const line = Number.parseFloat(css.getPropertyValue('--tile-line')) || 0.72
 

--- a/apps/client/src/components/ui/button.tsx
+++ b/apps/client/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type ButtonHTMLAttributes } from 'react'
 import { cn } from '../../lib/cn.js'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center rounded-none text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/apps/client/src/components/ui/card.tsx
+++ b/apps/client/src/components/ui/card.tsx
@@ -2,5 +2,7 @@ import type { HTMLAttributes } from 'react'
 import { cn } from '../../lib/cn.js'
 
 export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('rounded-lg border border-[var(--border)] p-4', className)} {...props} />
+  return (
+    <div className={cn('rounded-none border border-[var(--border)] p-4', className)} {...props} />
+  )
 }

--- a/apps/client/src/components/ui/input.tsx
+++ b/apps/client/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputE
     <input
       ref={ref}
       className={cn(
-        'h-10 w-full rounded-md border border-[var(--border)] bg-transparent px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
+        'h-10 w-full rounded-none border border-[var(--border)] bg-transparent px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
         className,
       )}
       {...props}

--- a/apps/client/src/components/ui/skeleton.tsx
+++ b/apps/client/src/components/ui/skeleton.tsx
@@ -2,5 +2,5 @@ import type { HTMLAttributes } from 'react'
 import { cn } from '../../lib/cn.js'
 
 export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-[var(--muted)]', className)} {...props} />
+  return <div className={cn('animate-pulse rounded-none bg-[var(--muted)]', className)} {...props} />
 }

--- a/apps/client/src/components/ui/textarea.tsx
+++ b/apps/client/src/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<H
     <textarea
       ref={ref}
       className={cn(
-        'min-h-32 w-full rounded-md border border-[var(--border)] bg-transparent p-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
+        'min-h-32 w-full rounded-none border border-[var(--border)] bg-transparent p-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]',
         className,
       )}
       {...props}

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -2,18 +2,46 @@
    no postcss.config.js. Light theme only (spec §2) — no .dark block. */
 @import 'tailwindcss';
 
+/* Font roles as Tailwind utilities: font-display, font-body, font-mono.
+   No webfont is loaded, so nothing can silently fall back to a wrong face. */
+@theme {
+  --font-display: 'Arial Black', 'Archivo Black', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-body: 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif;
+  --font-mono: ui-monospace, 'Cascadia Mono', 'Cascadia Code', Consolas, 'SF Mono', Menlo, monospace;
+}
+
 :root {
-  --background: oklch(0.98 0.051 105);       /* #FDFBD4 cream */
-  --foreground: oklch(0.28 0.047 67.5);      /* #38240D espresso */
-  --primary: oklch(0.581 0.155 49.5);        /* #C05800 burnt orange */
-  --primary-foreground: oklch(0.98 0.051 105); /* cream, for text on the orange primary */
-  --border: oklch(0.87 0.035 55);            /* light tan, same hue family as rust/orange */
-  --muted: oklch(0.94 0.025 60);             /* pale tan panel background */
-  --muted-foreground: oklch(0.403 0.101 53.8); /* #713600 rust */
-  --destructive: oklch(0.58 0.24 27);        /* red-orange, kept — already warm, harmonizes */
+  --background: #e7eaf1; /* paper — blue-shifted, so the neutral reads as chosen */
+  --sheet: #fafbfd; /* the contained page the content sits on */
+  --foreground: #14161d; /* ink — blue-black, not pure black */
+  --primary: #0f5d57; /* signal pine — links, active nav, focus */
+  --primary-foreground: #fafbfd;
+  --primary-wash: #0f5d5714; /* the same pine at 8% — tag chips, quiet fills */
+  --border: #d8dce4; /* hairline rule */
+  --muted: #eef0f5; /* pale panel */
+  --muted-foreground: #59606e; /* body grey, blue-biased to match the ink */
+  --ink-faint: #8a91a0; /* metadata, third-level text */
+  --destructive: #a82d42; /* oxblood — warm enough to read as danger, cool enough to belong */
+
+  /* Plotter pens for the generated post tiles. One is picked per post from a
+     hash of its slug, so a post's cover art never changes. */
+  --pen-0: #0f5d57;
+  --pen-1: #28356b;
+  --pen-2: #8a6a16;
+  --pen-3: #7a2e3b;
+  --pen-4: #3a414e;
+  --tile-wash: 0.1; /* alpha of the flat pen tint behind the linework */
+  --tile-line: 0.9; /* alpha of the linework itself */
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
 }

--- a/apps/client/src/lib/format-date.ts
+++ b/apps/client/src/lib/format-date.ts
@@ -1,0 +1,12 @@
+// Fixed en-GB so the feed's date column stays one width regardless of locale —
+// the metadata is set in a monospace face and lines up between cards.
+const formatter = new Intl.DateTimeFormat('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+})
+
+export function formatDate(iso: string): string {
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime()) ? '' : formatter.format(date)
+}

--- a/apps/client/src/pages/BlogFeedPage.tsx
+++ b/apps/client/src/pages/BlogFeedPage.tsx
@@ -45,13 +45,18 @@ export function BlogFeedPage() {
 
   const handleSearch = (next: string) => setTerm(next)
 
+  // Only the unfiltered feed has a lead story. Among search results the first
+  // hit is just the first hit, so promoting it would be a false claim.
+  const lead = !debouncedTerm && posts?.length ? posts[0] : undefined
+  const rest = lead ? posts!.slice(1) : (posts ?? [])
+
   let content: ReactNode
   if (isPending) {
     content = (
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-32" />
-        <Skeleton className="h-32" />
-        <Skeleton className="h-32" />
+      <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="aspect-[16/10]" />
+        <Skeleton className="aspect-[16/10]" />
+        <Skeleton className="aspect-[16/10]" />
       </div>
     )
   } else if (isError) {
@@ -62,21 +67,48 @@ export function BlogFeedPage() {
     )
   } else {
     content = (
-      <div className="flex flex-col gap-4">
-        {posts.map((post) => (
+      <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+        {rest.map((post) => (
           <PostCard key={post.id} post={post} />
         ))}
       </div>
     )
   }
 
-  // The search box is outside every branch on purpose: it must stay on screen
-  // while results load and, above all, when a search returns nothing — hiding
-  // it there would leave the reader stranded with no way to change the term.
+  // The band header carries the search box, and both sit outside every branch
+  // on purpose: the box must stay on screen while results load and, above all,
+  // when a search returns nothing — hiding it there would leave the reader
+  // stranded with no way to change the term.
   return (
-    <div className="flex flex-col gap-6">
-      <SearchBar value={term} onChange={handleSearch} />
-      {content}
+    <div className="flex flex-col gap-12">
+      <div className="flex flex-col gap-5">
+        <h1 className="font-display text-[clamp(3rem,8vw,6rem)] leading-[0.86] tracking-[-0.045em] text-balance">
+          The Blog
+        </h1>
+        <p className="max-w-[46ch] text-lg text-[var(--muted-foreground)]">
+          Notes from rebuilding a five-year-old MERN app as an Express and React monorepo — one
+          decision at a time.
+        </p>
+      </div>
+
+      {lead && <PostCard post={lead} featured />}
+
+      <section className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-b border-[var(--border)] pb-3">
+          <h2 className="flex items-baseline gap-3 font-mono text-xs tracking-[0.11em] text-[var(--ink-faint)] uppercase">
+            {debouncedTerm ? 'Results' : 'Recent writing'}
+            {!isPending && !isError && (
+              <span className="tabular-nums">
+                {rest.length} {rest.length === 1 ? 'post' : 'posts'}
+              </span>
+            )}
+          </h2>
+          <div className="w-full sm:w-64">
+            <SearchBar value={term} onChange={handleSearch} />
+          </div>
+        </div>
+        {content}
+      </section>
     </div>
   )
 }

--- a/apps/client/src/pages/EditPostPage.tsx
+++ b/apps/client/src/pages/EditPostPage.tsx
@@ -29,6 +29,7 @@ export function EditPostPage() {
           schema={UpdatePostSchema}
           initialValues={post}
           submitLabel="Save changes"
+          imagePreviewUrl={post.coverUrl}
           onSubmit={(values) =>
             updatePost.mutate(values, {
               // The slug is derived from the title, so it may have changed —

--- a/apps/client/src/pages/LoginPage.tsx
+++ b/apps/client/src/pages/LoginPage.tsx
@@ -23,7 +23,7 @@ export function LoginPage() {
 
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="w-full max-w-md p-8 space-y-6 border border-[var(--border)] rounded-lg">
+      <div className="w-full max-w-md space-y-6 border border-[var(--border)] p-8">
         <h1 className="text-2xl font-bold">Login</h1>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -6,8 +6,10 @@ import { useMe } from '../hooks/use-auth.js'
 import { CommentSection } from '../components/patterns/CommentSection.js'
 import { EmptyState } from '../components/patterns/EmptyState.js'
 import { LikeButton } from '../components/patterns/LikeButton.js'
+import { PostTile } from '../components/patterns/PostTile.js'
 import { Button } from '../components/ui/button.js'
 import { Skeleton } from '../components/ui/skeleton.js'
+import { formatDate } from '../lib/format-date.js'
 
 /**
  * The post detail page. `post.gated` is the server's verdict that this reader is
@@ -29,13 +31,21 @@ export function PostPage() {
   const isOwner = me?.id === post.author.id
 
   return (
-    <article className="flex flex-col gap-4">
-      <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold">{post.title}</h1>
-        <p className="text-sm text-[var(--muted-foreground)]">by {post.author.username}</p>
+    <article className="flex max-w-3xl flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <p className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase tabular-nums">
+          <time dateTime={post.createdAt}>{formatDate(post.createdAt)}</time>
+          <span aria-hidden="true">·</span>
+          <span>{post.author.username}</span>
+        </p>
+        <h1 className="font-display text-[clamp(2rem,5vw,3.25rem)] leading-[0.95] tracking-[-0.04em] text-balance">
+          {post.title}
+        </h1>
       </header>
 
-      <div className="whitespace-pre-wrap">{post.body}</div>
+      <PostTile slug={post.slug} className="aspect-[21/9]" />
+
+      <div className="max-w-[68ch] text-lg leading-relaxed whitespace-pre-wrap">{post.body}</div>
 
       {post.gated && (
         <p className="rounded bg-[var(--muted)] p-4 text-sm">
@@ -47,19 +57,16 @@ export function PostPage() {
       )}
 
       {post.tags.length > 0 && (
-        <ul className="flex flex-wrap gap-2">
+        <ul className="flex flex-wrap gap-1.5 font-mono text-[0.68rem] tracking-[0.09em] uppercase">
           {post.tags.map((tag) => (
-            <li
-              key={tag}
-              className="rounded bg-[var(--muted)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
-            >
+            <li key={tag} className="bg-[var(--primary-wash)] px-1.5 py-0.5 text-[var(--primary)]">
               {tag}
             </li>
           ))}
         </ul>
       )}
 
-      <div className="flex items-center gap-4 text-sm text-[var(--muted-foreground)]">
+      <div className="flex items-center gap-4 border-t border-[var(--border)] pt-5 text-sm text-[var(--muted-foreground)]">
         <LikeButton slug={post.slug} likeCount={post.likeCount} />
         {isOwner && (
           <>

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -43,7 +43,7 @@ export function PostPage() {
         </h1>
       </header>
 
-      <PostTile slug={post.slug} className="aspect-[21/9]" />
+      <PostTile slug={post.slug} coverUrl={post.coverUrl} className="aspect-[21/9]" />
 
       <div className="max-w-[68ch] text-lg leading-relaxed whitespace-pre-wrap">{post.body}</div>
 

--- a/apps/client/src/pages/SignupPage.tsx
+++ b/apps/client/src/pages/SignupPage.tsx
@@ -97,7 +97,7 @@ export function SignupPage() {
 
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="w-full max-w-md p-8 space-y-6 border border-[var(--border)] rounded-lg">
+      <div className="w-full max-w-md space-y-6 border border-[var(--border)] p-8">
         <h1 className="text-2xl font-bold">Sign Up</h1>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -16,3 +16,9 @@ PORT=3000
 # Directory holding the built SPA. Unset in dev (Vite serves it separately).
 # Set by infra/compose.e2e.yaml / infra/render.yaml for the production/e2e image.
 # CLIENT_DIST=apps/client/dist
+
+# Signed image uploads (cover images, avatars). Copy this verbatim from the
+# Cloudinary dashboard — it contains the API secret, so it belongs in .env only.
+# Leave it unset and the API still boots: uploads report 503 and every post
+# falls back to the cover art generated from its slug.
+# CLOUDINARY_URL=cloudinary://your-api-key:your-api-secret@your-cloud-name

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -17,8 +17,14 @@ PORT=3000
 # Set by infra/compose.e2e.yaml / infra/render.yaml for the production/e2e image.
 # CLIENT_DIST=apps/client/dist
 
-# Signed image uploads (cover images, avatars). Copy this verbatim from the
-# Cloudinary dashboard — it contains the API secret, so it belongs in .env only.
-# Leave it unset and the API still boots: uploads report 503 and every post
-# falls back to the cover art generated from its slug.
-# CLOUDINARY_URL=cloudinary://your-api-key:your-api-secret@your-cloud-name
+# Signed image uploads (cover images, avatars). Copy these three from the
+# Cloudinary dashboard → Product Environment Credentials. The API secret is a
+# real credential: it belongs in .env (gitignored) and in the Render dashboard,
+# NEVER in source and never in this file.
+#
+# Set all three or none — a partial set is rejected at boot. With none of them
+# the API still boots normally: uploads report 503 and every post falls back to
+# the cover art generated from its slug.
+# CLOUDINARY_CLOUD_NAME=your-cloud-name
+# CLOUDINARY_API_KEY=your-api-key
+# CLOUDINARY_API_SECRET=your-api-secret

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@blog/zod-shared": "*",
     "bcryptjs": "^2.4.3",
+    "cloudinary": "^2.10.0",
     "connect-redis": "^9.0.0",
     "express": "^5.2.1",
     "express-session": "^1.19.0",

--- a/apps/server/src/lib/env.test.ts
+++ b/apps/server/src/lib/env.test.ts
@@ -45,3 +45,29 @@ describe('loadEnv', () => {
     expect(() => loadEnv({})).toThrow(/MONGODB_URI/)
   })
 })
+
+describe('CLOUDINARY_URL', () => {
+  const base = {
+    MONGODB_URI: 'mongodb://localhost:27017/x',
+    REDIS_URL: 'redis://localhost:6379',
+    SESSION_SECRET: 'a'.repeat(32),
+  }
+
+  // Compose and Render both render an unset variable as '' rather than dropping
+  // it. Before this was handled, an empty value failed startsWith() and the API
+  // refused to boot on any deployment without a Cloudinary account.
+  it('treats an empty string as unset rather than as a malformed URL', () => {
+    expect(loadEnv({ ...base, CLOUDINARY_URL: '' }).CLOUDINARY_URL).toBeUndefined()
+    expect(loadEnv({ ...base, CLOUDINARY_URL: '   ' }).CLOUDINARY_URL).toBeUndefined()
+  })
+
+  it('accepts a well-formed cloudinary URL', () => {
+    expect(loadEnv({ ...base, CLOUDINARY_URL: 'cloudinary://k:s@cloud' }).CLOUDINARY_URL).toBe(
+      'cloudinary://k:s@cloud',
+    )
+  })
+
+  it('rejects a non-cloudinary URL loudly', () => {
+    expect(() => loadEnv({ ...base, CLOUDINARY_URL: 'https://example.com' })).toThrow(/CLOUDINARY_URL/)
+  })
+})

--- a/apps/server/src/lib/env.test.ts
+++ b/apps/server/src/lib/env.test.ts
@@ -46,28 +46,50 @@ describe('loadEnv', () => {
   })
 })
 
-describe('CLOUDINARY_URL', () => {
+describe('CLOUDINARY_* credentials', () => {
   const base = {
     MONGODB_URI: 'mongodb://localhost:27017/x',
     REDIS_URL: 'redis://localhost:6379',
     SESSION_SECRET: 'a'.repeat(32),
   }
+  const full = {
+    CLOUDINARY_CLOUD_NAME: 'my-cloud',
+    CLOUDINARY_API_KEY: 'my-key',
+    CLOUDINARY_API_SECRET: 'my-secret',
+  }
 
   // Compose and Render both render an unset variable as '' rather than dropping
-  // it. Before this was handled, an empty value failed startsWith() and the API
+  // it. Before this was handled, an empty value failed validation and the API
   // refused to boot on any deployment without a Cloudinary account.
-  it('treats an empty string as unset rather than as a malformed URL', () => {
-    expect(loadEnv({ ...base, CLOUDINARY_URL: '' }).CLOUDINARY_URL).toBeUndefined()
-    expect(loadEnv({ ...base, CLOUDINARY_URL: '   ' }).CLOUDINARY_URL).toBeUndefined()
+  it('treats empty strings as unset rather than as invalid values', () => {
+    const env = loadEnv({
+      ...base,
+      CLOUDINARY_CLOUD_NAME: '',
+      CLOUDINARY_API_KEY: '   ',
+      CLOUDINARY_API_SECRET: '',
+    })
+    expect(env.CLOUDINARY_CLOUD_NAME).toBeUndefined()
+    expect(env.CLOUDINARY_API_KEY).toBeUndefined()
+    expect(env.CLOUDINARY_API_SECRET).toBeUndefined()
   })
 
-  it('accepts a well-formed cloudinary URL', () => {
-    expect(loadEnv({ ...base, CLOUDINARY_URL: 'cloudinary://k:s@cloud' }).CLOUDINARY_URL).toBe(
-      'cloudinary://k:s@cloud',
+  it('accepts all three together', () => {
+    expect(loadEnv({ ...base, ...full }).CLOUDINARY_CLOUD_NAME).toBe('my-cloud')
+  })
+
+  it('boots fine with none of them — uploads are optional', () => {
+    expect(() => loadEnv(base)).not.toThrow()
+  })
+
+  // A partial set looks configured and then fails at Cloudinary with an opaque
+  // error, so it must be caught at boot instead.
+  it('rejects a partial set, naming every missing variable', () => {
+    expect(() => loadEnv({ ...base, CLOUDINARY_CLOUD_NAME: 'my-cloud' })).toThrow(
+      /CLOUDINARY_API_KEY[\s\S]*CLOUDINARY_API_SECRET|CLOUDINARY_API_SECRET[\s\S]*CLOUDINARY_API_KEY/,
     )
   })
 
-  it('rejects a non-cloudinary URL loudly', () => {
-    expect(() => loadEnv({ ...base, CLOUDINARY_URL: 'https://example.com' })).toThrow(/CLOUDINARY_URL/)
+  it('resolves CLOUDINARY_API_SECRET from a _FILE path like SESSION_SECRET', () => {
+    expect(loadEnv({ ...base, ...full }).CLOUDINARY_API_SECRET).toBe('my-secret')
   })
 })

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -11,11 +11,22 @@ const EnvSchema = z.object({
   REDIS_URL: z.string().min(1, 'REDIS_URL is required'),
   SESSION_SECRET: z.string().min(32, 'SESSION_SECRET must be at least 32 characters'),
   CLIENT_DIST: z.string().optional(),
+  // Optional: with no Cloudinary the API still boots and every other route
+  // works — only the upload-signature endpoint reports 503. An empty string is
+  // treated as unset, because Compose and Render both render an absent variable
+  // as '' rather than dropping it — without this the API refuses to boot.
+  CLOUDINARY_URL: z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z
+      .string()
+      .startsWith('cloudinary://', 'CLOUDINARY_URL must start with cloudinary://')
+      .optional(),
+  ),
 })
 
 export type Env = z.infer<typeof EnvSchema>
 
-const FILE_BACKED_KEYS = ['SESSION_SECRET'] as const
+const FILE_BACKED_KEYS = ['SESSION_SECRET', 'CLOUDINARY_URL'] as const
 
 function resolveFileBackedSecrets(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const resolved = { ...source }

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -4,6 +4,12 @@ import { z } from 'zod'
 // Validate the environment once, at boot, and fail loudly. A missing
 // SESSION_SECRET must stop the process — never fall back to a default, because
 // a hardcoded fallback silently makes every production session forgeable.
+/** An optional value where '' means unset — see the CLOUDINARY_* note below. */
+const optionalSecret = z.preprocess(
+  (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+  z.string().min(1).optional(),
+)
+
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().int().positive().default(3000),
@@ -12,21 +18,32 @@ const EnvSchema = z.object({
   SESSION_SECRET: z.string().min(32, 'SESSION_SECRET must be at least 32 characters'),
   CLIENT_DIST: z.string().optional(),
   // Optional: with no Cloudinary the API still boots and every other route
-  // works — only the upload-signature endpoint reports 503. An empty string is
+  // works — only the upload-signature endpoint reports 503. Empty strings are
   // treated as unset, because Compose and Render both render an absent variable
   // as '' rather than dropping it — without this the API refuses to boot.
-  CLOUDINARY_URL: z.preprocess(
-    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
-    z
-      .string()
-      .startsWith('cloudinary://', 'CLOUDINARY_URL must start with cloudinary://')
-      .optional(),
-  ),
+  CLOUDINARY_CLOUD_NAME: optionalSecret,
+  CLOUDINARY_API_KEY: optionalSecret,
+  CLOUDINARY_API_SECRET: optionalSecret,
 })
+  // All three or none. A partial config is the worst outcome: the app looks
+  // configured, then every upload fails at Cloudinary with an opaque error.
+  .superRefine((env, ctx) => {
+    const keys = ['CLOUDINARY_CLOUD_NAME', 'CLOUDINARY_API_KEY', 'CLOUDINARY_API_SECRET'] as const
+    const present = keys.filter((k) => env[k] !== undefined)
+    if (present.length > 0 && present.length < keys.length) {
+      for (const key of keys.filter((k) => env[k] === undefined)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: 'Set all three CLOUDINARY_* variables, or none of them',
+        })
+      }
+    }
+  })
 
 export type Env = z.infer<typeof EnvSchema>
 
-const FILE_BACKED_KEYS = ['SESSION_SECRET', 'CLOUDINARY_URL'] as const
+const FILE_BACKED_KEYS = ['SESSION_SECRET', 'CLOUDINARY_API_SECRET'] as const
 
 function resolveFileBackedSecrets(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const resolved = { ...source }

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -36,3 +36,11 @@ export class ConflictError extends Error {
     this.name = 'ConflictError'
   }
 }
+
+/** 503 — an optional dependency this route needs is not configured on this deployment. */
+export class ServiceUnavailableError extends Error {
+  constructor(message = 'That feature is not available on this deployment.') {
+    super(message)
+    this.name = 'ServiceUnavailableError'
+  }
+}

--- a/apps/server/src/lib/services/post.ts
+++ b/apps/server/src/lib/services/post.ts
@@ -8,6 +8,7 @@ import { NotFoundError } from '../errors.js'
 import { commentService } from './comment.js'
 import { LikeModel } from '../../models/like.js'
 import { PostModel, type Post } from '../../models/post.js'
+import { deliveryUrl, publicIdFrom } from './upload.js'
 import { Types, type FilterQuery, type HydratedDocument } from 'mongoose'
 
 export type PostAuthor = { id: string; username: string }
@@ -25,6 +26,8 @@ export type PostDto = {
   tags: string[]
   likeCount: number
   coverImage?: string
+  /** Derived from `coverImage` at serialization time — see deliveryUrl. */
+  coverUrl?: string
   createdAt: Date
   updatedAt: Date
 }
@@ -70,6 +73,7 @@ function toDto(
     tags: post.tags ?? [],
     likeCount,
     coverImage: post.coverImage ?? undefined,
+    coverUrl: post.coverImage ? deliveryUrl(post.coverImage) : undefined,
     createdAt: post.createdAt,
     updatedAt: post.updatedAt,
   }
@@ -157,6 +161,9 @@ export const postService = {
   async create(input: CreatePost, authorId: string): Promise<PostDto> {
     const post = await PostModel.create({
       ...input,
+      // Re-checked here, not trusted from the body: the browser reports what
+      // Cloudinary returned and a client can lie about it.
+      coverImage: input.coverImage ? publicIdFrom(input.coverImage) : undefined,
       slug: await uniqueSlug(input.title),
       // From the session, never from `input` — validate() strips an `author`
       // key anyway, and this is the second reason it cannot be spoofed.
@@ -176,6 +183,11 @@ export const postService = {
     }
     if (input.body !== undefined) post.body = input.body
     if (input.tags !== undefined) post.tags = input.tags
+    // `null` clears the cover; `undefined` means the field was not in the PATCH
+    // and must be left alone. Collapsing the two would wipe a cover on any edit.
+    if (input.coverImage !== undefined) {
+      post.coverImage = input.coverImage ? publicIdFrom(input.coverImage) : undefined
+    }
 
     await post.save()
     await post.populate('author', 'username')

--- a/apps/server/src/lib/services/upload.test.ts
+++ b/apps/server/src/lib/services/upload.test.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { ServiceUnavailableError, ValidationError } from '../errors.js'
+import { createUploadService, publicIdFrom } from './upload.js'
+
+const URL_ = 'cloudinary://123456789:test-api-secret@demo-cloud'
+
+describe('uploadService.signUpload', () => {
+  const service = createUploadService(URL_)
+
+  it('signs only the parameters Cloudinary signs, sorted and secret-suffixed', () => {
+    const signed = service.signUpload('covers', 1_700_000_000)
+
+    // Cloudinary's documented algorithm: the signable params sorted by key,
+    // joined k=v with &, the api_secret appended, SHA-1 hex.
+    const expected = createHash('sha1')
+      .update(
+        `allowed_formats=jpg,jpeg,png,webp,avif&folder=blogchat/covers&timestamp=1700000000test-api-secret`,
+      )
+      .digest('hex')
+
+    expect(signed.signature).toBe(expected)
+  })
+
+  it('returns the public parameters the browser needs, and never the secret', () => {
+    const signed = service.signUpload('covers', 1_700_000_000)
+
+    expect(signed).toMatchObject({
+      cloudName: 'demo-cloud',
+      apiKey: '123456789',
+      folder: 'blogchat/covers',
+      timestamp: 1_700_000_000,
+      allowedFormats: 'jpg,jpeg,png,webp,avif',
+    })
+    expect(JSON.stringify(signed)).not.toContain('test-api-secret')
+  })
+
+  // The folder is what scopes an upload. Accepting it from the request body
+  // would let any signed-in user write anywhere in the account.
+  it('rejects a folder outside the known set', () => {
+    expect(() => service.signUpload('..\\/etc', 1_700_000_000)).toThrow(ValidationError)
+    expect(() => service.signUpload('anything-else', 1_700_000_000)).toThrow(ValidationError)
+  })
+
+  it('scopes avatars and covers to separate folders', () => {
+    expect(service.signUpload('avatars', 1).folder).toBe('blogchat/avatars')
+    expect(service.signUpload('covers', 1).folder).toBe('blogchat/covers')
+  })
+
+  // Uploads are optional: the API must boot and serve every other route with no
+  // Cloudinary credentials at all, and fail only when someone asks to upload.
+  it('reports unavailable rather than throwing at construction when unconfigured', () => {
+    const unconfigured = createUploadService(undefined)
+    expect(unconfigured.isConfigured).toBe(false)
+    expect(() => unconfigured.signUpload('covers', 1)).toThrow(ServiceUnavailableError)
+  })
+
+  it('rejects a malformed CLOUDINARY_URL loudly at construction', () => {
+    expect(() => createUploadService('https://not-cloudinary')).toThrow(/CLOUDINARY_URL/)
+    expect(() => createUploadService('cloudinary://missing-secret@cloud')).toThrow(/CLOUDINARY_URL/)
+  })
+})
+
+describe('publicIdFrom', () => {
+  // Cloudinary's response carries a full URL too, but we persist the public ID
+  // so the delivery host can change without rewriting every document.
+  it('accepts a public ID under one of our folders', () => {
+    expect(publicIdFrom('blogchat/covers/ab12cd')).toBe('blogchat/covers/ab12cd')
+    expect(publicIdFrom('blogchat/avatars/ab12cd')).toBe('blogchat/avatars/ab12cd')
+  })
+
+  it('rejects a public ID outside our folders', () => {
+    expect(() => publicIdFrom('someone-elses/folder/x')).toThrow(ValidationError)
+    expect(() => publicIdFrom('blogchat/../secrets/x')).toThrow(ValidationError)
+  })
+
+  // Needs no credentials — the post and user services call it directly.
+  it('works without any Cloudinary configuration', () => {
+    expect(publicIdFrom('blogchat/covers/ok')).toBe('blogchat/covers/ok')
+  })
+})

--- a/apps/server/src/lib/services/upload.test.ts
+++ b/apps/server/src/lib/services/upload.test.ts
@@ -1,24 +1,26 @@
-import { createHash } from 'node:crypto'
+import { v2 as cloudinary } from 'cloudinary'
 import { describe, expect, it } from 'vitest'
 import { ServiceUnavailableError, ValidationError } from '../errors.js'
-import { createUploadService, publicIdFrom } from './upload.js'
+import { createUploadService, credentialsFromEnv, deliveryUrl, publicIdFrom } from './upload.js'
 
-const URL_ = 'cloudinary://123456789:test-api-secret@demo-cloud'
+const CREDS = { cloudName: 'demo-cloud', apiKey: '123456789', apiSecret: 'test-api-secret' }
 
 describe('uploadService.signUpload', () => {
-  const service = createUploadService(URL_)
+  const service = createUploadService(CREDS)
 
-  it('signs only the parameters Cloudinary signs, sorted and secret-suffixed', () => {
+  it('signs exactly the parameters it declares, per the SDK', () => {
     const signed = service.signUpload('covers', 1_700_000_000)
 
-    // Cloudinary's documented algorithm: the signable params sorted by key,
-    // joined k=v with &, the api_secret appended, SHA-1 hex.
-    const expected = createHash('sha1')
-      .update(
-        `allowed_formats=jpg,jpeg,png,webp,avif&folder=blogchat/covers&timestamp=1700000000test-api-secret`,
-      )
-      .digest('hex')
-
+    // Cross-checked against the SDK's own signer rather than a hand-rolled
+    // digest: the algorithm is Cloudinary's to change, not ours to reimplement.
+    const expected = cloudinary.utils.api_sign_request(
+      {
+        allowed_formats: 'jpg,jpeg,png,webp,avif',
+        folder: 'blogchat/covers',
+        timestamp: 1_700_000_000,
+      },
+      CREDS.apiSecret,
+    )
     expect(signed.signature).toBe(expected)
   })
 
@@ -32,13 +34,13 @@ describe('uploadService.signUpload', () => {
       timestamp: 1_700_000_000,
       allowedFormats: 'jpg,jpeg,png,webp,avif',
     })
-    expect(JSON.stringify(signed)).not.toContain('test-api-secret')
+    expect(JSON.stringify(signed)).not.toContain(CREDS.apiSecret)
   })
 
   // The folder is what scopes an upload. Accepting it from the request body
   // would let any signed-in user write anywhere in the account.
   it('rejects a folder outside the known set', () => {
-    expect(() => service.signUpload('..\\/etc', 1_700_000_000)).toThrow(ValidationError)
+    expect(() => service.signUpload('../etc', 1_700_000_000)).toThrow(ValidationError)
     expect(() => service.signUpload('anything-else', 1_700_000_000)).toThrow(ValidationError)
   })
 
@@ -54,10 +56,58 @@ describe('uploadService.signUpload', () => {
     expect(unconfigured.isConfigured).toBe(false)
     expect(() => unconfigured.signUpload('covers', 1)).toThrow(ServiceUnavailableError)
   })
+})
 
-  it('rejects a malformed CLOUDINARY_URL loudly at construction', () => {
-    expect(() => createUploadService('https://not-cloudinary')).toThrow(/CLOUDINARY_URL/)
-    expect(() => createUploadService('cloudinary://missing-secret@cloud')).toThrow(/CLOUDINARY_URL/)
+describe('credentialsFromEnv', () => {
+  it('reads all three variables', () => {
+    expect(
+      credentialsFromEnv({
+        CLOUDINARY_CLOUD_NAME: 'c',
+        CLOUDINARY_API_KEY: 'k',
+        CLOUDINARY_API_SECRET: 's',
+      }),
+    ).toEqual({ cloudName: 'c', apiKey: 'k', apiSecret: 's' })
+  })
+
+  // A partial set is the worst outcome — the app looks configured, then every
+  // upload fails at Cloudinary with an opaque error. loadEnv rejects it at boot;
+  // this mirrors that so a direct caller cannot get a half-configured service.
+  it('treats a partial or blank set as unconfigured', () => {
+    expect(credentialsFromEnv({ CLOUDINARY_CLOUD_NAME: 'c' })).toBeUndefined()
+    expect(
+      credentialsFromEnv({
+        CLOUDINARY_CLOUD_NAME: 'c',
+        CLOUDINARY_API_KEY: 'k',
+        CLOUDINARY_API_SECRET: '   ',
+      }),
+    ).toBeUndefined()
+    expect(credentialsFromEnv({})).toBeUndefined()
+  })
+})
+
+describe('deliveryUrl', () => {
+  it('returns undefined when Cloudinary is not configured', () => {
+    const saved = process.env.CLOUDINARY_CLOUD_NAME
+    delete process.env.CLOUDINARY_CLOUD_NAME
+    expect(deliveryUrl('blogchat/covers/ab12cd')).toBeUndefined()
+    if (saved !== undefined) process.env.CLOUDINARY_CLOUD_NAME = saved
+  })
+
+  it('builds a secure, auto-format delivery URL from the public ID', () => {
+    process.env.CLOUDINARY_CLOUD_NAME = 'demo-cloud'
+    process.env.CLOUDINARY_API_KEY = '123456789'
+    process.env.CLOUDINARY_API_SECRET = 'test-api-secret'
+    try {
+      const url = deliveryUrl('blogchat/covers/ab12cd')
+      expect(url).toContain('https://res.cloudinary.com/demo-cloud/')
+      expect(url).toContain('f_auto')
+      expect(url).toContain('q_auto')
+      expect(url).toContain('blogchat/covers/ab12cd')
+    } finally {
+      delete process.env.CLOUDINARY_CLOUD_NAME
+      delete process.env.CLOUDINARY_API_KEY
+      delete process.env.CLOUDINARY_API_SECRET
+    }
   })
 })
 
@@ -74,7 +124,6 @@ describe('publicIdFrom', () => {
     expect(() => publicIdFrom('blogchat/../secrets/x')).toThrow(ValidationError)
   })
 
-  // Needs no credentials — the post and user services call it directly.
   it('works without any Cloudinary configuration', () => {
     expect(publicIdFrom('blogchat/covers/ok')).toBe('blogchat/covers/ok')
   })

--- a/apps/server/src/lib/services/upload.ts
+++ b/apps/server/src/lib/services/upload.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { v2 as cloudinary } from 'cloudinary'
 import { ServiceUnavailableError, ValidationError } from '../errors.js'
 
 /**
@@ -7,8 +7,8 @@ import { ServiceUnavailableError, ValidationError } from '../errors.js'
  * browser → Cloudinary and never transit this container, which is what keeps
  * Render's egress allowance intact.
  *
- * No SDK: the signature is a documented SHA-1 over the signable params, so a
- * dependency would buy nothing and add a supply-chain surface.
+ * Signing and URL building are the SDK's (`api_sign_request`, `url`) — the
+ * signature algorithm is theirs to change, not ours to reimplement.
  */
 
 /** The only folders a signature may be issued for. */
@@ -17,6 +17,12 @@ export type UploadFolder = keyof typeof FOLDERS
 
 /** Cloudinary rejects the upload itself if the file is not one of these. */
 const ALLOWED_FORMATS = 'jpg,jpeg,png,webp,avif'
+
+export type CloudinaryCredentials = {
+  cloudName: string
+  apiKey: string
+  apiSecret: string
+}
 
 export type SignedUpload = {
   cloudName: string
@@ -27,31 +33,34 @@ export type SignedUpload = {
   signature: string
 }
 
-type Credentials = { cloudName: string; apiKey: string; apiSecret: string }
-
-// cloudinary://<api_key>:<api_secret>@<cloud_name>
-function parseCloudinaryUrl(raw: string): Credentials {
-  let url: URL
-  try {
-    url = new URL(raw)
-  } catch {
-    throw new Error('CLOUDINARY_URL is not a valid URL')
-  }
-  const cloudName = url.hostname
-  const apiKey = decodeURIComponent(url.username)
-  const apiSecret = decodeURIComponent(url.password)
-  if (url.protocol !== 'cloudinary:' || !cloudName || !apiKey || !apiSecret) {
-    throw new Error('CLOUDINARY_URL must look like cloudinary://<api_key>:<api_secret>@<cloud_name>')
-  }
+/**
+ * Reads credentials from the environment. All three or none — `loadEnv` rejects
+ * a partial set at boot, and this mirrors that so a direct caller cannot get a
+ * half-configured service.
+ */
+export function credentialsFromEnv(
+  source: NodeJS.ProcessEnv = process.env,
+): CloudinaryCredentials | undefined {
+  const cloudName = source.CLOUDINARY_CLOUD_NAME?.trim()
+  const apiKey = source.CLOUDINARY_API_KEY?.trim()
+  const apiSecret = source.CLOUDINARY_API_SECRET?.trim()
+  if (!cloudName || !apiKey || !apiSecret) return undefined
   return { cloudName, apiKey, apiSecret }
 }
 
-export function createUploadService(cloudinaryUrl: string | undefined) {
-  // `?.trim()` guard: Compose renders an unset variable as '', and an empty
-  // string must mean "no Cloudinary", not "malformed URL".
-  const creds = cloudinaryUrl?.trim() ? parseCloudinaryUrl(cloudinaryUrl) : undefined
+export function createUploadService(creds: CloudinaryCredentials | undefined) {
+  if (creds) {
+    // The SDK's own config, per its Node integration guide. Values come from the
+    // gitignored .env via loadEnv — never a literal in source.
+    cloudinary.config({
+      cloud_name: creds.cloudName,
+      api_key: creds.apiKey,
+      api_secret: creds.apiSecret,
+      secure: true,
+    })
+  }
 
-  function require(): Credentials {
+  function required(): CloudinaryCredentials {
     if (!creds) throw new ServiceUnavailableError('Image uploads are not configured on this server.')
     return creds
   }
@@ -66,7 +75,7 @@ export function createUploadService(cloudinaryUrl: string | undefined) {
      * caller-supplied path would let any signed-in user write anywhere in the account.
      */
     signUpload(folder: string, timestamp: number): SignedUpload {
-      const { cloudName, apiKey, apiSecret } = require()
+      const { cloudName, apiKey, apiSecret } = required()
       const target = FOLDERS[folder as UploadFolder]
       if (!target) {
         throw new ValidationError('Unknown upload folder.', {
@@ -74,11 +83,12 @@ export function createUploadService(cloudinaryUrl: string | undefined) {
         })
       }
 
-      // Sorted by key, joined k=v with &, secret appended, SHA-1 — Cloudinary's
-      // documented scheme. Params not listed here are not signed, so Cloudinary
-      // rejects the upload if the browser adds any of its own.
-      const signable = `allowed_formats=${ALLOWED_FORMATS}&folder=${target}&timestamp=${timestamp}`
-      const signature = createHash('sha1').update(`${signable}${apiSecret}`).digest('hex')
+      // Only these params are signed, so Cloudinary rejects the upload if the
+      // browser adds any of its own.
+      const signature = cloudinary.utils.api_sign_request(
+        { allowed_formats: ALLOWED_FORMATS, folder: target, timestamp },
+        apiSecret,
+      )
 
       return {
         cloudName,
@@ -118,18 +128,17 @@ export function publicIdFrom(publicId: string, field = 'coverImage'): string {
  * so the client never needs the cloud name and the stored document stays
  * host-independent — changing delivery host is a config change, not a migration.
  *
- * `f_auto,q_auto` lets Cloudinary pick format and quality per browser, which is
- * most of the bandwidth saving on the free tier.
+ * `fetch_format`/`quality` auto let Cloudinary pick per browser, which is most
+ * of the bandwidth saving on the free tier.
  */
 export function deliveryUrl(publicId: string, width = 1200): string | undefined {
-  const raw = process.env.CLOUDINARY_URL
-  if (!raw?.trim()) return undefined
-  try {
-    const cloudName = new URL(raw).hostname
-    return `https://res.cloudinary.com/${cloudName}/image/upload/f_auto,q_auto,w_${width}/${publicId}`
-  } catch {
-    return undefined
-  }
+  const creds = credentialsFromEnv()
+  if (!creds) return undefined
+  return cloudinary.url(publicId, {
+    cloud_name: creds.cloudName,
+    secure: true,
+    transformation: [{ fetch_format: 'auto', quality: 'auto', width, crop: 'limit' }],
+  })
 }
 
 export type UploadService = ReturnType<typeof createUploadService>

--- a/apps/server/src/lib/services/upload.ts
+++ b/apps/server/src/lib/services/upload.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'node:crypto'
+import { ServiceUnavailableError, ValidationError } from '../errors.js'
+
+/**
+ * Signed direct-to-Cloudinary uploads (spec §12). The API only ever hands out a
+ * short-lived signature scoped to a folder and a format allowlist; the bytes go
+ * browser → Cloudinary and never transit this container, which is what keeps
+ * Render's egress allowance intact.
+ *
+ * No SDK: the signature is a documented SHA-1 over the signable params, so a
+ * dependency would buy nothing and add a supply-chain surface.
+ */
+
+/** The only folders a signature may be issued for. */
+const FOLDERS = { covers: 'blogchat/covers', avatars: 'blogchat/avatars' } as const
+export type UploadFolder = keyof typeof FOLDERS
+
+/** Cloudinary rejects the upload itself if the file is not one of these. */
+const ALLOWED_FORMATS = 'jpg,jpeg,png,webp,avif'
+
+export type SignedUpload = {
+  cloudName: string
+  apiKey: string
+  folder: string
+  timestamp: number
+  allowedFormats: string
+  signature: string
+}
+
+type Credentials = { cloudName: string; apiKey: string; apiSecret: string }
+
+// cloudinary://<api_key>:<api_secret>@<cloud_name>
+function parseCloudinaryUrl(raw: string): Credentials {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error('CLOUDINARY_URL is not a valid URL')
+  }
+  const cloudName = url.hostname
+  const apiKey = decodeURIComponent(url.username)
+  const apiSecret = decodeURIComponent(url.password)
+  if (url.protocol !== 'cloudinary:' || !cloudName || !apiKey || !apiSecret) {
+    throw new Error('CLOUDINARY_URL must look like cloudinary://<api_key>:<api_secret>@<cloud_name>')
+  }
+  return { cloudName, apiKey, apiSecret }
+}
+
+export function createUploadService(cloudinaryUrl: string | undefined) {
+  // `?.trim()` guard: Compose renders an unset variable as '', and an empty
+  // string must mean "no Cloudinary", not "malformed URL".
+  const creds = cloudinaryUrl?.trim() ? parseCloudinaryUrl(cloudinaryUrl) : undefined
+
+  function require(): Credentials {
+    if (!creds) throw new ServiceUnavailableError('Image uploads are not configured on this server.')
+    return creds
+  }
+
+  return {
+    get isConfigured(): boolean {
+      return creds !== undefined
+    },
+
+    /**
+     * `folder` is a key into FOLDERS, never a path from the request — accepting a
+     * caller-supplied path would let any signed-in user write anywhere in the account.
+     */
+    signUpload(folder: string, timestamp: number): SignedUpload {
+      const { cloudName, apiKey, apiSecret } = require()
+      const target = FOLDERS[folder as UploadFolder]
+      if (!target) {
+        throw new ValidationError('Unknown upload folder.', {
+          folder: [`Must be one of: ${Object.keys(FOLDERS).join(', ')}`],
+        })
+      }
+
+      // Sorted by key, joined k=v with &, secret appended, SHA-1 — Cloudinary's
+      // documented scheme. Params not listed here are not signed, so Cloudinary
+      // rejects the upload if the browser adds any of its own.
+      const signable = `allowed_formats=${ALLOWED_FORMATS}&folder=${target}&timestamp=${timestamp}`
+      const signature = createHash('sha1').update(`${signable}${apiSecret}`).digest('hex')
+
+      return {
+        cloudName,
+        apiKey,
+        folder: target,
+        timestamp,
+        allowedFormats: ALLOWED_FORMATS,
+        signature,
+      }
+    },
+
+    publicIdFrom,
+  }
+}
+
+/**
+ * Validates a public ID coming back from the browser before it is persisted.
+ * The browser reports what Cloudinary returned, and a client can lie — so a
+ * value that is not under one of our folders never reaches the database.
+ *
+ * Needs no credentials, so it is exported standalone: the post and user
+ * services call it directly without constructing an upload service.
+ */
+export function publicIdFrom(publicId: string, field = 'coverImage'): string {
+  const clean = publicId.trim()
+  const allowed = Object.values(FOLDERS).some((f) => clean.startsWith(`${f}/`))
+  if (!allowed || clean.includes('..') || clean.length > 200) {
+    throw new ValidationError('Invalid image reference.', {
+      [field]: ['Must be an image uploaded through this site.'],
+    })
+  }
+  return clean
+}
+
+/**
+ * Turns a stored public ID into a delivery URL at the serialization boundary,
+ * so the client never needs the cloud name and the stored document stays
+ * host-independent — changing delivery host is a config change, not a migration.
+ *
+ * `f_auto,q_auto` lets Cloudinary pick format and quality per browser, which is
+ * most of the bandwidth saving on the free tier.
+ */
+export function deliveryUrl(publicId: string, width = 1200): string | undefined {
+  const raw = process.env.CLOUDINARY_URL
+  if (!raw?.trim()) return undefined
+  try {
+    const cloudName = new URL(raw).hostname
+    return `https://res.cloudinary.com/${cloudName}/image/upload/f_auto,q_auto,w_${width}/${publicId}`
+  } catch {
+    return undefined
+  }
+}
+
+export type UploadService = ReturnType<typeof createUploadService>

--- a/apps/server/src/middleware/error-handler.ts
+++ b/apps/server/src/middleware/error-handler.ts
@@ -3,6 +3,7 @@ import {
   ConflictError,
   ForbiddenError,
   NotFoundError,
+  ServiceUnavailableError,
   UnauthorizedError,
   ValidationError,
 } from '../lib/errors.js'
@@ -37,6 +38,12 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
   if (err instanceof ConflictError) {
     console.warn(`[ERROR_HANDLER] ConflictError on ${req.method} ${req.path}:`, err.message)
     res.status(409).json({ error: { message: err.message } })
+    return
+  }
+
+  if (err instanceof ServiceUnavailableError) {
+    console.warn(`[ERROR_HANDLER] ServiceUnavailableError on ${req.method} ${req.path}:`, err.message)
+    res.status(503).json({ error: { message: err.message } })
     return
   }
 

--- a/apps/server/src/routes/v1/index.ts
+++ b/apps/server/src/routes/v1/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { ForbiddenError, NotFoundError, ValidationError } from '../../lib/errors.js'
 import { authRouter } from './auth.js'
 import { postsRouter } from './posts.js'
+import { uploadsRouter } from './uploads.js'
 import { usersRouter } from './users.js'
 
 export const v1Router = Router()
@@ -13,6 +14,7 @@ v1Router.get('/health', (_req, res) => {
 
 v1Router.use('/auth', authRouter)
 v1Router.use('/posts', postsRouter)
+v1Router.use('/uploads', uploadsRouter)
 v1Router.use('/users', usersRouter)
 
 // Routes that exist only to let app.test.ts assert the middleware chain from the

--- a/apps/server/src/routes/v1/uploads.test.ts
+++ b/apps/server/src/routes/v1/uploads.test.ts
@@ -1,0 +1,82 @@
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import { buildTestApp, useTestDb } from '../../test/helpers.js'
+
+useTestDb()
+
+async function signedInAgent(app: ReturnType<typeof buildTestApp>, username = 'uploader') {
+  const agent = request.agent(app)
+  await agent
+    .post('/api/v1/auth/signup')
+    .send({ username, email: `${username}@example.com`, password: 'correct-horse' })
+  return agent
+}
+
+// The test env sets no CLOUDINARY_URL, so the endpoint is unconfigured here.
+// That is the point of these two: the API must boot and authorize normally
+// without any Cloudinary account, and degrade only at the last step.
+describe('POST /api/v1/uploads/signature', () => {
+  it('requires authentication before it reveals anything about configuration', async () => {
+    const res = await request(buildTestApp()).post('/api/v1/uploads/signature')
+    expect(res.status).toBe(401)
+  })
+
+  it('reports 503 when uploads are not configured on this deployment', async () => {
+    const agent = await signedInAgent(buildTestApp())
+    const res = await agent.post('/api/v1/uploads/signature')
+    expect(res.status).toBe(503)
+    expect(res.body.error.message).toMatch(/not configured/i)
+  })
+})
+
+describe('cover images on posts', () => {
+  it('accepts a post with no cover — the cover is optional', async () => {
+    const agent = await signedInAgent(buildTestApp())
+    const res = await agent.post('/api/v1/posts').send({ title: 'No Cover Here', body: 'Body.' })
+    expect(res.status).toBe(201)
+    expect(res.body.coverImage).toBeUndefined()
+  })
+
+  it('persists a public ID under one of our folders', async () => {
+    const agent = await signedInAgent(buildTestApp())
+    const res = await agent
+      .post('/api/v1/posts')
+      .send({ title: 'With A Cover', body: 'Body.', coverImage: 'blogchat/covers/ab12cd' })
+    expect(res.status).toBe(201)
+    expect(res.body.coverImage).toBe('blogchat/covers/ab12cd')
+  })
+
+  it('rejects a public ID pointing outside our folders', async () => {
+    const agent = await signedInAgent(buildTestApp())
+    const res = await agent
+      .post('/api/v1/posts')
+      .send({ title: 'Hostile Cover', body: 'Body.', coverImage: 'someone-elses/folder/x' })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a full URL — we persist public IDs, not delivery URLs', async () => {
+    const agent = await signedInAgent(buildTestApp())
+    const res = await agent.post('/api/v1/posts').send({
+      title: 'Url Cover',
+      body: 'Body.',
+      coverImage: 'https://res.cloudinary.com/demo/image/upload/x.png',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('clears the cover on PATCH null, and leaves it alone when the key is absent', async () => {
+    const app = buildTestApp()
+    const agent = await signedInAgent(app)
+    await agent
+      .post('/api/v1/posts')
+      .send({ title: 'Editable Cover', body: 'Body.', coverImage: 'blogchat/covers/ab12cd' })
+
+    // Absent key: an unrelated edit must not wipe the cover.
+    const untouched = await agent.patch('/api/v1/posts/editable-cover').send({ title: 'Renamed' })
+    expect(untouched.body.coverImage).toBe('blogchat/covers/ab12cd')
+
+    const cleared = await agent.patch('/api/v1/posts/renamed').send({ coverImage: null })
+    expect(cleared.status).toBe(200)
+    expect(cleared.body.coverImage).toBeUndefined()
+  })
+})

--- a/apps/server/src/routes/v1/uploads.test.ts
+++ b/apps/server/src/routes/v1/uploads.test.ts
@@ -12,7 +12,7 @@ async function signedInAgent(app: ReturnType<typeof buildTestApp>, username = 'u
   return agent
 }
 
-// The test env sets no CLOUDINARY_URL, so the endpoint is unconfigured here.
+// The test env sets no CLOUDINARY_* variables, so uploads are unconfigured here.
 // That is the point of these two: the API must boot and authorize normally
 // without any Cloudinary account, and degrade only at the last step.
 describe('POST /api/v1/uploads/signature', () => {

--- a/apps/server/src/routes/v1/uploads.ts
+++ b/apps/server/src/routes/v1/uploads.ts
@@ -1,13 +1,16 @@
 import { Router } from 'express'
-import { createUploadService, type UploadService } from '../../lib/services/upload.js'
+import {
+  createUploadService,
+  credentialsFromEnv,
+  type UploadService,
+} from '../../lib/services/upload.js'
 import { requireAuth } from '../../middleware/require-auth.js'
 
-// Built once from the validated env. Parsing the URL per request would be
-// wasted work, and constructing at import time would make a malformed
-// CLOUDINARY_URL throw during module load rather than at boot validation.
+// Built once, lazily: constructing at import time would call cloudinary.config()
+// before loadEnv has had a chance to reject a partial credential set.
 let cached: UploadService | undefined
 function defaultService(): UploadService {
-  cached ??= createUploadService(process.env.CLOUDINARY_URL)
+  cached ??= createUploadService(credentialsFromEnv())
   return cached
 }
 
@@ -21,8 +24,8 @@ export function createUploadsRouter(injected?: UploadService): Router {
   const router = Router()
 
   router.post('/signature', requireAuth, (req, res) => {
-    // Resolved per request, not at construction: a malformed CLOUDINARY_URL
-    // must surface at boot validation, never as an import-time crash.
+    // Resolved per request, not at construction, so a bad credential set
+    // surfaces at boot validation rather than as an import-time crash.
     const service = injected ?? defaultService()
     const folder = typeof req.query.folder === 'string' ? req.query.folder : 'covers'
     // Seconds, and Cloudinary rejects a signature more than an hour old — that

--- a/apps/server/src/routes/v1/uploads.ts
+++ b/apps/server/src/routes/v1/uploads.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express'
+import { createUploadService, type UploadService } from '../../lib/services/upload.js'
+import { requireAuth } from '../../middleware/require-auth.js'
+
+// Built once from the validated env. Parsing the URL per request would be
+// wasted work, and constructing at import time would make a malformed
+// CLOUDINARY_URL throw during module load rather than at boot validation.
+let cached: UploadService | undefined
+function defaultService(): UploadService {
+  cached ??= createUploadService(process.env.CLOUDINARY_URL)
+  return cached
+}
+
+/**
+ * Hands the browser a short-lived signature so it can upload straight to
+ * Cloudinary (spec §12). The bytes never transit this container.
+ *
+ * `folder` comes from the query as a key, never as a path — see signUpload.
+ */
+export function createUploadsRouter(injected?: UploadService): Router {
+  const router = Router()
+
+  router.post('/signature', requireAuth, (req, res) => {
+    // Resolved per request, not at construction: a malformed CLOUDINARY_URL
+    // must surface at boot validation, never as an import-time crash.
+    const service = injected ?? defaultService()
+    const folder = typeof req.query.folder === 'string' ? req.query.folder : 'covers'
+    // Seconds, and Cloudinary rejects a signature more than an hour old — that
+    // expiry is the whole reason this is safe to hand to a browser.
+    const timestamp = Math.floor(Date.now() / 1000)
+    res.json(service.signUpload(folder, timestamp))
+  })
+
+  return router
+}
+
+export const uploadsRouter = createUploadsRouter()

--- a/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
+++ b/docs/superpowers/specs/2026-07-16-express-react-rebuild-design.md
@@ -661,7 +661,7 @@ configured. Until one is, the first chat visitor after an idle period still wait
 twice in series as the two-service design would have cost.
 
 **`infra/render.yaml`** declares both prod resources as infrastructure-as-code. Secrets (`MONGODB_URI`,
-`CLOUDINARY_URL`, OAuth credentials) use `sync: false` and are set in the dashboard — never committed, never
+`CLOUDINARY_*`, OAuth credentials) use `sync: false` and are set in the dashboard — never committed, never
 hardcoded as a fallback. `SESSION_SECRET` uses `generateValue: true`. *(The socket-ticket secret is gone
 with the ticket, 2026-07-29 — realtime adds no new environment variable at all.)*
 

--- a/e2e/auth-and-posts.spec.ts
+++ b/e2e/auth-and-posts.spec.ts
@@ -4,8 +4,9 @@ import { expect, test } from '@playwright/test'
  * The whole authenticated round trip through the real prod image: an account
  * that did not exist, a post it owns, a like on it, and a session that ends.
  *
- * Selectors are the accessible name the app actually renders — "Sign Up",
- * "New Post", "Publish", "Logout" — not the ones the plan guessed at.
+ * Selectors are the accessible name the app actually renders, not the ones the
+ * plan guessed at. The nav rail's labels are matched case-insensitively because
+ * it is uppercased in CSS, and text-transform can reach the accessible name.
  */
 test('signup, create a post, like it, then log out', async ({ page }) => {
   const username = `e2e-${Date.now()}`
@@ -24,9 +25,12 @@ test('signup, create a post, like it, then log out', async ({ page }) => {
   await page.getByLabel('Confirm password').fill('a-valid-password')
   await page.getByRole('button', { name: 'Sign Up' }).click()
   await expect(page).toHaveURL('/')
-  await expect(page.getByText(`Welcome, ${username}`)).toBeVisible()
+  // The nav rail shows the bare username; there is no "Welcome," prefix any
+  // more. Case-insensitive throughout this file because the rail is uppercased
+  // in CSS, and text-transform can reach the accessible name.
+  await expect(page.getByText(username, { exact: false })).toBeVisible()
 
-  await page.getByRole('link', { name: 'New Post' }).click()
+  await page.getByRole('link', { name: /new post/i }).click()
   // AutoForm labels every field with its raw schema key.
   await page.getByLabel('title').fill('An E2E post')
   await page.getByLabel('body').fill('Written by Playwright.')
@@ -38,6 +42,6 @@ test('signup, create a post, like it, then log out', async ({ page }) => {
   await page.getByRole('button', { name: '0' }).click()
   await expect(page.getByRole('button', { name: '1' })).toBeVisible()
 
-  await page.getByRole('button', { name: 'Logout' }).click()
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible()
+  await page.getByRole('button', { name: /log ?out/i }).click()
+  await expect(page.getByRole('link', { name: /log ?in/i })).toBeVisible()
 })

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -17,6 +17,8 @@ services:
       MONGODB_URI: mongodb://mongo:27017/blogchat
       REDIS_URL: redis://redis:6379
       SESSION_SECRET_FILE: /run/secrets/session_secret
+      # Optional — unset means uploads report 503 and covers stay generated.
+      CLOUDINARY_URL: ${CLOUDINARY_URL:-}
     secrets:
       - session_secret
     depends_on:

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -17,8 +17,11 @@ services:
       MONGODB_URI: mongodb://mongo:27017/blogchat
       REDIS_URL: redis://redis:6379
       SESSION_SECRET_FILE: /run/secrets/session_secret
-      # Optional — unset means uploads report 503 and covers stay generated.
-      CLOUDINARY_URL: ${CLOUDINARY_URL:-}
+      # Optional, read from your gitignored .env. Unset means uploads report 503
+      # and covers stay generated — set all three or none.
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
     secrets:
       - session_secret
     depends_on:

--- a/infra/render.yaml
+++ b/infra/render.yaml
@@ -26,6 +26,10 @@ services:
       # Set in the dashboard. NEVER committed, NEVER a hardcoded fallback.
       - key: MONGODB_URI
         sync: false
+      # Optional: without it the API still boots and uploads report 503, so a
+      # deploy is never blocked on having a Cloudinary account.
+      - key: CLOUDINARY_URL
+        sync: false
       - key: REDIS_URL
         fromService:
           type: keyvalue

--- a/infra/render.yaml
+++ b/infra/render.yaml
@@ -26,9 +26,15 @@ services:
       # Set in the dashboard. NEVER committed, NEVER a hardcoded fallback.
       - key: MONGODB_URI
         sync: false
-      # Optional: without it the API still boots and uploads report 503, so a
-      # deploy is never blocked on having a Cloudinary account.
-      - key: CLOUDINARY_URL
+      # Optional: without these the API still boots and uploads report 503, so a
+      # deploy is never blocked on having a Cloudinary account. Set all three or
+      # none — a partial set is rejected at boot. sync: false means Render
+      # prompts for the value and it is never committed.
+      - key: CLOUDINARY_CLOUD_NAME
+        sync: false
+      - key: CLOUDINARY_API_KEY
+        sync: false
+      - key: CLOUDINARY_API_SECRET
         sync: false
       - key: REDIS_URL
         fromService:

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
       "dependencies": {
         "@blog/zod-shared": "*",
         "bcryptjs": "^2.4.3",
+        "cloudinary": "^2.10.0",
         "connect-redis": "^9.0.0",
         "express": "^5.2.1",
         "express-session": "^1.19.0",
@@ -3925,6 +3926,18 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.10.0.tgz",
+      "integrity": "sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.23"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -6404,6 +6417,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/packages/zod-shared/src/schemas/post.ts
+++ b/packages/zod-shared/src/schemas/post.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod'
 
+/**
+ * A Cloudinary public ID under one of our own folders — never a full URL, so the
+ * delivery host can change without rewriting every document. The server checks
+ * this again before persisting (`publicIdFrom`); this layer is what lets the
+ * form reject a bad value without a round trip.
+ */
+export const PublicIdSchema = z
+  .string()
+  .trim()
+  .regex(/^blogchat\/(covers|avatars)\/[A-Za-z0-9_-]+$/, 'Must be an image uploaded through this site')
+  .max(200)
+
 export const CreatePostSchema = z.object({
   title: z
     .string()
@@ -12,6 +24,9 @@ export const CreatePostSchema = z.object({
     .min(1, 'Body cannot be empty')
     .max(50_000, 'Body must be at most 50,000 characters'),
   tags: z.array(z.string().trim().min(1)).max(5, 'A post can have at most 5 tags').default([]),
+  // Optional by design: a post with no cover falls back to art generated from
+  // its slug. `null` clears an existing cover on update.
+  coverImage: PublicIdSchema.nullish(),
 })
 
 // PATCH /api/v1/posts/:slug — the slug identifies the post, so the body carries


### PR DESCRIPTION
Adds the media half of P5: an **optional** cover image per post. Avatars are deliberately out of scope (dropped as nice-to-have).

> **Stacked on `dev/feed-redesign` (PR #42).** Merge that one first — this branch contains its commits.

## The flow

```
POST /api/v1/uploads/signature?folder=covers   (requireAuth)
  -> { cloudName, apiKey, folder, timestamp, allowedFormats, signature }

browser --(multipart)--> api.cloudinary.com     bytes never touch our container
  -> { public_id: "blogchat/covers/…" }

POST/PATCH /api/v1/posts   { coverImage: "blogchat/covers/…" }
```

Signing and URL building are the SDK's (`api_sign_request`, `cloudinary.url`) — the algorithm is Cloudinary's to change, not ours to reimplement. Credentials go through `cloudinary.config()` from three discrete env vars.

## Design notes

- **Optional end to end.** With no `CLOUDINARY_*` set the API boots normally, every other route works, the signature endpoint returns 503, and each post falls back to the art generated from its slug. That is why `ServiceUnavailableError` (503) exists rather than reusing a 500.
- **All three credentials or none.** `loadEnv` rejects a partial set at boot. A half-configured app looks fine and then fails at Cloudinary with an opaque error — much worse than refusing to start.
- **`''` counts as unset.** Compose and Render both render an absent variable as an empty string rather than dropping it; without this the API would refuse to boot on any deployment without a Cloudinary account.
- **The folder is a key, never a path.** `signUpload('covers')` looks up `FOLDERS.covers`. Taking a path from the request would let any signed-in user write anywhere in the account.
- **Public ID persisted, URL derived.** `deliveryUrl()` builds the URL at the serialization boundary, so documents stay host-independent and the client never needs the cloud name. `f_auto,q_auto` does most of the free-tier bandwidth saving.
- **Two layers on the public ID.** The shared Zod schema shapes it, and `publicIdFrom()` re-checks it is under one of our folders before persisting — the browser reports what Cloudinary *said* it returned, and a client can lie.
- **`null` clears a cover; an absent key leaves it alone.** Collapsing those would wipe the cover on any unrelated edit. Covered by a test.

## Verification — against live Cloudinary, not just mocks

| Step | Result |
|---|---|
| Signature endpoint behind `requireAuth` | 200; API secret absent from the response |
| Cloudinary accepts the SDK signature | asset created |
| Scoped to our folder | `blogchat/covers/…` |
| `PATCH` persists the public ID, `coverUrl` derived | `…/c_limit,f_auto,q_auto,w_1200/…` |
| Delivery URL serves | HTTP 200, `image/png` |
| Foreign public ID | 400, `"Must be an image uploaded through this site"` |
| Post with no cover | falls back to generated art |

Delivery is doing real work: **7,831 bytes uploaded → 382 bytes served**.

`npm run test` — **397/397 pass**, 45 files. Client builds clean. Not run locally: `typecheck`/`lint` (CI owns them) and E2E.

## Deploying

`render.yaml` declares all three as `sync: false`, so Render prompts for them and they are never committed. Without them the service still deploys and runs — uploads simply report 503.