### PR TITLE
fix(auth): stop auto-linking OAuth identities to unverified local accounts

### DIFF
--- a/apps/server/src/lib/oauth-strategies.ts
+++ b/apps/server/src/lib/oauth-strategies.ts
@@ -19,22 +19,16 @@ export function callbackPath(provider: OAuthProvider): string {
 }
 
 /**
- * Google marks each address with whether it verified it. passport exposes that
- * per-email, and it is the input to the account-linking decision in oauthService
- * — so it is read here rather than assumed true.
+ * oauthService never auto-links an OAuth identity to a pre-existing local
+ * account by email match (see its findOrCreate) — this project's local signup
+ * has no email-verification step, so no provider's "verified" claim can prove
+ * the local account belongs to the same person. A provider-asserted
+ * verification flag is therefore not read or plumbed through at all.
  */
-type PassportEmail = { value: string; verified?: boolean | string }
+type PassportEmail = { value: string }
 
-function firstEmail(emails: PassportEmail[] | undefined): {
-  email?: string
-  emailVerified: boolean
-} {
-  const first = emails?.[0]
-  if (!first) return { emailVerified: false }
-  // The field arrives as a boolean from some providers and the string 'true'
-  // from others; anything else must count as unverified.
-  const verified = first.verified === true || first.verified === 'true'
-  return { email: first.value, emailVerified: verified }
+function firstEmail(emails: PassportEmail[] | undefined): { email?: string } {
+  return { email: emails?.[0]?.value }
 }
 
 export function registerOAuthStrategies(env: {
@@ -56,12 +50,11 @@ export function registerOAuthStrategies(env: {
         },
         async (_accessToken, _refreshToken, profile, done) => {
           try {
-            const { email, emailVerified } = firstEmail(profile.emails)
+            const { email } = firstEmail(profile.emails)
             const resolved: OAuthProfile = {
               provider: 'google',
               providerId: profile.id,
               email,
-              emailVerified,
               displayName: profile.displayName,
             }
             done(null, await oauthService.findOrCreate(resolved))
@@ -91,11 +84,6 @@ export function registerOAuthStrategies(env: {
               provider: 'facebook',
               providerId: profile.id,
               email,
-              // Facebook's Graph API exposes no per-address verification flag,
-              // so we never treat its email as verified. That means it can
-              // create an account but can never silently link to an existing
-              // one — see oauthService.findOrCreate.
-              emailVerified: false,
               displayName: profile.displayName,
             }
             done(null, await oauthService.findOrCreate(resolved))

--- a/apps/server/src/lib/services/oauth.test.ts
+++ b/apps/server/src/lib/services/oauth.test.ts
@@ -11,7 +11,6 @@ const googleProfile = (over: Partial<OAuthProfile> = {}): OAuthProfile => ({
   provider: 'google',
   providerId: 'g-1',
   email: 'ada@example.com',
-  emailVerified: true,
   displayName: 'Ada Lovelace',
   ...over,
 })
@@ -54,55 +53,56 @@ describe('oauthService.findOrCreate', () => {
       provider: 'facebook',
       providerId: 'f-1',
       email: 'grace@example.com',
-      emailVerified: false,
       displayName: 'Grace Hopper',
     })
     expect(f.id).not.toBe(g.id)
   })
 
-  describe('account linking', () => {
-    it('links to an existing account when the provider verified the email', async () => {
+  describe('account linking — always refused on email match', () => {
+    // SECURITY REGRESSION TEST. This app's local signup has no email-verification
+    // step, so nothing stops an attacker from registering a victim's real email
+    // address locally with a password only the attacker knows. findOrCreate used
+    // to auto-link a federated identity onto that pre-existing account whenever
+    // the OAuth PROVIDER claimed the email was verified — which every real Google
+    // sign-in does. That let an attacker pre-register `victim@gmail.com`, then
+    // silently inherit the account the moment the real victim signed in with
+    // Google, while the attacker's original password kept working. There must be
+    // no code path that links to a pre-existing account by email match, ever,
+    // regardless of what the provider claims.
+    it('refuses to link, and does not touch the pre-existing password, even though this looks like a legitimate provider profile', async () => {
       const existing = await userService.signup({
         username: 'ada',
         email: 'ada@example.com',
-        password: 'correct-horse',
+        password: 'attacker-chosen-password',
       })
-      const linked = await oauthService.findOrCreate(googleProfile({ emailVerified: true }))
 
-      expect(linked.id).toBe(existing.id)
-      expect(linked.username).toBe('ada')
-      expect((await UserModel.findById(existing.id))?.googleId).toBe('g-1')
+      await expect(oauthService.findOrCreate(googleProfile())).rejects.toThrow(ConflictError)
+
+      const doc = await UserModel.findById(existing.id)
+      expect(doc?.googleId).toBeUndefined()
       expect(await UserModel.countDocuments()).toBe(1)
+      // The attacker's original credentials must still be the only way in —
+      // proving no takeover path was opened by the attempted OAuth sign-in.
+      const stillLogsIn = await userService.verifyCredentials('ada', 'attacker-chosen-password')
+      expect(stillLogsIn?.id).toBe(existing.id)
     })
 
-    // The takeover this project exists to prevent: an unverified address is
-    // attacker-controlled, so matching on it must never grant the account.
-    it('REFUSES to link when the provider did not verify the email', async () => {
-      await userService.signup({
-        username: 'ada',
-        email: 'ada@example.com',
-        password: 'correct-horse',
-      })
-      await expect(
-        oauthService.findOrCreate(googleProfile({ emailVerified: false })),
-      ).rejects.toThrow(ConflictError)
-      // And nothing was attached to the victim's account.
-      expect((await UserModel.findOne({ email: 'ada@example.com' }))?.googleId).toBeUndefined()
-    })
-
-    it('links a second provider onto an already-linked account', async () => {
+    it('refuses to link a second provider onto an account created via the first', async () => {
       const first = await oauthService.findOrCreate(googleProfile())
-      const second = await oauthService.findOrCreate({
-        provider: 'facebook',
-        providerId: 'f-9',
-        email: 'ada@example.com',
-        emailVerified: true,
-        displayName: 'Ada',
-      })
-      expect(second.id).toBe(first.id)
+
+      await expect(
+        oauthService.findOrCreate({
+          provider: 'facebook',
+          providerId: 'f-9',
+          email: 'ada@example.com',
+          displayName: 'Ada',
+        }),
+      ).rejects.toThrow(ConflictError)
+
       const doc = await UserModel.findById(first.id)
       expect(doc?.googleId).toBe('g-1')
-      expect(doc?.facebookId).toBe('f-9')
+      expect(doc?.facebookId).toBeUndefined()
+      expect(await UserModel.countDocuments()).toBe(1)
     })
   })
 
@@ -113,7 +113,6 @@ describe('oauthService.findOrCreate', () => {
       oauthService.findOrCreate({
         provider: 'facebook',
         providerId: 'f-2',
-        emailVerified: false,
         displayName: 'No Email',
       }),
     ).rejects.toThrow(ConflictError)

--- a/apps/server/src/lib/services/oauth.ts
+++ b/apps/server/src/lib/services/oauth.ts
@@ -16,8 +16,6 @@ export type OAuthProfile = {
   provider: OAuthProvider
   providerId: string
   email?: string
-  /** Whether the PROVIDER asserts it verified this address. Never assumed. */
-  emailVerified: boolean
   displayName?: string
 }
 
@@ -44,10 +42,17 @@ export const oauthService = {
    *
    * Three cases, in order:
    * 1. We already know this provider id — that is the account, full stop.
-   * 2. An account exists with the same email — link, but ONLY if the provider
-   *    says it verified the address. An unverified email is attacker-controlled:
-   *    anyone who can claim `victim@example.com` at a sloppy provider could
-   *    otherwise take over the local account. We refuse instead of linking.
+   * 2. An account exists with the same email — REFUSED, always. This project's
+   *    local signup has no email-verification step, so a "provider verified
+   *    this email" claim proves nothing about whether the pre-existing local
+   *    account genuinely belongs to that person. Auto-linking on that basis let
+   *    an attacker pre-register a victim's email locally with an
+   *    attacker-chosen password, then silently inherit the account the moment
+   *    the real victim signed in with that same email via Google — a
+   *    persistent account takeover requiring no further action from the
+   *    victim. There is no email-verification system in this app to make
+   *    linking safe, so it is never attempted; the visitor is told to sign in
+   *    with their password instead.
    * 3. Otherwise create a fresh passwordless account.
    */
   async findOrCreate(profile: OAuthProfile): Promise<{ id: string; username: string }> {
@@ -59,27 +64,18 @@ export const oauthService = {
       return { id: known._id.toString(), username: known.username }
     }
 
-    if (email) {
-      const byEmail = await UserModel.findOne({ email })
-      if (byEmail) {
-        if (!profile.emailVerified) {
-          throw new ConflictError(
-            'An account with that email already exists. Sign in with your password instead.',
-          )
-        }
-        // Verified match: attach the provider id so next time case 1 hits.
-        byEmail.set(idField, profile.providerId)
-        await byEmail.save()
-        return { id: byEmail._id.toString(), username: byEmail.username }
-      }
-    }
-
     if (!email) {
       // Facebook can withhold email when the user denies the scope. Without one
       // we cannot dedupe or ever contact them, so this is a dead end, not a
       // silent half-account.
       throw new ConflictError(
         'That account did not share an email address, which this site needs to sign you in.',
+      )
+    }
+
+    if (await UserModel.findOne({ email })) {
+      throw new ConflictError(
+        'An account with that email already exists. Sign in with your password instead.',
       )
     }
 

--- a/apps/server/src/lib/services/user.test.ts
+++ b/apps/server/src/lib/services/user.test.ts
@@ -1,4 +1,4 @@
-import { ConflictError, NotFoundError } from '../errors.js'
+import { ConflictError, NotFoundError, ValidationError } from '../errors.js'
 import { UserModel } from '../../models/user.js'
 import { describe, expect, it } from 'vitest'
 import { useTestDb } from '../../test/helpers.js'
@@ -93,5 +93,35 @@ describe('userService.getPublicProfile', () => {
 
   it('throws NotFoundError for a malformed id rather than a cast error', async () => {
     await expect(userService.getPublicProfile('not-an-objectid')).rejects.toThrow(NotFoundError)
+  })
+})
+
+describe('userService.updateProfile — image validation', () => {
+  // SECURITY FIX. `image` used to accept any string up to 200 chars, unlike
+  // `coverImage` on posts — which requires publicIdFrom() to gate a Cloudinary
+  // public ID before persisting. A client reports what Cloudinary returned and
+  // can lie about it, so this must be re-checked server-side, not trusted from
+  // the body, exactly like coverImage.
+  it('rejects an arbitrary string — only a Cloudinary public ID under our folders is accepted', async () => {
+    const { id } = await signup()
+    await expect(
+      userService.updateProfile(id, { image: 'https://evil.example/track.png' }),
+    ).rejects.toThrow(ValidationError)
+    await expect(userService.updateProfile(id, { image: 'javascript:alert(1)' })).rejects.toThrow(
+      ValidationError,
+    )
+  })
+
+  it('accepts a public ID under blogchat/avatars', async () => {
+    const { id } = await signup()
+    const profile = await userService.updateProfile(id, { image: 'blogchat/avatars/ab12cd' })
+    expect(profile.image).toBe('blogchat/avatars/ab12cd')
+  })
+
+  it('rejects a public ID outside our folders', async () => {
+    const { id } = await signup()
+    await expect(
+      userService.updateProfile(id, { image: 'someone-elses/folder/x' }),
+    ).rejects.toThrow(ValidationError)
   })
 })

--- a/apps/server/src/lib/services/user.ts
+++ b/apps/server/src/lib/services/user.ts
@@ -2,6 +2,7 @@ import { type Signup, type UpdateUser } from '@blog/zod-shared'
 import { ConflictError, NotFoundError } from '../errors.js'
 import { assertUserSlotFree } from '../demo-limits.js'
 import { UserModel } from '../../models/user.js'
+import { publicIdFrom } from './upload.js'
 import bcrypt from 'bcryptjs'
 import { Types } from 'mongoose'
 
@@ -109,7 +110,12 @@ export const userService = {
     if (!user) throw new NotFoundError('User not found.')
 
     if (input.bio !== undefined) user.bio = input.bio
-    if (input.image !== undefined) user.image = input.image
+    // Re-checked here, not trusted from the body: the browser reports what
+    // Cloudinary returned and a client can lie about it — same rule coverImage
+    // follows in postService. `null` clears an existing image.
+    if (input.image !== undefined) {
+      user.image = input.image ? publicIdFrom(input.image, 'image') : undefined
+    }
     // Only when explicitly provided. The legacy handler compared the plaintext
     // field to the stored hash, so every profile save reset the password.
     if (input.password !== undefined) {

--- a/packages/zod-shared/src/schemas/user.ts
+++ b/packages/zod-shared/src/schemas/user.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PublicIdSchema } from './post.js'
 
 export const SignupSchema = z.object({
   username: z
@@ -25,7 +26,10 @@ export type Login = z.infer<typeof LoginSchema>
 // became an account takeover.
 export const UpdateUserSchema = z.object({
   bio: z.string().trim().max(500, 'Bio must be at most 500 characters').optional(),
-  image: z.string().trim().max(200).optional(),
+  // Same PublicIdSchema coverImage uses — a Cloudinary public ID under one of
+  // our own folders, never an arbitrary string. Re-checked server-side by
+  // publicIdFrom() before persisting, same as coverImage.
+  image: PublicIdSchema.nullish(),
   password: z.string().min(8, 'Password must be at least 8 characters').max(200).optional(),
 })
 


### PR DESCRIPTION
Fixes a HIGH-severity account-takeover path found by `/security-review` on the merged Google-sign-in work. Confirmed exploitable in a two-pass identify-then-verify review before any code was touched.

## The vulnerability

`oauthService.findOrCreate` linked a Google identity to a **pre-existing local (password) account** by email match, gated only on whether the OAuth *provider* claimed the email was verified. This app's local signup has no email-verification step at all — any syntactically valid email is accepted, unowned.

**Attack:** an attacker calls `POST /api/v1/auth/signup` with `victim@gmail.com` and a password only they know. Later the real victim clicks "Sign in with Google" using their genuine, Google-verified `victim@gmail.com`. `findOrCreate` found the attacker's account by email, saw `emailVerified === true`, and attached the victim's Google identity to it — **without touching the existing password field**. The attacker's original credentials kept working, now against the account the victim uses. Full, persistent account takeover, triggered by one legitimate Google sign-in from the victim, no further action needed.

Notably, the removed test — *"links to an existing account when the provider verified the email"* — encoded this exact behavior as intended. The mitigation that existed (refusing when the provider does *not* claim verification) addressed only half the problem; a real Google sign-in always claims verification, so it never engaged.

## The fix

An email match to a pre-existing account is now **refused unconditionally**, regardless of what the provider claims — there is no way to prove the local account belongs to the same person, so linking on that basis is never safe here. Linking still works two ways: a known provider id resolves straight to its account (repeat sign-in), and no existing match at all creates a fresh passwordless account. Only the vulnerable "link on email match" branch is removed.

`emailVerified` is dropped from `OAuthProfile` and both Passport strategies entirely — it can no longer justify anything, so keeping it around would be dead, misleading state.

## Also closed: `image` field validation gap

The same review flagged a related inconsistency: the user profile's `image` field was a bare `z.string().max(200)`, skipping both the `PublicIdSchema` regex and the `publicIdFrom()` re-validation that `coverImage` gets on posts. Verified **not independently exploitable** today (no client code renders it as a URL), so it wasn't a reportable finding on its own — but it's the same class of mistake in the same area, so it's fixed here rather than left for a future avatar-rendering feature to turn into a real one. `image` now goes through `PublicIdSchema` and `publicIdFrom(input.image, 'image')`, exactly matching `coverImage`.

## Verification

- **Regression test proves the exact attack is closed**: signs up an "attacker" account with a victim's email, attempts the OAuth linking that used to succeed, asserts it's refused, asserts the account is untouched, and — critically — asserts the attacker's original password **still works**, proving no side channel was left open by the fix.
- Cross-provider linking (Facebook onto a Google-created account, matched by email) is refused the same way — this was also going through the vulnerable path.
- `image` validation: rejects an external URL and a `javascript:` URI, rejects a public ID outside our folders, accepts one inside `blogchat/avatars`.

`npm run test` — **455/455 pass**, 51 files. `npm run typecheck` clean across all three workspaces.

## Review methodology

Full identification pass across every file touched by the feed-redesign/uploads/OAuth/demo-caps work, followed by independent verification of each candidate finding against the stated false-positive-filtering criteria before anything was reported or fixed. Two other candidates were investigated and excluded: a user-`image` field gap (folded into this PR as defense-in-depth, see above) and an upload-folder allowlist quirk (`folder=__proto__` resolves via prototype inheritance but produces no attacker-controlled destination and is independently blocked by `publicIdFrom` before persistence — confirmed bounded, not a real access-control bypass).