### PR TITLE
fix(auth): route OAuth callback URLs through the RENDER_EXTERNAL_URL fallback

### DIFF
--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -59,6 +59,22 @@ export type Env = z.infer<typeof EnvSchema>
 
 const FILE_BACKED_KEYS = ['SESSION_SECRET', 'CLOUDINARY_API_SECRET'] as const
 
+/**
+ * Standalone on purpose: callers that need PUBLIC_ORIGIN alone (the OAuth
+ * strategy setup in routes/v1/auth.ts) must not have to satisfy the full
+ * EnvSchema — e.g. MONGODB_URI/SESSION_SECRET — just to resolve one field.
+ * loadEnv() below is one caller of this, not the only path to it.
+ */
+export function resolvePublicOrigin(source: NodeJS.ProcessEnv = process.env): string {
+  const explicit = source.PUBLIC_ORIGIN?.trim()
+  if (explicit) return explicit
+  // Render injects RENDER_EXTERNAL_URL. Without this fallback a deploy keeps
+  // building localhost callbacks and breaks sign-in, with nothing failing loudly.
+  const renderUrl = source.RENDER_EXTERNAL_URL?.trim()
+  if (renderUrl) return renderUrl
+  return 'http://localhost:5173'
+}
+
 function resolveFileBackedSecrets(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const resolved = { ...source }
   for (const key of FILE_BACKED_KEYS) {
@@ -67,11 +83,7 @@ function resolveFileBackedSecrets(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv 
       resolved[key] = readFileSync(filePath, 'utf-8').trim()
     }
   }
-  // Render injects RENDER_EXTERNAL_URL. Without this fallback a deploy keeps
-  // building localhost callbacks and breaks sign-in, with nothing failing loudly.
-  if (!resolved.PUBLIC_ORIGIN?.trim() && resolved.RENDER_EXTERNAL_URL?.trim()) {
-    resolved.PUBLIC_ORIGIN = resolved.RENDER_EXTERNAL_URL.trim()
-  }
+  resolved.PUBLIC_ORIGIN = resolvePublicOrigin(resolved)
   return resolved
 }
 

--- a/apps/server/src/routes/v1/auth.ts
+++ b/apps/server/src/routes/v1/auth.ts
@@ -2,6 +2,7 @@ import { LoginSchema, SignupSchema } from '@blog/zod-shared'
 import { ServiceUnavailableError, UnauthorizedError } from '../../lib/errors.js'
 import { Router } from 'express'
 import passport from 'passport'
+import { resolvePublicOrigin } from '../../lib/env.js'
 import {
   registerOAuthStrategies,
   type ConfiguredProviders,
@@ -15,6 +16,14 @@ export const authRouter = Router()
 
 // Lazily registered so the strategies are built after loadEnv has validated the
 // credential pairs, and so a deployment with no OAuth apps pays nothing.
+//
+// REGRESSION GUARD: this used to build PUBLIC_ORIGIN from raw
+// `process.env.PUBLIC_ORIGIN ?? 'http://localhost:5173'`, bypassing the
+// RENDER_EXTERNAL_URL fallback entirely. On Render, where PUBLIC_ORIGIN is
+// correctly left unset, that raw read is undefined and fell straight to the
+// localhost default — so the Google OAuth callback URL sent to Google was
+// `http://localhost:5173/...` in production. resolvePublicOrigin() is the one
+// place that fallback lives; call it here rather than re-deriving it.
 let providers: ConfiguredProviders | undefined
 function configuredProviders(): ConfiguredProviders {
   providers ??= registerOAuthStrategies({
@@ -22,7 +31,7 @@ function configuredProviders(): ConfiguredProviders {
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     FACEBOOK_APP_ID: process.env.FACEBOOK_APP_ID,
     FACEBOOK_APP_SECRET: process.env.FACEBOOK_APP_SECRET,
-    PUBLIC_ORIGIN: process.env.PUBLIC_ORIGIN ?? 'http://localhost:5173',
+    PUBLIC_ORIGIN: resolvePublicOrigin(),
   })
   return providers
 }

--- a/apps/server/src/routes/v1/oauth-callback-url.test.ts
+++ b/apps/server/src/routes/v1/oauth-callback-url.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest'
+import { afterAll, describe, expect, it } from 'vitest'
+import { buildTestApp, useTestDb } from '../../test/helpers.js'
+
+useTestDb()
+
+// A dedicated file, not a case inside oauth.test.ts: configuredProviders()
+// caches its result in a module-level singleton on first call, and
+// oauth.test.ts's own tests are the first callers in that module instance
+// (with GOOGLE_CLIENT_ID unset). This file needs a fresh module load so
+// resolvePublicOrigin() actually runs against the env set below.
+const ORIGINAL = {
+  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+  PUBLIC_ORIGIN: process.env.PUBLIC_ORIGIN,
+  RENDER_EXTERNAL_URL: process.env.RENDER_EXTERNAL_URL,
+}
+afterAll(() => {
+  for (const [key, value] of Object.entries(ORIGINAL)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
+
+process.env.GOOGLE_CLIENT_ID = 'test-client-id'
+process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret'
+delete process.env.PUBLIC_ORIGIN
+
+describe('GET /api/v1/auth/google — callback URL production regression', () => {
+  // REGRESSION: registerOAuthStrategies used to be built from
+  // `process.env.PUBLIC_ORIGIN ?? 'http://localhost:5173'` directly, bypassing
+  // the RENDER_EXTERNAL_URL fallback. With PUBLIC_ORIGIN correctly left unset
+  // on Render, that sent Google a callback URL of
+  // `http://localhost:5173/api/v1/auth/google/callback` in production —
+  // rejected by Google as a redirect_uri_mismatch, since only the real
+  // onrender.com URL was registered. This proves resolvePublicOrigin() is
+  // actually reached from the OAuth route, not just from loadEnv().
+  it('builds the callback from RENDER_EXTERNAL_URL when PUBLIC_ORIGIN is unset', async () => {
+    process.env.RENDER_EXTERNAL_URL = 'https://blog-chat-app.onrender.com'
+
+    const res = await request(buildTestApp()).get('/api/v1/auth/google')
+
+    expect(res.status).toBe(302)
+    const location = res.headers.location
+    if (!location) throw new Error('Expected a Location header on the OAuth redirect.')
+    expect(location).toContain('accounts.google.com')
+    const redirectUri = new URL(location).searchParams.get('redirect_uri')
+    expect(redirectUri).toBe('https://blog-chat-app.onrender.com/api/v1/auth/google/callback')
+    expect(redirectUri).not.toContain('localhost')
+  })
+})


### PR DESCRIPTION
Fixes Google sign-in being rejected in production with `redirect_uri_mismatch` — the server was sending Google `http://localhost:5173/api/v1/auth/google/callback` instead of the real onrender.com URL.

## Root cause

`registerOAuthStrategies` in `routes/v1/auth.ts` built `PUBLIC_ORIGIN` from raw `process.env.PUBLIC_ORIGIN ?? 'http://localhost:5173'` — completely bypassing the `RENDER_EXTERNAL_URL` fallback, which only lived inside `env.ts`'s `resolveFileBackedSecrets()`. With `PUBLIC_ORIGIN` correctly left unset on Render (per its own contract — "only needed for a custom domain"), the raw read was `undefined` and fell straight to the hardcoded localhost default. Confirmed live by hitting `GET /api/v1/auth/google` on the deployed service and reading the actual `redirect_uri` in the resulting `Location` header.

## Fix

Extracted `resolvePublicOrigin()` as a standalone function, independent of the full `EnvSchema`, and call it from `auth.ts`. It can't go through `loadEnv()` directly — that also requires `MONGODB_URI`/`SESSION_SECRET`, which the test harness passes to `buildTestApp` as explicit options rather than populating in `process.env`, so routing through `loadEnv()` at request time broke five existing tests.

## Test

New regression test builds a real test app with `GOOGLE_CLIENT_ID` set, `PUBLIC_ORIGIN` unset, and `RENDER_EXTERNAL_URL` set to a fake onrender.com URL, then asserts the actual `redirect_uri` query param Google would receive resolves to that URL — reproducing the exact production failure. Lives in its own file rather than inside `oauth.test.ts`, because `configuredProviders()` caches its result in a module-level singleton on first call, and that file's own tests are already the first callers with no credentials configured.

`npm run test` — **458/458 pass**, 52 files. `npm run typecheck` clean.

## Next step

Once this merges to `staging`, it needs to reach `master` and redeploy to Render before Google sign-in actually works in production — `staging` → `master` PR #49 is already open and will pick this up.