### PR TITLE
Self-service account management and public profiles

### DIFF
--- a/apps/client/src/api/users.ts
+++ b/apps/client/src/api/users.ts
@@ -1,8 +1,22 @@
 import { request } from './client.js'
 import type { z } from 'zod'
-import { UpdateUserSchema } from '@blog/zod-shared'
+import { DeleteUserSchema, UpdateUserSchema } from '@blog/zod-shared'
 
-export type UserProfile = { id: string; username: string; bio?: string; avatar?: string }
+/**
+ * `email`/`hasPassword`/`oauthProvider` are only ever present when the
+ * requester is viewing their own account — see userService.getPublicProfile's
+ * viewerId gate. Anyone else's profile arrives without them.
+ */
+export type UserProfile = {
+  id: string
+  username: string
+  bio?: string
+  image?: string
+  createdAt: string
+  email?: string
+  hasPassword?: boolean
+  oauthProvider?: 'google' | 'facebook' | null
+}
 
 export const usersApi = {
   get: (id: string) => request<UserProfile>(`/api/v1/users/${id}`),
@@ -10,5 +24,6 @@ export const usersApi = {
   update: (id: string, input: z.infer<typeof UpdateUserSchema>) =>
     request<UserProfile>(`/api/v1/users/${id}`, { method: 'PATCH', body: JSON.stringify(input) }),
 
-  remove: (id: string) => request<void>(`/api/v1/users/${id}`, { method: 'DELETE' }),
+  remove: (id: string, confirmation: z.infer<typeof DeleteUserSchema>) =>
+    request<void>(`/api/v1/users/${id}`, { method: 'DELETE', body: JSON.stringify(confirmation) }),
 }

--- a/apps/client/src/components/layouts/PageShell.tsx
+++ b/apps/client/src/components/layouts/PageShell.tsx
@@ -39,7 +39,9 @@ export function PageShell({ children }: { children: React.ReactNode }) {
                   New post
                 </NavLink>
                 <span aria-hidden="true" className="h-4 w-px bg-[var(--border)]" />
-                <span className="text-[var(--ink-faint)]">{me.username}</span>
+                <Link to="/account" className="text-[var(--ink-faint)] hover:text-[var(--foreground)]">
+                  {me.username}
+                </Link>
                 {/* There is no /logout route — logging out is a POST, not a
                     page. Navigating there rendered a dead end. */}
                 <button

--- a/apps/client/src/components/patterns/AutoForm.test.tsx
+++ b/apps/client/src/components/patterns/AutoForm.test.tsx
@@ -14,7 +14,7 @@ const schema = z.object({
 })
 
 function addTag(tag: string) {
-  const input = screen.getByLabelText('tags')
+  const input = screen.getByLabelText('Tags')
   fireEvent.change(input, { target: { value: tag } })
   fireEvent.keyDown(input, { key: 'Enter' })
 }
@@ -24,15 +24,15 @@ describe('AutoForm', () => {
 
   it('renders one labeled field per schema key', () => {
     render(<AutoForm schema={schema} onSubmit={vi.fn()} />)
-    expect(screen.getByLabelText('title')).toBeInTheDocument()
-    expect(screen.getByLabelText('draft')).toBeInTheDocument()
-    expect(screen.getByLabelText('tags')).toBeInTheDocument()
+    expect(screen.getByLabelText('Title')).toBeInTheDocument()
+    expect(screen.getByLabelText('Draft')).toBeInTheDocument()
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument()
   })
 
   it('derives the control from the schema type, not the field name', () => {
     render(<AutoForm schema={schema} onSubmit={vi.fn()} />)
-    expect(screen.getByLabelText('draft')).toHaveAttribute('type', 'checkbox')
-    expect(screen.getByLabelText('tags')).toHaveAttribute('type', 'text')
+    expect(screen.getByLabelText('Draft')).toHaveAttribute('type', 'checkbox')
+    expect(screen.getByLabelText('Tags')).toHaveAttribute('type', 'text')
   })
 
   // `.partial()` wraps every field in ZodOptional *outside* the ZodDefault that
@@ -41,11 +41,11 @@ describe('AutoForm', () => {
   it('still derives field kinds through a .partial() schema', () => {
     const onSubmit = vi.fn()
     render(<AutoForm schema={schema.partial()} onSubmit={onSubmit} />)
-    expect(screen.getByLabelText('draft')).toHaveAttribute('type', 'checkbox')
+    expect(screen.getByLabelText('Draft')).toHaveAttribute('type', 'checkbox')
 
     addTag('express')
     addTag('testing')
-    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'A valid title' } })
     fireEvent.click(screen.getByText('Save'))
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tags: ['express', 'testing'] }))
   })
@@ -53,7 +53,7 @@ describe('AutoForm', () => {
   it('shows the schema error message and does not call onSubmit for invalid input', () => {
     const onSubmit = vi.fn()
     render(<AutoForm schema={schema} onSubmit={onSubmit} />)
-    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'ab' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'ab' } })
     fireEvent.click(screen.getByText('Save'))
     expect(screen.getByText('Title must be at least 3 characters')).toBeInTheDocument()
     expect(onSubmit).not.toHaveBeenCalled()
@@ -62,7 +62,7 @@ describe('AutoForm', () => {
   it('submits the tags added one at a time as a string array', () => {
     const onSubmit = vi.fn()
     render(<AutoForm schema={schema} onSubmit={onSubmit} />)
-    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'A valid title' } })
     addTag('express')
     addTag('testing')
     expect(screen.getByText('express')).toBeInTheDocument()
@@ -75,7 +75,7 @@ describe('AutoForm', () => {
   it('drops a tag removed with its × button', () => {
     const onSubmit = vi.fn()
     render(<AutoForm schema={schema} onSubmit={onSubmit} />)
-    fireEvent.change(screen.getByLabelText('title'), { target: { value: 'A valid title' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'A valid title' } })
     addTag('keep')
     addTag('drop')
     fireEvent.click(screen.getByLabelText('Remove tag drop'))
@@ -92,11 +92,11 @@ describe('AutoForm', () => {
         submitLabel="Save changes"
       />,
     )
-    expect(screen.getByLabelText('title')).toHaveValue('Seeded')
-    expect(screen.getByLabelText('draft')).toBeChecked()
+    expect(screen.getByLabelText('Title')).toHaveValue('Seeded')
+    expect(screen.getByLabelText('Draft')).toBeChecked()
     expect(screen.getByText('a')).toBeInTheDocument()
     expect(screen.getByText('b')).toBeInTheDocument()
-    expect(screen.getByLabelText('tags')).toHaveValue('')
+    expect(screen.getByLabelText('Tags')).toHaveValue('')
     expect(screen.getByText('Save changes')).toBeInTheDocument()
   })
 })

--- a/apps/client/src/components/patterns/AutoForm.tsx
+++ b/apps/client/src/components/patterns/AutoForm.tsx
@@ -3,11 +3,18 @@ import { ZodFirstPartyTypeKind, type z, type ZodObject, type ZodRawShape, type Z
 import { Button } from '../ui/button.js'
 import { Input } from '../ui/input.js'
 import { Label } from '../ui/label.js'
+import { PasswordInput } from '../ui/password-input.js'
 import { Textarea } from '../ui/textarea.js'
 import { ImageUpload } from './ImageUpload.js'
 import { TagsInput } from './TagsInput.js'
 
-type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'image' | 'text'
+type FieldKind = 'checkbox' | 'textarea' | 'tags' | 'image' | 'password' | 'text'
+
+/** "currentPassword" -> "Current Password"; "coverImage" -> "Cover Image". */
+function humanize(key: string): string {
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
 
 /**
  * `ZodTypeDef` is the public (near-empty) shape of `_def`; the discriminant and
@@ -53,6 +60,7 @@ function fieldKind(key: string, schema: ZodTypeAny): FieldKind {
   // Keyed by name, not by type: a public ID is a plain string to zod, and a raw
   // text box for one would be unusable — nobody types a Cloudinary ID by hand.
   if (key === 'coverImage' || key === 'avatar') return 'image'
+  if (key.toLowerCase().includes('password')) return 'password'
   return 'text'
 }
 
@@ -129,7 +137,7 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
         return (
           <div key={key} className="flex flex-col gap-1">
             {/* ImageUpload renders its own label and controls. */}
-            {kind !== 'image' && <Label htmlFor={key}>{key}</Label>}
+            {kind !== 'image' && <Label htmlFor={key}>{humanize(key)}</Label>}
             {kind === 'image' ? (
               <ImageUpload
                 value={typeof values[key] === 'string' ? (values[key] as string) : null}
@@ -153,6 +161,12 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
               />
             ) : kind === 'textarea' ? (
               <Textarea
+                id={key}
+                value={String(values[key] ?? '')}
+                onChange={(e) => setValues((v) => ({ ...v, [key]: e.target.value }))}
+              />
+            ) : kind === 'password' ? (
+              <PasswordInput
                 id={key}
                 value={String(values[key] ?? '')}
                 onChange={(e) => setValues((v) => ({ ...v, [key]: e.target.value }))}

--- a/apps/client/src/components/patterns/ChatRoom.test.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.test.tsx
@@ -3,8 +3,15 @@
 // apps/client/src/components/patterns/CommentForm.test.tsx does.
 import '@testing-library/jest-dom/vitest'
 import type { ChatMessage } from '@blog/zod-shared'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Every ChatRoom render needs a Router context now that author names link to
+// /users/:id — wrapped once here rather than passing { wrapper: MemoryRouter }
+// at every call site below.
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, { wrapper: MemoryRouter, ...options })
 import type { ChatStatus, ChatUser } from '../../hooks/use-chat.js'
 
 // Mocked so each test can drive ChatRoom through a specific hook state

--- a/apps/client/src/components/patterns/ChatRoom.test.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.test.tsx
@@ -3,16 +3,18 @@
 // apps/client/src/components/patterns/CommentForm.test.tsx does.
 import '@testing-library/jest-dom/vitest'
 import type { ChatMessage } from '@blog/zod-shared'
-import { cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render as rtlRender, screen, type RenderOptions } from '@testing-library/react'
+import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ChatStatus, ChatUser } from '../../hooks/use-chat.js'
 
 // Every ChatRoom render needs a Router context now that author names link to
 // /users/:id — wrapped once here rather than passing { wrapper: MemoryRouter }
 // at every call site below.
-const render: typeof rtlRender = (ui, options) =>
-  rtlRender(ui, { wrapper: MemoryRouter, ...options })
-import type { ChatStatus, ChatUser } from '../../hooks/use-chat.js'
+function render(ui: ReactElement, options?: RenderOptions) {
+  return rtlRender(ui, { wrapper: MemoryRouter, ...options })
+}
 
 // Mocked so each test can drive ChatRoom through a specific hook state
 // directly, instead of exercising the real socket.

--- a/apps/client/src/components/patterns/ChatRoom.tsx
+++ b/apps/client/src/components/patterns/ChatRoom.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router'
 import { Button } from '../ui/button.js'
 import { Input } from '../ui/input.js'
 import { useChat } from '../../hooks/use-chat.js'
@@ -46,7 +47,10 @@ export function ChatRoom() {
           <li key={m.id} className="text-sm">
             {m.author.username ? (
               <>
-                <span className="font-semibold">{m.author.username}</span> {m.body}
+                <Link to={`/users/${m.author.id}`} className="font-semibold hover:underline">
+                  {m.author.username}
+                </Link>{' '}
+                {m.body}
               </>
             ) : (
               m.body

--- a/apps/client/src/components/patterns/CommentThread.test.tsx
+++ b/apps/client/src/components/patterns/CommentThread.test.tsx
@@ -4,6 +4,7 @@
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildCommentTree, CommentThread } from './CommentThread.js'
 import { queryKeys } from '../../lib/query-client.js'
@@ -67,7 +68,9 @@ function renderThread(comments: Comment[], me: AuthUser | null) {
   client.setQueryData(queryKeys.me, me)
   return render(
     <QueryClientProvider client={client}>
-      <CommentThread slug="my-post" comments={buildCommentTree(comments)} />
+      <MemoryRouter>
+        <CommentThread slug="my-post" comments={buildCommentTree(comments)} />
+      </MemoryRouter>
     </QueryClientProvider>,
   )
 }

--- a/apps/client/src/components/patterns/CommentThread.tsx
+++ b/apps/client/src/components/patterns/CommentThread.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router'
 import { toast } from 'sonner'
 import { ApiError } from '../../api/client.js'
 import { useMe } from '../../hooks/use-auth.js'
@@ -54,7 +55,10 @@ function CommentItem({ slug, node, depth }: { slug: string; node: CommentNode; d
     <li className="flex flex-col gap-2">
       <article className="flex flex-col gap-1 border border-[var(--border)] p-3">
         <header className="text-xs text-[var(--muted-foreground)]">
-          {node.author.username} · {new Date(node.createdAt).toLocaleDateString()}
+          <Link to={`/users/${node.author.id}`} className="hover:text-[var(--foreground)]">
+            {node.author.username}
+          </Link>{' '}
+          · {new Date(node.createdAt).toLocaleDateString()}
         </header>
 
         {editing ? (

--- a/apps/client/src/components/patterns/PostCard.tsx
+++ b/apps/client/src/components/patterns/PostCard.tsx
@@ -15,7 +15,9 @@ export function PostCard({ post, featured = false }: { post: Post; featured?: bo
     <p className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase tabular-nums">
       <time dateTime={post.createdAt}>{formatDate(post.createdAt)}</time>
       <span aria-hidden="true">·</span>
-      <span>{post.author.username}</span>
+      <Link to={`/users/${post.author.id}`} className="hover:text-[var(--foreground)]">
+        {post.author.username}
+      </Link>
       <span aria-hidden="true">·</span>
       <span>
         {post.likeCount} {post.likeCount === 1 ? 'like' : 'likes'}

--- a/apps/client/src/components/ui/index.ts
+++ b/apps/client/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export { Button, type ButtonProps } from './button.js'
 export { Input } from './input.js'
+export { PasswordInput } from './password-input.js'
 export { Label } from './label.js'
 export { Textarea } from './textarea.js'
 export { Card } from './card.js'

--- a/apps/client/src/components/ui/password-input.tsx
+++ b/apps/client/src/components/ui/password-input.tsx
@@ -1,0 +1,35 @@
+import { Eye, EyeOff } from 'lucide-react'
+import { forwardRef, useState, type InputHTMLAttributes } from 'react'
+import { cn } from '../../lib/cn.js'
+import { Input } from './input.js'
+
+/**
+ * A password field hidden by default, with a toggle to reveal it — the same
+ * control on every password input in the app (login, signup, account).
+ */
+export const PasswordInput = forwardRef<
+  HTMLInputElement,
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+>(({ className, ...props }, ref) => {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <div className="relative">
+      <Input
+        ref={ref}
+        type={visible ? 'text' : 'password'}
+        className={cn('pr-10', className)}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        aria-label={visible ? 'Hide password' : 'Show password'}
+        className="absolute inset-y-0 right-0 flex w-10 items-center justify-center text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+      >
+        {visible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+      </button>
+    </div>
+  )
+})
+PasswordInput.displayName = 'PasswordInput'

--- a/apps/client/src/hooks/use-users.ts
+++ b/apps/client/src/hooks/use-users.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { DeleteUser, UpdateUser } from '@blog/zod-shared'
+import { usersApi } from '../api/users.js'
+import { queryKeys } from '../lib/query-client.js'
+
+/**
+ * Shared by `AccountPage` (self) and `UserProfilePage` (anyone) — the payload
+ * just varies by viewer, decided server-side (see userService.getPublicProfile).
+ */
+export function useUserProfile(id: string) {
+  return useQuery({
+    queryKey: queryKeys.users.detail(id),
+    queryFn: () => usersApi.get(id),
+    enabled: Boolean(id),
+  })
+}
+
+export function useUpdateUser(id: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: UpdateUser) => usersApi.update(id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.detail(id) })
+      // A username change must show up in PageShell's header immediately.
+      queryClient.invalidateQueries({ queryKey: queryKeys.me })
+    },
+  })
+}
+
+export function useDeleteUser(id: string) {
+  return useMutation({
+    mutationFn: (confirmation: DeleteUser) => usersApi.remove(id, confirmation),
+  })
+}

--- a/apps/client/src/pages/AccountPage.tsx
+++ b/apps/client/src/pages/AccountPage.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { UpdateUserSchema } from '@blog/zod-shared'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { ApiError } from '../api/client.js'
+import { AutoForm } from '../components/patterns/AutoForm.js'
+import { EmptyState } from '../components/patterns/EmptyState.js'
+import { RequireAuth } from '../components/patterns/RequireAuth.js'
+import { Button } from '../components/ui/button.js'
+import { Input } from '../components/ui/input.js'
+import { Label } from '../components/ui/label.js'
+import { Skeleton } from '../components/ui/skeleton.js'
+import { useMe } from '../hooks/use-auth.js'
+import { useDeleteUser, useUpdateUser, useUserProfile } from '../hooks/use-users.js'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '../lib/query-client.js'
+
+function AccountPageContent() {
+  // RequireAuth already redirected an anonymous visitor before this renders,
+  // so `me` is guaranteed here.
+  const { data: me } = useMe()
+  const id = me!.id
+  const { data: profile, isPending, isError } = useUserProfile(id)
+  const updateUser = useUpdateUser(id)
+  const deleteUser = useDeleteUser(id)
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [confirmValue, setConfirmValue] = useState('')
+
+  if (isPending) return <Skeleton className="h-64" />
+  if (isError || !profile || profile.hasPassword === undefined) {
+    return <EmptyState message="Could not load your account." />
+  }
+
+  // image editing is out of scope for now, and email is locked server-side for
+  // an OAuth-linked account — hidden here rather than shown and always 400ing.
+  // currentPassword only applies to an account that already has one; an OAuth
+  // account setting its first password has nothing to verify against.
+  const formSchema = UpdateUserSchema.omit({
+    image: true,
+    ...(profile.oauthProvider ? { email: true } : {}),
+    ...(!profile.hasPassword ? { currentPassword: true } : {}),
+  })
+
+  const hasPassword = profile.hasPassword
+
+  return (
+    <div className="flex max-w-lg flex-col gap-10">
+      <div>
+        <h1 className="mb-4 text-xl font-semibold">Account</h1>
+        <AutoForm
+          schema={formSchema}
+          initialValues={profile}
+          submitLabel="Save changes"
+          onSubmit={(values) =>
+            updateUser.mutate(values, {
+              onSuccess: () => toast.success('Account updated.'),
+              onError: (err) =>
+                toast.error(err instanceof ApiError ? err.message : 'Could not save changes.'),
+            })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-[var(--border)] pt-6">
+        <h2 className="text-sm font-semibold text-[var(--destructive)]">Danger zone</h2>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Deleting your account permanently removes your posts, comments, and likes.
+        </p>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="delete-confirm">
+            {hasPassword ? 'Enter your password to confirm' : 'Type your username to confirm'}
+          </Label>
+          <Input
+            id="delete-confirm"
+            type={hasPassword ? 'password' : 'text'}
+            value={confirmValue}
+            onChange={(e) => setConfirmValue(e.target.value)}
+          />
+        </div>
+        <Button
+          variant="destructive"
+          disabled={deleteUser.isPending || !confirmValue}
+          onClick={() =>
+            deleteUser.mutate(
+              hasPassword
+                ? { currentPassword: confirmValue }
+                : { usernameConfirmation: confirmValue },
+              {
+                onSuccess: () => {
+                  queryClient.setQueryData(queryKeys.me, null)
+                  queryClient.invalidateQueries({ queryKey: queryKeys.posts.all })
+                  navigate('/')
+                },
+                onError: (err) =>
+                  toast.error(err instanceof ApiError ? err.message : 'Could not delete your account.'),
+              },
+            )
+          }
+        >
+          Delete account
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function AccountPage() {
+  return (
+    <RequireAuth>
+      <AccountPageContent />
+    </RequireAuth>
+  )
+}

--- a/apps/client/src/pages/AccountPage.tsx
+++ b/apps/client/src/pages/AccountPage.tsx
@@ -9,6 +9,7 @@ import { RequireAuth } from '../components/patterns/RequireAuth.js'
 import { Button } from '../components/ui/button.js'
 import { Input } from '../components/ui/input.js'
 import { Label } from '../components/ui/label.js'
+import { PasswordInput } from '../components/ui/password-input.js'
 import { Skeleton } from '../components/ui/skeleton.js'
 import { useMe } from '../hooks/use-auth.js'
 import { useDeleteUser, useUpdateUser, useUserProfile } from '../hooks/use-users.js'
@@ -71,12 +72,20 @@ function AccountPageContent() {
           <Label htmlFor="delete-confirm">
             {hasPassword ? 'Enter your password to confirm' : 'Type your username to confirm'}
           </Label>
-          <Input
-            id="delete-confirm"
-            type={hasPassword ? 'password' : 'text'}
-            value={confirmValue}
-            onChange={(e) => setConfirmValue(e.target.value)}
-          />
+          {hasPassword ? (
+            <PasswordInput
+              id="delete-confirm"
+              value={confirmValue}
+              onChange={(e) => setConfirmValue(e.target.value)}
+            />
+          ) : (
+            <Input
+              id="delete-confirm"
+              type="text"
+              value={confirmValue}
+              onChange={(e) => setConfirmValue(e.target.value)}
+            />
+          )}
         </div>
         <Button
           variant="destructive"

--- a/apps/client/src/pages/LoginPage.tsx
+++ b/apps/client/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { OAuthButtons } from '../components/patterns/OAuthButtons.js'
 import { Button } from '../components/ui/button.js'
 import { Input } from '../components/ui/input.js'
 import { Label } from '../components/ui/label.js'
+import { PasswordInput } from '../components/ui/password-input.js'
 import { useLogin } from '../hooks/use-auth.js'
 
 export function LoginPage() {
@@ -49,9 +50,8 @@ export function LoginPage() {
 
           <div className="space-y-2">
             <Label htmlFor="password">Password</Label>
-            <Input
+            <PasswordInput
               id="password"
-              type="password"
               placeholder="Enter your password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}

--- a/apps/client/src/pages/PostPage.tsx
+++ b/apps/client/src/pages/PostPage.tsx
@@ -36,7 +36,9 @@ export function PostPage() {
         <p className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase tabular-nums">
           <time dateTime={post.createdAt}>{formatDate(post.createdAt)}</time>
           <span aria-hidden="true">·</span>
-          <span>{post.author.username}</span>
+          <Link to={`/users/${post.author.id}`} className="hover:text-[var(--foreground)]">
+            {post.author.username}
+          </Link>
         </p>
         <h1 className="font-display text-[clamp(2rem,5vw,3.25rem)] leading-[0.95] tracking-[-0.04em] text-balance">
           {post.title}

--- a/apps/client/src/pages/SignupPage.tsx
+++ b/apps/client/src/pages/SignupPage.tsx
@@ -5,6 +5,7 @@ import { OAuthButtons } from '../components/patterns/OAuthButtons.js'
 import { Button } from '../components/ui/button.js'
 import { Input } from '../components/ui/input.js'
 import { Label } from '../components/ui/label.js'
+import { PasswordInput } from '../components/ui/password-input.js'
 import { useSignup } from '../hooks/use-auth.js'
 import { DEBUG } from '../lib/constants.js'
 import { SignupFormSchema } from '../lib/signup-form-schema.js'
@@ -140,9 +141,8 @@ export function SignupPage() {
           <div className="space-y-2">
             <Label htmlFor="password">Password</Label>
             <p className="text-xs text-[var(--muted-foreground)]">At least 8 characters</p>
-            <Input
+            <PasswordInput
               id="password"
-              type="password"
               value={password}
               onChange={(e) => {
                 setPassword(e.target.value)
@@ -158,9 +158,8 @@ export function SignupPage() {
           <div className="space-y-2">
             <Label htmlFor="confirmPassword">Confirm password</Label>
             <p className="text-xs text-[var(--muted-foreground)]">Re-enter the same password</p>
-            <Input
+            <PasswordInput
               id="confirmPassword"
-              type="password"
               value={confirmPassword}
               onChange={(e) => {
                 setConfirmPassword(e.target.value)

--- a/apps/client/src/pages/UserProfilePage.tsx
+++ b/apps/client/src/pages/UserProfilePage.tsx
@@ -1,0 +1,39 @@
+import { Link, useParams } from 'react-router'
+import { EmptyState } from '../components/patterns/EmptyState.js'
+import { Skeleton } from '../components/ui/skeleton.js'
+import { useMe } from '../hooks/use-auth.js'
+import { useUserProfile } from '../hooks/use-users.js'
+import { formatDate } from '../lib/format-date.js'
+
+/**
+ * Public, read-only — anyone's username links here. Editing only ever
+ * happens on `/account`, reached from this page via "Edit profile" when the
+ * viewer is looking at themselves.
+ */
+export function UserProfilePage() {
+  const { id = '' } = useParams<{ id: string }>()
+  const { data: me } = useMe()
+  const { data: profile, isPending, isError } = useUserProfile(id)
+
+  if (isPending) return <Skeleton className="h-64" />
+  if (isError || !profile) return <EmptyState message="Could not find this user." />
+
+  const isSelf = me?.id === id
+
+  return (
+    <div className="flex max-w-lg flex-col gap-4">
+      <div className="flex items-baseline justify-between gap-4">
+        <h1 className="text-xl font-semibold">{profile.username}</h1>
+        {isSelf && (
+          <Link to="/account" className="text-sm underline">
+            Edit profile
+          </Link>
+        )}
+      </div>
+      <p className="font-mono text-xs tracking-[0.09em] text-[var(--ink-faint)] uppercase">
+        Joined <time dateTime={profile.createdAt}>{formatDate(profile.createdAt)}</time>
+      </p>
+      {profile.bio && <p className="text-sm leading-relaxed whitespace-pre-wrap">{profile.bio}</p>}
+    </div>
+  )
+}

--- a/apps/client/src/routes.tsx
+++ b/apps/client/src/routes.tsx
@@ -7,6 +7,8 @@ import { EditPostPage } from './pages/EditPostPage.js'
 import { LoginPage } from './pages/LoginPage.js'
 import { SignupPage } from './pages/SignupPage.js'
 import { ChatPage } from './pages/ChatPage.js'
+import { AccountPage } from './pages/AccountPage.js'
+import { UserProfilePage } from './pages/UserProfilePage.js'
 
 export const router = createBrowserRouter([
   {
@@ -23,6 +25,8 @@ export const router = createBrowserRouter([
       { path: '/login', element: <LoginPage /> },
       { path: '/signup', element: <SignupPage /> },
       { path: '/chat', element: <ChatPage /> },
+      { path: '/account', element: <AccountPage /> },
+      { path: '/users/:id', element: <UserProfilePage /> },
     ],
   },
 ])

--- a/apps/server/src/lib/services/user.test.ts
+++ b/apps/server/src/lib/services/user.test.ts
@@ -1,8 +1,12 @@
-import { ConflictError, NotFoundError, ValidationError } from '../errors.js'
+import { ConflictError, NotFoundError, UnauthorizedError, ValidationError } from '../errors.js'
 import { UserModel } from '../../models/user.js'
+import { CommentModel } from '../../models/comment.js'
+import { LikeModel } from '../../models/like.js'
+import { PostModel } from '../../models/post.js'
 import { describe, expect, it } from 'vitest'
 import { useTestDb } from '../../test/helpers.js'
 import { userService } from './user.js'
+import { postService } from './post.js'
 
 useTestDb()
 
@@ -79,7 +83,7 @@ describe('userService.verifyCredentials', () => {
 })
 
 describe('userService.getPublicProfile', () => {
-  it('never exposes the password hash or the email', async () => {
+  it('never exposes the password hash or the email to a non-owner viewer', async () => {
     const { id } = await signup()
     const profile = await userService.getPublicProfile(id)
     expect(profile).not.toHaveProperty('password')
@@ -93,6 +97,32 @@ describe('userService.getPublicProfile', () => {
 
   it('throws NotFoundError for a malformed id rather than a cast error', async () => {
     await expect(userService.getPublicProfile('not-an-objectid')).rejects.toThrow(NotFoundError)
+  })
+
+  it('includes email, hasPassword and oauthProvider only when the viewer is the owner', async () => {
+    const { id } = await signup()
+    const own = (await userService.getPublicProfile(id, id)) as {
+      email: string
+      hasPassword: boolean
+      oauthProvider: string | null
+    }
+    expect(own.email).toBe('y@example.com')
+    expect(own.hasPassword).toBe(true)
+    expect(own.oauthProvider).toBeNull()
+
+    const other = await userService.getPublicProfile(id, '507f1f77bcf86cd799439011')
+    expect(other).not.toHaveProperty('email')
+  })
+
+  it('reports oauthProvider google for a Google-linked account', async () => {
+    const oauthUser = await UserModel.create({
+      username: 'oauth',
+      email: 'o@example.com',
+      googleId: 'g-123',
+    })
+    const id = oauthUser._id.toString()
+    const profile = (await userService.getPublicProfile(id, id)) as { oauthProvider: string | null }
+    expect(profile.oauthProvider).toBe('google')
   })
 })
 
@@ -123,5 +153,138 @@ describe('userService.updateProfile — image validation', () => {
     await expect(
       userService.updateProfile(id, { image: 'someone-elses/folder/x' }),
     ).rejects.toThrow(ValidationError)
+  })
+})
+
+describe('userService.updateProfile — username', () => {
+  it('lets a user rename themselves', async () => {
+    const { id } = await signup()
+    const profile = await userService.updateProfile(id, { username: 'renamed' })
+    expect(profile.username).toBe('renamed')
+  })
+
+  it('throws ConflictError when the new username is already taken', async () => {
+    const { id } = await signup()
+    await signup({ username: 'taken', email: 'taken@example.com' })
+    await expect(userService.updateProfile(id, { username: 'taken' })).rejects.toThrow(ConflictError)
+  })
+})
+
+describe('userService.updateProfile — email', () => {
+  it('lets a local user change their email', async () => {
+    const { id } = await signup()
+    const profile = await userService.updateProfile(id, { email: 'new@example.com' })
+    expect(profile.email).toBe('new@example.com')
+  })
+
+  it('throws ConflictError when the new email is already registered', async () => {
+    const { id } = await signup()
+    await signup({ username: 'other', email: 'taken@example.com' })
+    await expect(userService.updateProfile(id, { email: 'taken@example.com' })).rejects.toThrow(
+      ConflictError,
+    )
+  })
+
+  it('rejects an email change for a Google-linked account', async () => {
+    const oauthUser = await UserModel.create({
+      username: 'oauth',
+      email: 'o@example.com',
+      googleId: 'g-123',
+    })
+    const id = oauthUser._id.toString()
+    await expect(userService.updateProfile(id, { email: 'new@example.com' })).rejects.toThrow(
+      ValidationError,
+    )
+    expect((await UserModel.findById(id))!.email).toBe('o@example.com')
+  })
+})
+
+describe('userService.updateProfile — password', () => {
+  it('requires the current password to change an existing one', async () => {
+    const { id } = await signup()
+    await expect(
+      userService.updateProfile(id, { password: 'brand-new-password' }),
+    ).rejects.toThrow(UnauthorizedError)
+  })
+
+  it('rejects a wrong current password', async () => {
+    const { id } = await signup()
+    await expect(
+      userService.updateProfile(id, { currentPassword: 'nope', password: 'brand-new-password' }),
+    ).rejects.toThrow(UnauthorizedError)
+  })
+
+  it('accepts a correct current password and re-hashes the new one', async () => {
+    const { id } = await signup()
+    await userService.updateProfile(id, {
+      currentPassword: 'correct-horse',
+      password: 'brand-new-password',
+    })
+    expect(await userService.verifyCredentials('yonatan', 'brand-new-password')).not.toBeNull()
+  })
+
+  it('lets an OAuth account set its first password without a currentPassword', async () => {
+    const oauthUser = await UserModel.create({
+      username: 'oauth',
+      email: 'o@example.com',
+      googleId: 'g-123',
+    })
+    const id = oauthUser._id.toString()
+    await userService.updateProfile(id, { password: 'first-password' })
+    expect(await userService.verifyCredentials('oauth', 'first-password')).not.toBeNull()
+  })
+})
+
+describe('userService.remove', () => {
+  it('rejects deletion with a wrong current password and leaves the account intact', async () => {
+    const { id } = await signup()
+    await expect(userService.remove(id, { currentPassword: 'wrong' })).rejects.toThrow(
+      UnauthorizedError,
+    )
+    expect(await UserModel.findById(id)).not.toBeNull()
+  })
+
+  it('deletes the account given the correct current password', async () => {
+    const { id } = await signup()
+    await userService.remove(id, { currentPassword: 'correct-horse' })
+    expect(await UserModel.findById(id)).toBeNull()
+  })
+
+  it('deletes an OAuth (no-password) account given a matching username confirmation', async () => {
+    const oauthUser = await UserModel.create({
+      username: 'oauth',
+      email: 'o@example.com',
+      googleId: 'g-123',
+    })
+    const id = oauthUser._id.toString()
+    await expect(
+      userService.remove(id, { usernameConfirmation: 'wrong-name' }),
+    ).rejects.toThrow(UnauthorizedError)
+    await userService.remove(id, { usernameConfirmation: 'oauth' })
+    expect(await UserModel.findById(id)).toBeNull()
+  })
+
+  it('cascades: deletes the user\'s own posts, their likes/comments on other posts, and other people\'s comments on the user\'s own posts', async () => {
+    const { id } = await signup()
+    const { id: otherId } = await signup({ username: 'other', email: 'other@example.com' })
+
+    // The user's own post, plus another user commenting on it.
+    const ownPost = await postService.create({ title: 'My post', body: 'hello world' }, id)
+    await CommentModel.create({ post: ownPost.id, author: otherId, body: 'nice post' })
+
+    // Another user's post, on which the target user comments and likes.
+    const otherPost = await postService.create({ title: 'Other post', body: 'hello world' }, otherId)
+    await CommentModel.create({ post: otherPost.id, author: id, body: 'nice post' })
+    await LikeModel.create({ post: otherPost.id, user: id })
+
+    await userService.remove(id, { currentPassword: 'correct-horse' })
+
+    expect(await PostModel.findById(ownPost.id)).toBeNull()
+    expect(await CommentModel.countDocuments({ post: ownPost.id })).toBe(0)
+    expect(await CommentModel.countDocuments({ author: id })).toBe(0)
+    expect(await LikeModel.countDocuments({ user: id })).toBe(0)
+    // The other user and their post are untouched.
+    expect(await PostModel.findById(otherPost.id)).not.toBeNull()
+    expect(await UserModel.findById(otherId)).not.toBeNull()
   })
 })

--- a/apps/server/src/lib/services/user.test.ts
+++ b/apps/server/src/lib/services/user.test.ts
@@ -269,11 +269,14 @@ describe('userService.remove', () => {
     const { id: otherId } = await signup({ username: 'other', email: 'other@example.com' })
 
     // The user's own post, plus another user commenting on it.
-    const ownPost = await postService.create({ title: 'My post', body: 'hello world' }, id)
+    const ownPost = await postService.create({ title: 'My post', body: 'hello world', tags: [] }, id)
     await CommentModel.create({ post: ownPost.id, author: otherId, body: 'nice post' })
 
     // Another user's post, on which the target user comments and likes.
-    const otherPost = await postService.create({ title: 'Other post', body: 'hello world' }, otherId)
+    const otherPost = await postService.create(
+      { title: 'Other post', body: 'hello world', tags: [] },
+      otherId,
+    )
     await CommentModel.create({ post: otherPost.id, author: id, body: 'nice post' })
     await LikeModel.create({ post: otherPost.id, user: id })
 

--- a/apps/server/src/lib/services/user.ts
+++ b/apps/server/src/lib/services/user.ts
@@ -1,7 +1,11 @@
-import { type Signup, type UpdateUser } from '@blog/zod-shared'
-import { ConflictError, NotFoundError } from '../errors.js'
+import { type DeleteUser, type Signup, type UpdateUser } from '@blog/zod-shared'
+import { ConflictError, NotFoundError, UnauthorizedError, ValidationError } from '../errors.js'
 import { assertUserSlotFree } from '../demo-limits.js'
 import { UserModel } from '../../models/user.js'
+import { CommentModel } from '../../models/comment.js'
+import { LikeModel } from '../../models/like.js'
+import { PostModel } from '../../models/post.js'
+import { postService } from './post.js'
 import { publicIdFrom } from './upload.js'
 import bcrypt from 'bcryptjs'
 import { Types } from 'mongoose'
@@ -14,6 +18,13 @@ export type PublicUser = {
   bio?: string
   image?: string
   createdAt: Date
+}
+
+/** Only ever returned to the account owner — see `getPublicProfile`'s viewerId gate. */
+export type PrivateUser = PublicUser & {
+  email: string
+  hasPassword: boolean
+  oauthProvider: 'google' | 'facebook' | null
 }
 
 /** MongoServerError code for a unique-index violation. */
@@ -86,7 +97,12 @@ export const userService = {
     return { id: user._id.toString(), username: user.username }
   },
 
-  async getPublicProfile(id: string): Promise<PublicUser> {
+  /**
+   * `viewerId` gates the private fields (email, password/OAuth status) the
+   * same way `postService.getBySlug`'s `viewerId` gates a post's full body —
+   * only the account owner ever sees them; everyone else gets `PublicUser`.
+   */
+  async getPublicProfile(id: string, viewerId?: string): Promise<PublicUser | PrivateUser> {
     // A malformed id would otherwise throw a CastError and surface as a 500.
     if (!Types.ObjectId.isValid(id)) throw new NotFoundError('User not found.')
 
@@ -95,19 +111,42 @@ export const userService = {
 
     // Built field by field, not by deleting from the document: a whitelist
     // cannot leak a field added to the schema later.
-    return {
+    const publicView: PublicUser = {
       id: user._id.toString(),
       username: user.username,
       bio: user.bio ?? undefined,
       image: user.image ?? undefined,
       createdAt: user.createdAt,
     }
+    if (viewerId !== id) return publicView
+
+    return {
+      ...publicView,
+      email: user.email,
+      hasPassword: Boolean(user.password),
+      oauthProvider: user.googleId ? 'google' : user.facebookId ? 'facebook' : null,
+    }
   },
 
-  async updateProfile(id: string, input: UpdateUser): Promise<PublicUser> {
+  async updateProfile(id: string, input: UpdateUser): Promise<PrivateUser> {
     if (!Types.ObjectId.isValid(id)) throw new NotFoundError('User not found.')
     const user = await UserModel.findById(id)
     if (!user) throw new NotFoundError('User not found.')
+
+    // A new value to SET, never used to look up which account this is — that
+    // stays fixed to `id` throughout. See the schema comment in zod-shared.
+    if (input.username !== undefined) user.username = input.username
+
+    if (input.email !== undefined) {
+      // Locked, not merely defaulted: changing it would let the stored email
+      // drift from the Google-verified one oauthService.findOrCreate keys on.
+      if (user.googleId || user.facebookId) {
+        throw new ValidationError('Invalid input.', {
+          email: ["Email is managed by your Google account and can't be changed."],
+        })
+      }
+      user.email = input.email
+    }
 
     if (input.bio !== undefined) user.bio = input.bio
     // Re-checked here, not trusted from the body: the browser reports what
@@ -116,19 +155,57 @@ export const userService = {
     if (input.image !== undefined) {
       user.image = input.image ? publicIdFrom(input.image, 'image') : undefined
     }
+
     // Only when explicitly provided. The legacy handler compared the plaintext
     // field to the stored hash, so every profile save reset the password.
     if (input.password !== undefined) {
+      if (user.password) {
+        // Changing an existing password requires proving you know it — a
+        // hijacked session should not be able to silently lock the owner out.
+        const currentValid =
+          input.currentPassword !== undefined &&
+          (await bcrypt.compare(input.currentPassword, user.password))
+        if (!currentValid) throw new UnauthorizedError('Current password is incorrect.')
+      }
+      // Else: an OAuth account setting its first password — nothing to verify
+      // against, this is the "add local login" path, not a change.
       user.password = await bcrypt.hash(input.password, BCRYPT_COST)
     }
 
-    await user.save()
-    return this.getPublicProfile(id)
+    try {
+      await user.save()
+    } catch (err) {
+      if (isDuplicateKeyError(err)) {
+        throw new ConflictError(
+          err.keyPattern?.username ? 'That username is taken.' : 'That email is already registered.',
+        )
+      }
+      throw err
+    }
+
+    return (await this.getPublicProfile(id, id)) as PrivateUser
   },
 
-  async remove(id: string): Promise<void> {
+  async remove(id: string, confirmation: DeleteUser): Promise<void> {
     if (!Types.ObjectId.isValid(id)) throw new NotFoundError('User not found.')
-    const result = await UserModel.findByIdAndDelete(id)
-    if (!result) throw new NotFoundError('User not found.')
+    const user = await UserModel.findById(id)
+    if (!user) throw new NotFoundError('User not found.')
+
+    const confirmed = user.password
+      ? confirmation.currentPassword !== undefined &&
+        (await bcrypt.compare(confirmation.currentPassword, user.password))
+      : confirmation.usernameConfirmation === user.username
+    if (!confirmed) throw new UnauthorizedError('Confirmation did not match.')
+
+    const authorId = new Types.ObjectId(id)
+    // Each post's own likes/comments cascade for free via postService.remove.
+    const posts = await PostModel.find({ author: authorId }).select('slug')
+    for (const post of posts) await postService.remove(post.slug)
+    // Catches this user's activity on OTHER people's posts, which the loop
+    // above never touches.
+    await CommentModel.deleteMany({ author: authorId })
+    await LikeModel.deleteMany({ user: authorId })
+
+    await UserModel.findByIdAndDelete(id)
   },
 }

--- a/apps/server/src/routes/v1/users.test.ts
+++ b/apps/server/src/routes/v1/users.test.ts
@@ -25,12 +25,20 @@ describe('GET /api/v1/users/:id', () => {
     expect(res.body.username).toBe('author')
   })
 
-  it('never exposes the password hash or the email', async () => {
+  it('never exposes the password hash or the email to a non-owner viewer', async () => {
     const a = app()
     const { id } = await signedInAgent(a, 'author')
     const res = await request(a).get(`/api/v1/users/${id}`)
     expect(res.text).not.toContain('$2a$')
     expect(res.text).not.toContain('@example.com')
+  })
+
+  it('includes email and hasPassword when the viewer is the owner', async () => {
+    const { agent, id } = await signedInAgent(app(), 'author')
+    const res = await agent.get(`/api/v1/users/${id}`)
+    expect(res.body.email).toBe('author@example.com')
+    expect(res.body.hasPassword).toBe(true)
+    expect(res.body.oauthProvider).toBeNull()
   })
 
   it('returns 404 for an unknown id', async () => {
@@ -82,24 +90,59 @@ describe('PATCH /api/v1/users/:id', () => {
 
   it('hashes a new password rather than storing it plaintext', async () => {
     const { agent, id } = await signedInAgent(app(), 'author')
-    await agent.patch(`/api/v1/users/${id}`).send({ password: 'a-brand-new-password' })
+    await agent
+      .patch(`/api/v1/users/${id}`)
+      .send({ currentPassword: 'correct-horse', password: 'a-brand-new-password' })
     const stored = (await UserModel.findById(id))!.password!
     expect(stored).not.toBe('a-brand-new-password')
     expect(await bcrypt.compare('a-brand-new-password', stored)).toBe(true)
   })
 
-  it('ignores a username field — usernames are not editable here', async () => {
+  it('rejects a password change with a wrong current password', async () => {
+    const { agent, id } = await signedInAgent(app(), 'author')
+    const res = await agent
+      .patch(`/api/v1/users/${id}`)
+      .send({ currentPassword: 'wrong', password: 'a-brand-new-password' })
+    expect(res.status).toBe(401)
+  })
+
+  it('lets a user change their own username', async () => {
+    const { agent, id } = await signedInAgent(app(), 'author')
+    const res = await agent.patch(`/api/v1/users/${id}`).send({ username: 'renamed' })
+    expect(res.status).toBe(200)
+    expect(res.body.username).toBe('renamed')
+    expect((await UserModel.findById(id))!.username).toBe('renamed')
+  })
+
+  it('returns 409 for a username that is already taken', async () => {
+    const a = app()
+    await signedInAgent(a, 'taken')
+    const { agent, id } = await signedInAgent(a, 'author')
+    const res = await agent.patch(`/api/v1/users/${id}`).send({ username: 'taken' })
+    expect(res.status).toBe(409)
+  })
+
+  it('updates the session so GET /auth/me reflects a new username without re-login', async () => {
     const { agent, id } = await signedInAgent(app(), 'author')
     await agent.patch(`/api/v1/users/${id}`).send({ username: 'renamed' })
-    expect((await UserModel.findById(id))!.username).toBe('author')
+    const me = await agent.get('/api/v1/auth/me')
+    expect(me.body.username).toBe('renamed')
   })
 })
 
 describe('DELETE /api/v1/users/:id', () => {
-  it('lets a user delete their own account', async () => {
+  it('lets a user delete their own account with the correct current password', async () => {
     const { agent, id } = await signedInAgent(app(), 'author')
-    expect((await agent.delete(`/api/v1/users/${id}`)).status).toBe(204)
+    const res = await agent.delete(`/api/v1/users/${id}`).send({ currentPassword: 'correct-horse' })
+    expect(res.status).toBe(204)
     expect(await UserModel.findById(id)).toBeNull()
+  })
+
+  it('rejects deletion with a wrong current password and keeps the account', async () => {
+    const { agent, id } = await signedInAgent(app(), 'author')
+    const res = await agent.delete(`/api/v1/users/${id}`).send({ currentPassword: 'wrong' })
+    expect(res.status).toBe(401)
+    expect(await UserModel.findById(id)).not.toBeNull()
   })
 
   it('REGRESSION: a user cannot delete another user (legacy user.js:60)', async () => {
@@ -107,7 +150,10 @@ describe('DELETE /api/v1/users/:id', () => {
     const { id: victimId } = await signedInAgent(a, 'victim')
     const { agent: attacker } = await signedInAgent(a, 'attacker')
 
-    expect((await attacker.delete(`/api/v1/users/${victimId}`)).status).toBe(403)
+    expect(
+      (await attacker.delete(`/api/v1/users/${victimId}`).send({ currentPassword: 'correct-horse' }))
+        .status,
+    ).toBe(403)
     expect(await UserModel.findById(victimId)).not.toBeNull()
   })
 

--- a/apps/server/src/routes/v1/users.ts
+++ b/apps/server/src/routes/v1/users.ts
@@ -1,4 +1,4 @@
-import { UpdateUserSchema } from '@blog/zod-shared'
+import { DeleteUserSchema, UpdateUserSchema } from '@blog/zod-shared'
 import { ForbiddenError } from '../../lib/errors.js'
 import { Router, type RequestHandler } from 'express'
 import { userService } from '../../lib/services/user.js'
@@ -24,7 +24,7 @@ const requireSelf: RequestHandler<{ id: string }> = (req, _res, next) => {
 }
 
 usersRouter.get('/:id', async (req, res) => {
-  res.json(await userService.getPublicProfile(req.params.id))
+  res.json(await userService.getPublicProfile(req.params.id, req.session.userId))
 })
 
 usersRouter.patch(
@@ -33,12 +33,22 @@ usersRouter.patch(
   requireSelf,
   validate(UpdateUserSchema),
   async (req, res) => {
-    res.json(await userService.updateProfile(req.params.id, req.body))
+    const profile = await userService.updateProfile(req.params.id, req.body)
+    // GET /auth/me reads req.session.username directly, not the DB — without
+    // this the header keeps showing the old username until the next login.
+    req.session.username = profile.username
+    res.json(profile)
   },
 )
 
-usersRouter.delete('/:id', requireAuth, requireSelf, async (req, res) => {
-  await userService.remove(req.params.id)
-  req.session.destroy(() => {})
-  res.status(204).end()
-})
+usersRouter.delete(
+  '/:id',
+  requireAuth,
+  requireSelf,
+  validate(DeleteUserSchema),
+  async (req, res) => {
+    await userService.remove(req.params.id, req.body)
+    req.session.destroy(() => {})
+    res.status(204).end()
+  },
+)

--- a/packages/zod-shared/src/schemas/user.ts
+++ b/packages/zod-shared/src/schemas/user.ts
@@ -1,15 +1,21 @@
 import { z } from 'zod'
 import { PublicIdSchema } from './post.js'
 
+const UsernameSchema = z
+  .string()
+  .trim()
+  .min(3, 'Username must be at least 3 characters')
+  .max(30, 'Username must be at most 30 characters')
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Letters, numbers, hyphens and underscores only')
+
+const EmailSchema = z.string().trim().toLowerCase().email('Enter a valid email address')
+
+const PasswordSchema = z.string().min(8, 'Password must be at least 8 characters').max(200)
+
 export const SignupSchema = z.object({
-  username: z
-    .string()
-    .trim()
-    .min(3, 'Username must be at least 3 characters')
-    .max(30, 'Username must be at most 30 characters')
-    .regex(/^[a-zA-Z0-9_-]+$/, 'Letters, numbers, hyphens and underscores only'),
-  email: z.string().trim().toLowerCase().email('Enter a valid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters').max(200),
+  username: UsernameSchema,
+  email: EmailSchema,
+  password: PasswordSchema,
 })
 
 export const LoginSchema = z.object({
@@ -21,16 +27,34 @@ export type Signup = z.infer<typeof SignupSchema>
 export type Login = z.infer<typeof LoginSchema>
 
 // PATCH /api/v1/users/:id — the id in the URL identifies the user and the
-// session proves who is asking. The body carries NO id and NO username:
-// the legacy /update-user took both from the body, which is exactly how it
-// became an account takeover.
+// session proves who is asking. The body carries NO id: the legacy
+// /update-user took the id from the body, which is exactly how it became an
+// account takeover. `username`/`email` below are values being SET, never used
+// to select which account is modified — that selection stays exclusively the
+// URL id vs. the session, enforced by requireSelf.
 export const UpdateUserSchema = z.object({
+  username: UsernameSchema.optional(),
+  email: EmailSchema.optional(),
   bio: z.string().trim().max(500, 'Bio must be at most 500 characters').optional(),
   // Same PublicIdSchema coverImage uses — a Cloudinary public ID under one of
   // our own folders, never an arbitrary string. Re-checked server-side by
   // publicIdFrom() before persisting, same as coverImage.
   image: PublicIdSchema.nullish(),
-  password: z.string().min(8, 'Password must be at least 8 characters').max(200).optional(),
+  // Required only when the account already has a password; userService
+  // enforces that conditionally since it depends on DB state the schema
+  // can't see. Absent entirely for an OAuth account setting its first one.
+  currentPassword: z.string().optional(),
+  password: PasswordSchema.optional(),
 })
 
 export type UpdateUser = z.infer<typeof UpdateUserSchema>
+
+// DELETE /api/v1/users/:id — same non-negotiable as above, the id always
+// comes from the URL/session. This body only carries the confirmation proof:
+// current password for an account that has one, else the typed-out username.
+export const DeleteUserSchema = z.object({
+  currentPassword: z.string().optional(),
+  usernameConfirmation: z.string().optional(),
+})
+
+export type DeleteUser = z.infer<typeof DeleteUserSchema>


### PR DESCRIPTION
## Summary
- Extends the already-shipped `PATCH`/`DELETE /api/v1/users/:id` API with username and email editing, current-password verification before a password change, OAuth accounts setting an initial password, and cascade-deleting a user's posts/comments/likes on account deletion.
- Adds the client side that never existed for this API: `/account` (self, editable) and `/users/:id` (anyone, read-only), reached by making every username byline in the app clickable.
- Fixes a real bug found in manual testing: password fields were plain-text inputs showing the value in the clear, and the shared `AutoForm` rendered raw camelCase schema keys as labels (e.g. `currentPassword`). Adds a shared `PasswordInput` with a show/hide toggle used on login, signup, and account update/delete, and humanizes `AutoForm`'s labels.

## Test plan
- [x] `npm run test` — 475 passing (server + client)
- [x] Manual pass via `docker compose watch`: account edit (username/email/bio/password), OAuth-account password set, account deletion with cascade, public profile view
- [ ] E2E (Playwright) — not run locally (Docker build blocked by local Avast TLS interception); will run in CI on this PR