### PR TITLE
fix(client): blank optional AutoForm fields no longer force a password

### DIFF
--- a/apps/client/src/components/patterns/AutoForm.test.tsx
+++ b/apps/client/src/components/patterns/AutoForm.test.tsx
@@ -83,6 +83,18 @@ describe('AutoForm', () => {
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tags: ['keep'] }))
   })
 
+  it('submits a blank optional field as absent, not empty, so it never fails a value-only check like min-length', () => {
+    const onSubmit = vi.fn()
+    const withOptionalPassword = schema.extend({
+      password: z.string().min(8, 'Password must be at least 8 characters').optional(),
+    })
+    render(<AutoForm schema={withOptionalPassword} onSubmit={onSubmit} />)
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'A valid title' } })
+    fireEvent.click(screen.getByText('Save'))
+    expect(screen.queryByText('Password must be at least 8 characters')).not.toBeInTheDocument()
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ password: undefined }))
+  })
+
   it('seeds the form from initialValues', () => {
     render(
       <AutoForm

--- a/apps/client/src/components/patterns/AutoForm.tsx
+++ b/apps/client/src/components/patterns/AutoForm.tsx
@@ -85,9 +85,13 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
 }) {
   // Derived once, up front: `schema.shape` is indexed by an open `string` key,
   // so re-reading it per render would fight `noUncheckedIndexedAccess`.
-  const fields: { key: string; kind: FieldKind }[] = Object.entries(schema.shape).map(
-    ([key, fieldSchema]) => ({ key, kind: fieldKind(key, fieldSchema) }),
-  )
+  const fields: { key: string; kind: FieldKind; optional: boolean }[] = Object.entries(
+    schema.shape,
+  ).map(([key, fieldSchema]) => ({
+    key,
+    kind: fieldKind(key, fieldSchema),
+    optional: fieldSchema.isOptional(),
+  }))
 
   const [values, setValues] = useState<Record<string, string | boolean | string[] | null>>(() => {
     const initial = (initialValues ?? {}) as Record<string, unknown>
@@ -112,14 +116,23 @@ export function AutoForm<S extends ZodObject<ZodRawShape>>({
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   // `tags` is already held as an array by TagsInput, so nothing is parsed out of
-  // a raw string here — the state shape per field kind is the parsed shape.
-  function parsedValue(key: string): unknown {
-    return values[key]
+  // a raw string here — the state shape per field kind is the parsed shape. An
+  // untouched optional text field stays '' in local state; sent as-is it fails
+  // schema checks meant only for a value someone actually typed (e.g. password's
+  // min-length), so a blank optional field reports absent, not empty.
+  function parsedValue(key: string, kind: FieldKind, optional: boolean): unknown {
+    const value = values[key]
+    if (optional && value === '' && (kind === 'text' || kind === 'textarea' || kind === 'password')) {
+      return undefined
+    }
+    return value
   }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    const candidate = Object.fromEntries(fields.map(({ key }) => [key, parsedValue(key)]))
+    const candidate = Object.fromEntries(
+      fields.map(({ key, kind, optional }) => [key, parsedValue(key, kind, optional)]),
+    )
     const result = schema.safeParse(candidate)
     if (!result.success) {
       setErrors(


### PR DESCRIPTION
## Summary
- `AutoForm` submitted every field's raw string, so an untouched optional field (e.g. AccountPage's "set a password" box) sent `''` instead of `undefined`.
- Zod's `.optional()` only skips validation on `undefined`, so `''` still hit `PasswordSchema.min(8)` and blocked every account save — bio-only edits included — behind a password field. Worse for Google OAuth accounts, which have no password to enter at all.
- Fix: a blank optional text/textarea/password field is now submitted as `undefined`, not `''`.

## Test plan
- [x] `npm run test -- apps/client/src/components/patterns/AutoForm.test.tsx` — added a regression test for the exact bug
- [x] `npm run test` — full suite, 476 passing